### PR TITLE
Dev

### DIFF
--- a/frontend/src/features/nodes/VpcNode/VpcModal.tsx
+++ b/frontend/src/features/nodes/VpcNode/VpcModal.tsx
@@ -473,6 +473,7 @@ const styles: Record<string, React.CSSProperties> = {
     flexDirection: 'column',
     gap: '6px',
     flex: 1,
+    minWidth: 0,
   },
   formGroupShort: {
     display: 'flex',
@@ -597,6 +598,10 @@ const styles: Record<string, React.CSSProperties> = {
     backgroundColor: '#FFF',
     outline: 'none',
     height: '32px',
+    width: '100%',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
   },
   simulateBtn: {
     backgroundColor: 'var(--color-accent)',

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -4,6 +4,8 @@ import { initReactI18next } from 'react-i18next';
 import frTranslations from './locales/fr.json';
 import enTranslations from './locales/en.json';
 
+const savedLanguage = localStorage.getItem('torollo_lang') || 'en';
+
 i18n
   .use(initReactI18next)
   .init({
@@ -11,7 +13,7 @@ i18n
       fr: { translation: frTranslations },
       en: { translation: enTranslations }
     },
-    lng: 'fr', // French as default
+    lng: savedLanguage, // English as default, or use saved
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false // React already safes from XSS

--- a/frontend/src/pages/CanvasPage/components/CanvasTopbar.tsx
+++ b/frontend/src/pages/CanvasPage/components/CanvasTopbar.tsx
@@ -29,6 +29,7 @@ export default function CanvasTopbar({
   const toggleLanguage = () => {
     const nextLang = i18n.language === 'fr' ? 'en' : 'fr';
     i18n.changeLanguage(nextLang);
+    localStorage.setItem('torollo_lang', nextLang);
   };
 
   return (

--- a/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -26,6 +26,7 @@ export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
   const toggleLanguage = () => {
     const nextLang = i18n.language === 'fr' ? 'en' : 'fr';
     i18n.changeLanguage(nextLang);
+    localStorage.setItem('torollo_lang', nextLang);
   };
 
   const fetchProjects = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torollo",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torollo",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "dependencies": {
         "chokidar": "^3.6.0",
         "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torollo",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Interactive visual system design learning lab and container supervisor.",
   "keywords": [
     "system-design",


### PR DESCRIPTION
## Summary of Changes
Resolved an issue in the VPC Simulator Modal where long node names caused the select dropdown to expand infinitely, breaking the layout and causing horizontal scrolling. Long text now cleanly truncates.

## Types of Changes
- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [x] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

## Checklist
- [x] My code follows the repository's code style and lint standards
- [ ] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
