### PR TITLE
Feat/redis node

### DIFF
--- a/backend/src/infrastructure/docker/ContainerManager.ts
+++ b/backend/src/infrastructure/docker/ContainerManager.ts
@@ -6,7 +6,7 @@ export interface ContainerInfo {
   image: string;
   state: string;
   status: string;
-  type?: 'ubuntu' | 'postgres' | 'sql' | 'nosql' | 'nat' | 'loadbalancer' | 'autoscalinggroup';
+  type?: 'ubuntu' | 'postgres' | 'sql' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'autoscalinggroup';
   port?: string;
   ip?: string;
   asgId?: string;
@@ -38,6 +38,7 @@ export class ContainerManager {
   private static readonly POSTGRES_IMAGE_TAG = 'derssa/backend-lab-postgres:v1';
   private static readonly MONGO_IMAGE_TAG = 'derssa/backend-lab-mongo:v1';
   private static readonly NGINX_IMAGE_TAG = 'derssa/backend-lab-nginx:v1';
+  private static readonly REDIS_IMAGE_TAG = 'redis:7-alpine';
 
   /**
    * Ensures that the custom prebuilt Ubuntu image exists locally.
@@ -155,6 +156,40 @@ export class ContainerManager {
   }
 
   /**
+   * Ensures that the Redis image exists locally.
+   */
+  private static async ensureRedisImage(): Promise<void> {
+    const images = await docker.listImages();
+    const hasImage = images.some(img =>
+      img.RepoTags && img.RepoTags.includes(this.REDIS_IMAGE_TAG)
+    );
+
+    if (!hasImage) {
+      console.log('Pulling Redis image (first time only)...');
+      await new Promise<void>((resolve, reject) => {
+        docker.pull(this.REDIS_IMAGE_TAG, {}, (err, stream) => {
+          if (err) return reject(err);
+          if (!stream) return reject(new Error('Pull stream is undefined'));
+
+          docker.modem.followProgress(
+            stream,
+            (errFinished) => {
+              if (errFinished) return reject(errFinished);
+              resolve();
+            },
+            (event) => {
+              if (event.status) {
+                const progress = event.progress ? ` ${event.progress}` : '';
+                console.log(`[Docker Hub Pull - Redis] ${event.status}${progress}`);
+              }
+            }
+          );
+        });
+      });
+    }
+  }
+
+  /**
    * Ensures that the Nginx Load Balancer image exists locally.
    */
   private static async ensureNginxImage(): Promise<void> {
@@ -197,8 +232,9 @@ export class ContainerManager {
         if (c.Ports && c.Ports.length > 0) {
           const matchedPostgres = c.Ports.find(p => p.PrivatePort === 5432);
           const matchedMongo = c.Ports.find(p => p.PrivatePort === 27017);
+          const matchedRedis = c.Ports.find(p => p.PrivatePort === 6379);
           const matchedNginx = c.Ports.find(p => p.PrivatePort === 80);
-          const matchedPort = matchedPostgres || matchedMongo || matchedNginx;
+          const matchedPort = matchedPostgres || matchedMongo || matchedRedis || matchedNginx;
           if (matchedPort && matchedPort.PublicPort) {
             port = matchedPort.PublicPort.toString();
           }
@@ -223,7 +259,7 @@ export class ContainerManager {
           image: c.Image,
           state: isFakeCrashed ? 'exited' : c.State,
           status: isFakeCrashed ? 'Exited (0) 1 second ago' : c.Status,
-          type: (c.Labels['akal.node.type'] || 'ubuntu') as 'ubuntu' | 'postgres' | 'sql' | 'nosql' | 'nat' | 'loadbalancer' | 'autoscalinggroup',
+          type: (c.Labels['akal.node.type'] || 'ubuntu') as 'ubuntu' | 'postgres' | 'sql' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'autoscalinggroup',
           port,
           ip,
           asgId,
@@ -242,11 +278,13 @@ export class ContainerManager {
   ): Promise<ContainerInfo> {
     const isPostgres = type === 'postgres' || type === 'sql';
     const isMongo = type === 'nosql';
+    const isRedis = type === 'redis';
     const isLoadBalancer = type === 'loadbalancer';
     let image = this.UBUNTU_IMAGE_TAG;
     if (customImage) image = customImage;
     else if (isPostgres) image = this.POSTGRES_IMAGE_TAG;
     else if (isMongo) image = this.MONGO_IMAGE_TAG;
+    else if (isRedis) image = this.REDIS_IMAGE_TAG;
     else if (isLoadBalancer) image = this.NGINX_IMAGE_TAG;
 
     if (customImage) {
@@ -255,6 +293,8 @@ export class ContainerManager {
       await this.ensurePostgresImage();
     } else if (isMongo) {
       await this.ensureMongoImage();
+    } else if (isRedis) {
+      await this.ensureRedisImage();
     } else if (isLoadBalancer) {
       await this.ensureNginxImage();
     } else {
@@ -304,6 +344,8 @@ export class ContainerManager {
       createOpts.Cmd = ['postgres', '-c', 'fsync=off', '-c', 'synchronous_commit=off', '-c', 'full_page_writes=off'];
     } else if (isMongo) {
       // MongoDB does not require special env vars for standard default use
+    } else if (isRedis) {
+      // Redis starts on its default command; no special env vars or entrypoint needed
     } else if (isLoadBalancer) {
       createOpts.HostConfig.PortBindings = {
         '80/tcp': [{ HostPort: '' }]
@@ -353,7 +395,7 @@ export class ContainerManager {
       image,
       state: 'running',
       status: 'Up less than a second',
-      type: type as 'ubuntu' | 'postgres' | 'sql' | 'nosql' | 'nat' | 'loadbalancer',
+      type: type as 'ubuntu' | 'postgres' | 'sql' | 'nosql' | 'redis' | 'nat' | 'loadbalancer',
       port,
       ip
     };
@@ -387,6 +429,44 @@ export class ContainerManager {
         let cleanOutput = output.trim();
         if (cleanOutput.includes("connection to server on socket") || cleanOutput.includes("Is the server running locally")) {
           cleanOutput = "ERROR: Database server is still starting up. Please wait 5-10 seconds for initialization to complete and try again.";
+        }
+        resolve(cleanOutput);
+      });
+
+      stream.on('error', (err) => {
+        reject(err);
+      });
+    });
+  }
+
+  public static async executeRedisCommand(containerId: string, args: string[]): Promise<string> {
+    const container = docker.getContainer(containerId);
+
+    const exec = await container.exec({
+      Cmd: ['redis-cli', ...args],
+      AttachStdout: true,
+      AttachStderr: true
+    });
+
+    const stream = await exec.start({});
+
+    return new Promise<string>((resolve, reject) => {
+      let output = '';
+
+      container.modem.demuxStream(stream, {
+        write: (chunk: Buffer) => {
+          output += chunk.toString();
+        }
+      }, {
+        write: (chunk: Buffer) => {
+          output += chunk.toString();
+        }
+      });
+
+      stream.on('end', () => {
+        let cleanOutput = output.trim();
+        if (cleanOutput.includes("Could not connect to Redis") || cleanOutput.includes("Connection refused")) {
+          cleanOutput = "ERROR: Redis server is still starting up. Please wait 5-10 seconds for initialization to complete and try again.";
         }
         resolve(cleanOutput);
       });

--- a/backend/src/modules/containers/controllers/containerController.ts
+++ b/backend/src/modules/containers/controllers/containerController.ts
@@ -161,6 +161,31 @@ export class ContainerController {
     }
   }
 
+  public static async redisExplorer(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const explorerData = await ContainerService.getRedisExplorer(id as string);
+      res.json(explorerData);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }
+
+  public static async redisQuery(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const { query } = req.body;
+      if (!query) {
+        res.status(400).json({ error: 'Query is required' });
+        return;
+      }
+      const result = await ContainerService.executeRedisQuery(id as string, query);
+      res.json({ result });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }
+
   public static async nosqlExplorer(req: Request, res: Response): Promise<void> {
     try {
       const { id } = req.params;

--- a/backend/src/modules/containers/routes/containerRoutes.ts
+++ b/backend/src/modules/containers/routes/containerRoutes.ts
@@ -13,6 +13,8 @@ router.get('/:id/postgres/explorer', ContainerController.postgresExplorer);
 router.post('/:id/postgres/query', ContainerController.postgresQuery);
 router.get('/:id/nosql/explorer', ContainerController.nosqlExplorer);
 router.post('/:id/nosql/query', ContainerController.nosqlQuery);
+router.get('/:id/redis/explorer', ContainerController.redisExplorer);
+router.post('/:id/redis/query', ContainerController.redisQuery);
 router.post('/:id/scale', ContainerController.scale);
 
 // ASG Routes

--- a/backend/src/modules/containers/services/containerService.ts
+++ b/backend/src/modules/containers/services/containerService.ts
@@ -1,5 +1,20 @@
 import { ContainerManager, ContainerInfo } from '../../../infrastructure/docker/ContainerManager';
 
+/**
+ * Tokenizes a redis-cli command line into individual arguments, honoring single
+ * and double quoted segments. This lets values containing spaces survive intact,
+ * e.g. `SET greeting "hello world"` -> ['SET', 'greeting', 'hello world'].
+ */
+function parseRedisArgs(input: string): string[] {
+  const args: string[] = [];
+  const tokenPattern = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = tokenPattern.exec(input)) !== null) {
+    args.push(match[1] ?? match[2] ?? match[3]);
+  }
+  return args;
+}
+
 export class ContainerService {
   public static async listContainers(projectId: string): Promise<ContainerInfo[]> {
     return ContainerManager.listContainersByProject(projectId);
@@ -113,6 +128,47 @@ export class ContainerService {
 
   public static async executePostgresQuery(containerId: string, database: string, query: string): Promise<string> {
     return ContainerManager.executePsqlCommand(containerId, database, query);
+  }
+
+  public static async getRedisExplorer(containerId: string) {
+    // Seed a few demo keys exactly once per container, so beginners immediately have
+    // something to explore (mirrors the Postgres/Mongo seeding). The "seeded" marker is
+    // stored in logical DB 1, which survives a FLUSHDB on the default DB 0 — that way a
+    // user can run destructive commands (FLUSHDB, DEL) and actually observe an empty
+    // cache instead of it being silently re-seeded on the next explorer refresh.
+    const seeded = await ContainerManager.executeRedisCommand(containerId, ['-n', '1', 'GET', 'akal:seeded']);
+    if (seeded.startsWith('ERROR')) {
+      throw new Error(seeded);
+    }
+    if (seeded.trim() === '') {
+      await ContainerManager.executeRedisCommand(containerId, ['SET', 'user:1:name', 'Alice Smith']);
+      await ContainerManager.executeRedisCommand(containerId, ['SET', 'user:2:name', 'Bob Jones']);
+      await ContainerManager.executeRedisCommand(containerId, ['INCR', 'page:home:views']);
+      await ContainerManager.executeRedisCommand(containerId, ['RPUSH', 'queue:emails', 'welcome', 'reminder', 'invoice']);
+      await ContainerManager.executeRedisCommand(containerId, ['HSET', 'product:1', 'name', 'Micro VM vCPU', 'price', '4.50']);
+      await ContainerManager.executeRedisCommand(containerId, ['SADD', 'tags:active', 'admin', 'developer', 'analyst']);
+      await ContainerManager.executeRedisCommand(containerId, ['-n', '1', 'SET', 'akal:seeded', '1']);
+    }
+
+    // List all keys (KEYS is fine for an educational lab; production would use SCAN)
+    const keysRaw = await ContainerManager.executeRedisCommand(containerId, ['KEYS', '*']);
+    const keys = keysRaw.split('\n').map(k => k.trim()).filter(Boolean);
+
+    const entries: Array<{ key: string; type: string }> = [];
+    for (const key of keys) {
+      const type = await ContainerManager.executeRedisCommand(containerId, ['TYPE', key]);
+      entries.push({ key, type: type.trim() });
+    }
+
+    return entries;
+  }
+
+  public static async executeRedisQuery(containerId: string, query: string): Promise<string> {
+    const args = parseRedisArgs(query);
+    if (args.length === 0) {
+      return '';
+    }
+    return ContainerManager.executeRedisCommand(containerId, args);
   }
 
   public static async getNosqlExplorer(containerId: string) {

--- a/frontend/src/features/nodes/RedisNode/RedisModal.tsx
+++ b/frontend/src/features/nodes/RedisNode/RedisModal.tsx
@@ -1,0 +1,687 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X, Database, Key, Play, Copy, Check, Search, BookOpen, Terminal, RefreshCw, AlertCircle, Eye, Loader2, Server } from 'lucide-react';
+import { API_BASE } from '../../../shared/types';
+import redisCheatSheet from './data/redisCheatSheet.json';
+
+interface RedisModalProps {
+  containerId: string;
+  nodeName: string;
+  projectId: string;
+  onClose: () => void;
+}
+
+interface RedisKey {
+  key: string;
+  type: string;
+}
+
+const CHEAT_SHEET_DATA = redisCheatSheet;
+const REDIS_IMAGE = 'redis:7-alpine';
+
+/** Maps a Redis value type to the read command that displays its content. */
+function readCommandForType(type: string, key: string): string {
+  switch (type) {
+    case 'list':
+      return `LRANGE ${key} 0 -1`;
+    case 'hash':
+      return `HGETALL ${key}`;
+    case 'set':
+      return `SMEMBERS ${key}`;
+    case 'zset':
+      return `ZRANGE ${key} 0 -1 WITHSCORES`;
+    case 'stream':
+      return `XRANGE ${key} - +`;
+    default:
+      return `GET ${key}`;
+  }
+}
+
+export default function RedisModal({ containerId, nodeName, projectId, onClose }: RedisModalProps) {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<'details' | 'explorer' | 'shell' | 'cheatsheet'>('details');
+  const [explorerData, setExplorerData] = useState<RedisKey[]>([]);
+  const [loadingExplorer, setLoadingExplorer] = useState(false);
+  const [explorerError, setExplorerError] = useState<string | null>(null);
+
+  // Shell states
+  const [command, setCommand] = useState('KEYS *');
+  const [queryOutput, setQueryOutput] = useState('');
+  const [executing, setExecuting] = useState(false);
+
+  // Cheat Sheet Search
+  const [cheatQuery, setCheatQuery] = useState('');
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  const fetchExplorerDataRef = useRef<() => Promise<void>>(undefined);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const fetchExplorerData = useCallback(async () => {
+    try {
+      setLoadingExplorer(true);
+      setExplorerError(null);
+      const res = await fetch(`${API_BASE}/api/projects/${projectId}/containers/${containerId}/redis/explorer`);
+      if (res.ok) {
+        const data = await res.json();
+        setExplorerData(data);
+      } else {
+        const errData = await res.json();
+        if (errData.error && errData.error.includes('starting up')) {
+          setExplorerError('starting_up');
+          // Auto retry in 2.5 seconds. Clear any pending timer first so overlapping
+          // triggers (auto-retry + manual Retry) never stack into multiple loops.
+          if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+          retryTimerRef.current = setTimeout(() => {
+            fetchExplorerDataRef.current?.();
+          }, 2500);
+        } else {
+          setExplorerError(errData.error || 'Failed to inspect keys');
+        }
+      }
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : 'Failed to connect to container';
+      setExplorerError(errMsg);
+    } finally {
+      setLoadingExplorer(false);
+    }
+  }, [projectId, containerId]);
+
+  useEffect(() => {
+    fetchExplorerDataRef.current = fetchExplorerData;
+  }, [fetchExplorerData]);
+  useEffect(() => {
+    fetchExplorerData();
+    return () => {
+      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    };
+  }, [fetchExplorerData]);
+
+  const runCommand = async (commandToRun: string) => {
+    if (!commandToRun.trim()) {
+      setQueryOutput('No command to run.');
+      return;
+    }
+    try {
+      setExecuting(true);
+      setQueryOutput('Executing command in container...');
+      const res = await fetch(`${API_BASE}/api/projects/${projectId}/containers/${containerId}/redis/query`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: commandToRun })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setQueryOutput(data.result || 'Command executed successfully with no output.');
+        fetchExplorerData();
+      } else {
+        setQueryOutput(`ERROR: ${data.error}`);
+      }
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      setQueryOutput(`Execution failed: ${errMsg}`);
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const handleExecuteCommand = () => runCommand(command);
+
+  const handleViewValue = (entry: RedisKey) => {
+    const readCommand = readCommandForType(entry.type, entry.key);
+    setCommand(readCommand);
+    setActiveTab('shell');
+    runCommand(readCommand);
+  };
+
+  const handleCopyCheat = (code: string, idx: number) => {
+    // navigator.clipboard is undefined on non-secure origins (e.g. http://<LAN-ip>);
+    // guard + catch so a copy failure never throws and we only flash the check on success.
+    navigator.clipboard?.writeText(code)
+      .then(() => {
+        setCopiedIndex(idx);
+        setTimeout(() => setCopiedIndex(null), 2000);
+      })
+      .catch(() => { /* clipboard unavailable; nothing copied */ });
+  };
+
+  const filteredCheatSheet = CHEAT_SHEET_DATA.filter(item => {
+    const query = cheatQuery.toLowerCase();
+    return (
+      item.name.toLowerCase().includes(query) ||
+      item.description.toLowerCase().includes(query) ||
+      item.category.toLowerCase().includes(query)
+    );
+  });
+
+  return (
+    <div style={styles.overlay}>
+      <div style={styles.container} className="glass">
+        {/* Header Tabs */}
+        <div style={styles.header}>
+          <div style={styles.tabs}>
+            <button
+              style={{ ...styles.tabBtn, ...(activeTab === 'details' ? styles.activeTabBtn : {}) }}
+              onClick={() => setActiveTab('details')}
+            >
+              <Server size={15} style={{ marginRight: 6 }} />
+              {t('redis.tabs.details')}
+            </button>
+            <button
+              style={{ ...styles.tabBtn, ...(activeTab === 'explorer' ? styles.activeTabBtn : {}) }}
+              onClick={() => setActiveTab('explorer')}
+            >
+              <Database size={15} style={{ marginRight: 6 }} />
+              {t('redis.tabs.explorer')}
+            </button>
+            <button
+              style={{ ...styles.tabBtn, ...(activeTab === 'shell' ? styles.activeTabBtn : {}) }}
+              onClick={() => setActiveTab('shell')}
+            >
+              <Terminal size={15} style={{ marginRight: 6 }} />
+              {t('redis.tabs.shell')}
+            </button>
+            <button
+              style={{ ...styles.tabBtn, ...(activeTab === 'cheatsheet' ? styles.activeTabBtn : {}) }}
+              onClick={() => setActiveTab('cheatsheet')}
+            >
+              <BookOpen size={15} style={{ marginRight: 6 }} />
+              {t('redis.tabs.cheatsheet')}
+            </button>
+          </div>
+          <button onClick={onClose} style={styles.closeBtn}>
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Modal Body */}
+        <div style={styles.body}>
+          {/* TAB: Details */}
+          {activeTab === 'details' && (
+            <div style={styles.tabContent}>
+              <h3 style={{ margin: '0 0 8px 0', fontSize: '16px', color: '#1E293B' }}>{t('redis.details.title')}</h3>
+              <p style={{ margin: '0 0 20px 0', fontSize: '13px', color: '#64748B' }}>
+                {t('redis.details.desc')}
+              </p>
+
+              <div style={{ border: '1px solid #E2E8F0', borderRadius: '8px', padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('redis.details.imageLabel')}</span>
+                  <span style={styles.detailValue}>{REDIS_IMAGE}</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('redis.details.portLabel')}</span>
+                  <span style={styles.detailValue}>6379</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>Node</span>
+                  <span style={styles.detailValue}>{nodeName}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* TAB: Key Explorer */}
+          {activeTab === 'explorer' && (
+            <div style={styles.tabContent}>
+              <div style={styles.sectionHeader}>
+                <span style={styles.sectionTitle}>{t('redis.explorer.title')}{nodeName}</span>
+                <button onClick={fetchExplorerData} disabled={loadingExplorer} style={styles.iconActionBtn}>
+                  <RefreshCw size={14} className={loadingExplorer ? 'spin' : ''} />
+                </button>
+              </div>
+
+              <div style={styles.explorerTree}>
+                {explorerError ? (
+                  explorerError === 'starting_up' ? (
+                    <div style={styles.errorContainer}>
+                      <Loader2 size={24} className="spin" color="#3B82F6" style={{ marginBottom: 12 }} />
+                      <span style={styles.errorMessage}>{t('redis.explorer.initializing')}</span>
+                    </div>
+                  ) : (
+                    <div style={styles.errorContainer}>
+                      <AlertCircle size={24} color="#EF4444" style={{ marginBottom: 12 }} />
+                      <span style={styles.errorMessage}>{explorerError}</span>
+                      <button onClick={fetchExplorerData} style={styles.retryBtn}>
+                        <RefreshCw size={12} style={{ marginRight: 6 }} />
+                        {t('redis.explorer.retryBtn')}
+                      </button>
+                    </div>
+                  )
+                ) : explorerData.length > 0 ? (
+                  explorerData.map(entry => (
+                    <div key={entry.key} style={styles.treeNode}>
+                      <div style={styles.treeRow}>
+                        <Key size={14} color="#DC2626" style={{ marginRight: 8 }} />
+                        <span style={styles.keyName}>{entry.key}</span>
+                        <span style={styles.keyType}>{entry.type}</span>
+
+                        <button
+                          onClick={() => handleViewValue(entry)}
+                          style={styles.inlineViewBtn}
+                          title="View value in Redis shell"
+                          className="glass"
+                        >
+                          <Eye size={12} style={{ marginRight: 4 }} />
+                          {t('redis.explorer.viewDataBtn')}
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div style={styles.treeRowEmpty}>{t('redis.explorer.noKeys')}</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* TAB: Redis Shell */}
+          {activeTab === 'shell' && (
+            <div style={{ ...styles.tabContent, display: 'flex', flexDirection: 'column' }}>
+              <div style={styles.shellHeader}>
+                <span style={styles.label}>redis-cli</span>
+                <button
+                  onClick={handleExecuteCommand}
+                  disabled={executing || !command.trim()}
+                  style={styles.runBtn}
+                >
+                  <Play size={14} style={{ marginRight: 6 }} fill="#FFF" />
+                  {executing ? t('redis.shell.executingBtn') : t('redis.shell.executeBtn')}
+                </button>
+              </div>
+
+              <textarea
+                value={command}
+                onChange={(e) => setCommand(e.target.value)}
+                placeholder={t('redis.shell.placeholder')}
+                style={styles.sqlTextarea}
+              />
+
+              <div style={styles.terminalHeader}>{t('redis.shell.consoleTitle')}</div>
+              <pre style={styles.terminalOutput}>
+                <code>{queryOutput || t('redis.shell.emptyOutput')}</code>
+              </pre>
+            </div>
+          )}
+
+          {/* TAB: Cheat Sheet */}
+          {activeTab === 'cheatsheet' && (
+            <div style={{ ...styles.tabContent, display: 'flex', flexDirection: 'column' }}>
+              <div style={styles.searchBar}>
+                <div style={styles.searchWrapper}>
+                  <Search size={15} color="var(--color-text-muted)" style={styles.searchIcon} />
+                  <input
+                    type="text"
+                    placeholder={t('redis.cheatsheet.placeholder')}
+                    value={cheatQuery}
+                    onChange={(e) => setCheatQuery(e.target.value)}
+                    style={styles.searchInput}
+                  />
+                </div>
+              </div>
+
+              <div style={styles.cheatSheetList}>
+                {filteredCheatSheet.map((item, idx) => (
+                  <div key={item.name} style={styles.cheatCard}>
+                    <div style={styles.cheatHeader}>
+                      <span style={styles.cheatName}>{item.name}</span>
+                      <span style={styles.cheatCategory}>{item.category}</span>
+                    </div>
+                    <p style={styles.cheatDesc}>{item.description}</p>
+                    <div style={styles.codeContainer}>
+                      <pre style={styles.code}>
+                        <code>{item.example}</code>
+                      </pre>
+                      <button
+                        onClick={() => handleCopyCheat(item.example, idx)}
+                        style={styles.copyBtn}
+                      >
+                        {copiedIndex === idx ? <Check size={14} color="#10B981" /> : <Copy size={14} />}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100vw',
+    height: '100vh',
+    backgroundColor: 'rgba(0, 0, 0, 0.65)',
+    zIndex: 1000,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '24px',
+    boxSizing: 'border-box',
+  },
+  container: {
+    width: '900px',
+    maxWidth: '100%',
+    height: '600px',
+    maxHeight: '100%',
+    borderRadius: '12px',
+    display: 'flex',
+    flexDirection: 'column',
+    boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.5)',
+    overflow: 'hidden',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '12px 20px',
+    borderBottom: '1px solid var(--border-color)',
+    backgroundColor: 'var(--bg-surface-solid)',
+    borderTopLeftRadius: '12px',
+    borderTopRightRadius: '12px',
+  },
+  tabs: {
+    display: 'flex',
+    gap: '8px',
+  },
+  tabBtn: {
+    backgroundColor: 'transparent',
+    border: 'none',
+    borderRadius: '6px',
+    color: 'var(--color-text-secondary)',
+    cursor: 'pointer',
+    padding: '8px 14px',
+    fontSize: '13px',
+    fontWeight: 600,
+    display: 'flex',
+    alignItems: 'center',
+    transition: 'all 0.2s',
+  },
+  activeTabBtn: {
+    backgroundColor: 'var(--color-accent-glow)',
+    color: 'var(--color-accent)',
+  },
+  closeBtn: {
+    background: 'none',
+    border: 'none',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    padding: '6px',
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: 'background-color 0.2s, color 0.2s',
+  },
+  body: {
+    flex: 1,
+    overflow: 'hidden',
+    backgroundColor: '#FFFFFF',
+  },
+  tabContent: {
+    height: '100%',
+    overflowY: 'auto',
+    padding: '20px',
+    boxSizing: 'border-box',
+  },
+  detailRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    fontSize: '13px',
+  },
+  detailLabel: {
+    color: 'var(--color-text-secondary)',
+    fontWeight: 600,
+  },
+  detailValue: {
+    color: 'var(--color-text-primary)',
+    fontFamily: 'var(--font-mono)',
+  },
+  sectionHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '16px',
+  },
+  sectionTitle: {
+    fontSize: '14px',
+    fontWeight: 700,
+    color: 'var(--color-text-primary)',
+  },
+  iconActionBtn: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    color: 'var(--color-text-muted)',
+    padding: '4px',
+    borderRadius: '4px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  explorerTree: {
+    border: '1px solid var(--border-color)',
+    borderRadius: '8px',
+    padding: '12px',
+    backgroundColor: 'var(--bg-main)',
+    minHeight: '240px',
+  },
+  treeNode: {
+    marginBottom: '6px',
+  },
+  treeRow: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: '6px 8px',
+    borderRadius: '6px',
+    transition: 'background-color 0.2s',
+    userSelect: 'none',
+  },
+  treeRowEmpty: {
+    padding: '6px 8px',
+    fontSize: '12px',
+    color: 'var(--color-text-muted)',
+    fontStyle: 'italic',
+  },
+  keyName: {
+    fontSize: '13px',
+    fontWeight: 600,
+    color: 'var(--color-text-primary)',
+    fontFamily: 'var(--font-mono)',
+  },
+  keyType: {
+    fontSize: '11px',
+    color: 'var(--color-text-muted)',
+    fontStyle: 'italic',
+    marginLeft: '10px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+  },
+  shellHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '12px',
+    flexShrink: 0,
+  },
+  label: {
+    fontSize: '12px',
+    fontWeight: 600,
+    color: 'var(--color-text-secondary)',
+    fontFamily: 'var(--font-mono)',
+  },
+  runBtn: {
+    backgroundColor: '#10B981',
+    color: '#FFF',
+    border: 'none',
+    borderRadius: '6px',
+    padding: '8px 16px',
+    fontSize: '13px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    boxShadow: '0 1px 3px rgba(16, 185, 129, 0.3)',
+  },
+  sqlTextarea: {
+    width: '100%',
+    height: '140px',
+    padding: '12px',
+    borderRadius: '8px',
+    border: '1px solid var(--border-color)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: '13px',
+    resize: 'none',
+    boxSizing: 'border-box',
+    outline: 'none',
+    marginBottom: '16px',
+    backgroundColor: 'var(--bg-main)',
+    color: 'var(--color-text-primary)',
+  },
+  terminalHeader: {
+    fontSize: '11px',
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    marginBottom: '8px',
+  },
+  terminalOutput: {
+    flex: 1,
+    margin: 0,
+    padding: '12px',
+    backgroundColor: '#0F172A',
+    color: '#E2E8F0',
+    borderRadius: '8px',
+    fontFamily: 'var(--font-mono)',
+    fontSize: '13px',
+    overflow: 'auto',
+    border: '1px solid rgba(255,255,255,0.05)',
+  },
+  searchBar: {
+    marginBottom: '16px',
+  },
+  searchWrapper: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  searchIcon: {
+    position: 'absolute',
+    left: '12px',
+  },
+  searchInput: {
+    width: '100%',
+    padding: '10px 12px 10px 36px',
+    backgroundColor: 'var(--bg-main)',
+    border: '1px solid var(--border-color)',
+    borderRadius: '8px',
+    fontSize: '13px',
+    outline: 'none',
+  },
+  cheatSheetList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+  },
+  cheatCard: {
+    border: '1px solid var(--border-color)',
+    borderRadius: '8px',
+    padding: '16px',
+    backgroundColor: 'rgba(255,255,255,0.02)',
+  },
+  cheatHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '8px',
+  },
+  cheatName: {
+    fontSize: '14px',
+    fontWeight: 700,
+    color: 'var(--color-accent)',
+  },
+  cheatCategory: {
+    fontSize: '11px',
+    color: 'var(--color-text-secondary)',
+    backgroundColor: 'rgba(0, 0, 0, 0.04)',
+    border: '1px solid var(--border-color)',
+    padding: '2px 6px',
+    borderRadius: '4px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+  },
+  cheatDesc: {
+    fontSize: '13px',
+    color: 'var(--color-text-secondary)',
+    margin: '0 0 12px 0',
+  },
+  codeContainer: {
+    position: 'relative',
+  },
+  code: {
+    margin: 0,
+    padding: '10px 14px',
+    backgroundColor: 'var(--bg-main)',
+    color: 'var(--color-text-primary)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: '13px',
+    borderRadius: '6px',
+    overflowX: 'auto',
+    border: '1px solid var(--border-color)',
+  },
+  copyBtn: {
+    position: 'absolute',
+    right: '8px',
+    top: '8px',
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    color: 'var(--color-text-muted)',
+    padding: '4px',
+    borderRadius: '4px',
+  },
+  inlineViewBtn: {
+    marginLeft: 'auto',
+    backgroundColor: 'var(--color-accent-glow)',
+    border: '1px solid rgba(37, 99, 235, 0.2)',
+    borderRadius: '4px',
+    color: 'var(--color-accent)',
+    fontSize: '11px',
+    padding: '2px 8px',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    transition: 'all 0.2s',
+  },
+  errorContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '30px 20px',
+    textAlign: 'center',
+  },
+  errorMessage: {
+    fontSize: '13px',
+    color: 'var(--color-text-secondary)',
+    marginBottom: '16px',
+    maxWidth: '400px',
+  },
+  retryBtn: {
+    backgroundColor: 'var(--color-accent)',
+    color: '#FFF',
+    border: 'none',
+    borderRadius: '6px',
+    padding: '6px 16px',
+    fontSize: '12px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+  }
+};

--- a/frontend/src/features/nodes/RedisNode/RedisNode.tsx
+++ b/frontend/src/features/nodes/RedisNode/RedisNode.tsx
@@ -1,0 +1,48 @@
+import { Database, Search } from 'lucide-react';
+import BaseNode from '../components/BaseNode';
+import styles from '../ServiceNode.module.css';
+
+interface RedisNodeProps {
+  data: {
+    id: string;
+    name: string;
+    state?: string;
+    ip?: string;
+    onSecurityGroupOpen?: (id: string, name: string) => void;
+    onInspect: (id: string, name: string) => void;
+    onStop: (id: string) => void;
+    onStart: (id: string) => void;
+    onDelete: (id: string) => void;
+  };
+}
+
+export default function RedisNode({ data }: RedisNodeProps) {
+  const isRunning = data.state === 'running';
+
+  return (
+    <BaseNode
+      id={data.id}
+      name={data.name}
+      isRunning={isRunning}
+      icon={<Database size={18} color={isRunning ? '#DC2626' : '#6B7280'} />}
+      customBorder={isRunning ? '1px solid #DC2626' : undefined}
+      subtitle={
+        <>
+          <span className={styles.label}>IP/Port:</span>
+          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip ? `${data.ip}:6379` : '6379'}</span>
+        </>
+      }
+      onStart={data.onStart}
+      onStop={data.onStop}
+      onDelete={data.onDelete}
+      onSecurityGroupOpen={data.onSecurityGroupOpen}
+      primaryAction={{
+        label: 'Inspect',
+        icon: <Search size={14} />,
+        color: '#DC2626', // Redis Red
+        onClick: data.onInspect,
+        title: 'Inspect Redis Keys / Shell',
+      }}
+    />
+  );
+}

--- a/frontend/src/features/nodes/RedisNode/data/redisCheatSheet.json
+++ b/frontend/src/features/nodes/RedisNode/data/redisCheatSheet.json
@@ -1,0 +1,110 @@
+[
+  {
+    "name": "Set Key",
+    "category": "Strings (Beginner)",
+    "description": "Store a string value under a key.",
+    "example": "SET user:1:name \"Alice Smith\""
+  },
+  {
+    "name": "Get Key",
+    "category": "Strings (Beginner)",
+    "description": "Read the value stored at a key.",
+    "example": "GET user:1:name"
+  },
+  {
+    "name": "Delete Key",
+    "category": "Keys (Beginner)",
+    "description": "Remove one or more keys.",
+    "example": "DEL user:1:name"
+  },
+  {
+    "name": "List Keys",
+    "category": "Keys (Beginner)",
+    "description": "Find all keys matching a pattern.",
+    "example": "KEYS user:*"
+  },
+  {
+    "name": "Key Type",
+    "category": "Keys (Beginner)",
+    "description": "Show the data type stored at a key.",
+    "example": "TYPE queue:emails"
+  },
+  {
+    "name": "Set Expiry",
+    "category": "Expiration (Beginner)",
+    "description": "Expire a key automatically after N seconds.",
+    "example": "EXPIRE session:abc 60"
+  },
+  {
+    "name": "Time To Live",
+    "category": "Expiration (Beginner)",
+    "description": "Show remaining seconds before a key expires.",
+    "example": "TTL session:abc"
+  },
+  {
+    "name": "Set With Expiry",
+    "category": "Expiration (Intermediate)",
+    "description": "Store a value and set its TTL in one command.",
+    "example": "SET session:abc token123 EX 60"
+  },
+  {
+    "name": "Increment Counter",
+    "category": "Counters (Beginner)",
+    "description": "Atomically increment a numeric value (great for page views).",
+    "example": "INCR page:home:views"
+  },
+  {
+    "name": "Push To List",
+    "category": "Lists (Intermediate)",
+    "description": "Append one or more values to the tail of a list.",
+    "example": "RPUSH queue:emails welcome reminder"
+  },
+  {
+    "name": "Read List Range",
+    "category": "Lists (Intermediate)",
+    "description": "Read elements of a list (0 -1 returns all).",
+    "example": "LRANGE queue:emails 0 -1"
+  },
+  {
+    "name": "Set Hash Fields",
+    "category": "Hashes (Intermediate)",
+    "description": "Store multiple fields of an object under one key.",
+    "example": "HSET product:1 name \"Micro VM\" price 4.50"
+  },
+  {
+    "name": "Read Hash",
+    "category": "Hashes (Intermediate)",
+    "description": "Return all fields and values of a hash.",
+    "example": "HGETALL product:1"
+  },
+  {
+    "name": "Add To Set",
+    "category": "Sets (Intermediate)",
+    "description": "Add unique members to a set.",
+    "example": "SADD tags:active admin developer"
+  },
+  {
+    "name": "Read Set Members",
+    "category": "Sets (Intermediate)",
+    "description": "Return all members of a set.",
+    "example": "SMEMBERS tags:active"
+  },
+  {
+    "name": "Scan Keys",
+    "category": "Keys (Advanced)",
+    "description": "Iterate keys without blocking the server (production-safe alternative to KEYS).",
+    "example": "SCAN 0 MATCH user:* COUNT 100"
+  },
+  {
+    "name": "Database Size",
+    "category": "Server (Advanced)",
+    "description": "Count the number of keys in the current database.",
+    "example": "DBSIZE"
+  },
+  {
+    "name": "Flush Database",
+    "category": "Server (Advanced)",
+    "description": "Delete every key in the current database (irreversible).",
+    "example": "FLUSHDB"
+  }
+]

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -141,6 +141,40 @@
       "placeholder": "Search SQL commands or concepts..."
     }
   },
+  "redis": {
+    "tabs": {
+      "details": "Details",
+      "explorer": "Key Explorer",
+      "shell": "Redis Shell",
+      "cheatsheet": "Redis Cheat Sheet"
+    },
+    "details": {
+      "title": "Cache Node Details",
+      "desc": "In-memory key-value cache backed by a real Redis container. Use the Key Explorer and Shell to inspect and manipulate data.",
+      "imageLabel": "Image",
+      "portLabel": "Port",
+      "stateLabel": "State",
+      "running": "Running",
+      "stopped": "Stopped"
+    },
+    "explorer": {
+      "title": "Inspect keys: ",
+      "initializing": "Redis server is initializing... This may take a few seconds.",
+      "retryBtn": "Retry Key Scan",
+      "viewDataBtn": "View Value",
+      "noKeys": "No keys found. Use the Shell to add some."
+    },
+    "shell": {
+      "executeBtn": "Run Command",
+      "executingBtn": "Running...",
+      "placeholder": "Write a redis-cli command here, e.g. SET key value",
+      "consoleTitle": "Output Console",
+      "emptyOutput": "No output. Run a command to see the result."
+    },
+    "cheatsheet": {
+      "placeholder": "Search Redis commands or concepts..."
+    }
+  },
   "nosql": {
     "tabs": {
       "details": "Details & Config",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -141,6 +141,40 @@
       "placeholder": "Rechercher des commandes ou concepts SQL..."
     }
   },
+  "redis": {
+    "tabs": {
+      "details": "Détails",
+      "explorer": "Explorateur de Clés",
+      "shell": "Shell Redis",
+      "cheatsheet": "Aide-mémoire Redis"
+    },
+    "details": {
+      "title": "Détails du Nœud de Cache",
+      "desc": "Cache clé-valeur en mémoire adossé à un vrai conteneur Redis. Utilisez l'Explorateur de Clés et le Shell pour inspecter et manipuler les données.",
+      "imageLabel": "Image",
+      "portLabel": "Port",
+      "stateLabel": "État",
+      "running": "En cours d'exécution",
+      "stopped": "Arrêté"
+    },
+    "explorer": {
+      "title": "Inspecter les clés : ",
+      "initializing": "Le serveur Redis s'initialise... Cela peut prendre quelques secondes.",
+      "retryBtn": "Réessayer le Scan des Clés",
+      "viewDataBtn": "Voir la Valeur",
+      "noKeys": "Aucune clé trouvée. Utilisez le Shell pour en ajouter."
+    },
+    "shell": {
+      "executeBtn": "Exécuter la Commande",
+      "executingBtn": "Exécution en cours...",
+      "placeholder": "Écrivez une commande redis-cli ici, ex: SET clé valeur",
+      "consoleTitle": "Console de Sortie",
+      "emptyOutput": "Aucune sortie. Exécutez une commande pour voir le résultat."
+    },
+    "cheatsheet": {
+      "placeholder": "Rechercher des commandes ou concepts Redis..."
+    }
+  },
   "nosql": {
     "tabs": {
       "details": "Détails & Config",

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -10,6 +10,8 @@ import PostgresNode from '../../features/nodes/PostgresNode/PostgresNode';
 import PostgresModal from '../../features/nodes/PostgresNode/PostgresModal';
 import NoSqlNode from '../../features/nodes/NoSqlNode/NoSqlNode';
 import NoSqlModal from '../../features/nodes/NoSqlNode/NoSqlModal';
+import RedisNode from '../../features/nodes/RedisNode/RedisNode';
+import RedisModal from '../../features/nodes/RedisNode/RedisModal';
 
 import LoadBalancerNode from '../../features/nodes/LoadBalancerNode/LoadBalancerNode';
 import LoadBalancerModal from '../../features/nodes/LoadBalancerNode/LoadBalancerModal';
@@ -120,6 +122,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [inspectingPostgres, setInspectingPostgres] = useState<{ id: string; name: string } | null>(null);
   const [inspectingNosql, setInspectingNosql] = useState<{ id: string; name: string } | null>(null);
+  const [inspectingRedis, setInspectingRedis] = useState<{ id: string; name: string } | null>(null);
 
   const [inspectingNat, setInspectingNat] = useState<{ id: string; name: string } | null>(null);
   const [inspectingLoadBalancer, setInspectingLoadBalancer] = useState<{ id: string; name: string } | null>(null);
@@ -171,6 +174,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     postgres: PostgresNode,
     sql: PostgresNode,
     nosql: NoSqlNode,
+    redis: RedisNode,
     nat: NatNode,
     vpc: VpcNode,
     subnet: SubnetNode,
@@ -399,9 +403,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     if (!targetNode) return;
     const targetType = targetNode.type || 'ubuntu';
     
-    const isDb = ['postgres', 'sql', 'nosql', 'mysql'].includes(targetType);
+    const isDb = ['postgres', 'sql', 'nosql', 'mysql', 'redis'].includes(targetType);
     const defaultProtocol = isDb ? 'TCP' : 'ALL';
-    const defaultPort = (targetType === 'postgres' || targetType === 'sql') ? '5432' : (targetType === 'nosql') ? '27017' : (targetType === 'mysql') ? '3306' : 'ALL';
+    const defaultPort = (targetType === 'postgres' || targetType === 'sql') ? '5432' : (targetType === 'nosql') ? '27017' : (targetType === 'mysql') ? '3306' : (targetType === 'redis') ? '6379' : 'ALL';
 
     const currentRules = networkConfig.nodeSecurityGroups[target] || [];
     const alreadyExists = currentRules.some(r => r.type === 'inbound' && r.action === 'ALLOW' && r.port === defaultPort && r.source === source);
@@ -753,6 +757,8 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
                 setInspectingPostgres({ id, name });
               } else if (nodeType === 'nosql') {
                 setInspectingNosql({ id, name });
+              } else if (nodeType === 'redis') {
+                setInspectingRedis({ id, name });
               } else if (nodeType === 'nat') {
                 setInspectingNat({ id, name });
               } else if (nodeType === 'loadbalancer') {
@@ -1414,6 +1420,8 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
               ? "Create SQL Database Node"
               : dropState?.type === 'nosql'
                 ? "Create NoSQL Database Node"
+                : dropState?.type === 'redis'
+                  ? "Create Cache Store Node"
                 : dropState?.type === 'nat'
                   ? "Create NAT Gateway Node"
                   : dropState?.type === 'loadbalancer'
@@ -1428,6 +1436,8 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
               ? "e.g. sql-1"
               : dropState?.type === 'nosql'
                 ? "e.g. nosql-1"
+                : dropState?.type === 'redis'
+                  ? "e.g. redis-1"
                 : dropState?.type === 'nat'
                   ? "e.g. nat-1"
                   : dropState?.type === 'loadbalancer'
@@ -1446,6 +1456,8 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
                   ? 'sql-'
                   : type === 'nosql'
                     ? 'nosql-'
+                    : type === 'redis'
+                      ? 'redis-'
                     : type === 'nat'
                       ? 'nat-'
                       : type === 'loadbalancer'
@@ -1492,6 +1504,15 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           nodeName={inspectingNosql.name}
           projectId={projectId}
           onClose={() => setInspectingNosql(null)}
+        />
+      )}
+
+      {inspectingRedis && (
+        <RedisModal
+          containerId={inspectingRedis.id}
+          nodeName={inspectingRedis.name}
+          projectId={projectId}
+          onClose={() => setInspectingRedis(null)}
         />
       )}
 

--- a/frontend/src/pages/CanvasPage/components/NodeLibrary.tsx
+++ b/frontend/src/pages/CanvasPage/components/NodeLibrary.tsx
@@ -89,6 +89,13 @@ export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
           desc: 'Document DB + Shell',
           icon: <Braces size={18} color="#475569" />,
           collapsedIcon: <Braces size={20} color="#475569" />
+        },
+        {
+          type: 'redis',
+          name: 'Cache Store',
+          desc: 'In-memory key-value cache',
+          icon: <Database size={18} color="#DC2626" />,
+          collapsedIcon: <Database size={20} color="#DC2626" />
         }
       ]
     }

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -5,7 +5,7 @@ export interface ContainerData {
   name: string;
   state: string;
   status: string;
-  type?: 'ubuntu' | 'postgres' | 'mysql' | 'sql' | 'nosql' | 'nat' | 'loadbalancer' | 'autoscalinggroup';
+  type?: 'ubuntu' | 'postgres' | 'mysql' | 'sql' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'autoscalinggroup';
   port?: string;
   ip?: string;
   image?: string;

--- a/frontend/src/shared/utils/architectureValidator.ts
+++ b/frontend/src/shared/utils/architectureValidator.ts
@@ -42,6 +42,9 @@ export function validateArchitecture(
   const successes: string[] = [];
 
   const dbTypes = ['postgres', 'sql', 'nosql', 'mysql'];
+  // Data stores that should be kept private and never exposed publicly. Redis is a
+  // cache rather than a relational DB tier, so it is tracked separately from dbTypes.
+  const sensitiveTypes = [...dbTypes, 'redis'];
 
   // --- 1. ERROR CHECKS ---
   
@@ -58,38 +61,38 @@ export function validateArchitecture(
 
   // --- 2. WARNING CHECKS ---
 
-  // DB in public subnet check
+  // Data store in public subnet check
   containers.forEach(node => {
-    const isDb = dbTypes.includes(node.type || '');
-    if (isDb) {
+    const isSensitive = sensitiveTypes.includes(node.type || '');
+    if (isSensitive) {
       const subnetId = networkConfig.nodeSubnetMap[node.id];
       if (subnetId) {
         const subnet = networkConfig.subnets.find(s => s.id === subnetId);
         if (subnet && subnet.type === 'public') {
-          warnings.push(`Database "${node.name}" is in a public subnet. For safety, database instances should be kept in private subnets.`);
+          warnings.push(`Data store "${node.name}" is in a public subnet. For safety, data store instances should be kept in private subnets.`);
         }
       }
     }
   });
 
-  // Database 0.0.0.0/0 exposure check
+  // Data store 0.0.0.0/0 exposure check
   containers.forEach(node => {
-    const isDb = dbTypes.includes(node.type || '');
-    if (isDb) {
+    const isSensitive = sensitiveTypes.includes(node.type || '');
+    if (isSensitive) {
       const rules = networkConfig.nodeSecurityGroups[node.id] || [];
       const hasPublicAccess = rules.some(
         rule => rule.type === 'inbound' && rule.action === 'ALLOW' && rule.source === '0.0.0.0/0'
       );
       if (hasPublicAccess) {
-        warnings.push(`Database "${node.name}" is exposed to the public internet (0.0.0.0/0) in its security group.`);
+        warnings.push(`Data store "${node.name}" is exposed to the public internet (0.0.0.0/0) in its security group.`);
       }
     }
   });
 
-  // Check for Redis/caching tier
+  // Check for Redis/caching tier (by node type or by name, for backwards compatibility)
   const hasCacheNode = containers.some(c => {
     const name = c.name.toLowerCase();
-    return name.includes('redis') || name.includes('cache') || name.includes('memcached');
+    return c.type === 'redis' || name.includes('redis') || name.includes('cache') || name.includes('memcached');
   });
   if (containers.length > 0 && !hasCacheNode) {
     // Only warn if there's at least one DB


### PR DESCRIPTION
## Summary of Changes
Provide a brief summary of what this PR introduces and the problem it solves.

Adds a new Redis "cache store" infrastructure node, backed by a redis:7-alpine Docker Container, mirroring the existing Postgres and MongoDB nodes 

The node ships with a 4-tab inspection modal (Details, Key explorer, Redis shell, Cheat sheet) and three integrations: auto-creation of a TCP 6379 security-group when wired to a server, recognition of Redis as the caching tier in the architecture validator, and treatment of Redis as a sensitive data store. Demo keys are seeded once on first inspection.

## Types of Changes
- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification
Describe how you tested this change locally (e.g. "Simulated network config, ran ping node-2 from terminal modal").
Tested locally with Docker Desktop running:
- Dropped a Cache Store node on the canvas → confirmed a real redis:7-alpine container via docker ps | grep redis.
- Key Explorer: seeded keys (user:1:name, queue:emails, product:1, …) appear with correct types; View Value reads each per its type.
- Redis Shell: SET test 123 → GET test returns 123; quoted values with spaces (SET k "a b") parse as a single argument.
- One-time seeding: ran FLUSHDB then refreshed → cache stays empty (not silently re-seeded).
- Integrations: server→Redis connection auto-created the TCP 6379 rule; adding the node cleared the "No caching tier detected" warning; placing it in a public subnet triggered the exposure warning.

## Checklist
- [x] My code follows the repository's code style and lint standards
- [ ] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
