### PR TITLE
feat: add /health readiness probe

### DIFF
--- a/backend/src/modules/health/controllers/healthController.test.ts
+++ b/backend/src/modules/health/controllers/healthController.test.ts
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import express from 'express';
+import { HealthController } from './healthController';
+import docker from '../../../infrastructure/docker/DockerClient';
+
+jest.mock('../../../infrastructure/docker/DockerClient', () => ({
+  ping: jest.fn(),
+}));
+
+const app = express();
+app.get('/health', HealthController.check);
+
+describe('HealthController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /health', () => {
+    it('should return 200 ok when Docker is reachable', async () => {
+      (docker.ping as jest.Mock).mockResolvedValue('OK');
+
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        status: 'ok',
+        checks: { docker: { status: 'ok' } },
+      });
+    });
+
+    it('should return 503 degraded when Docker is unreachable', async () => {
+      (docker.ping as jest.Mock).mockRejectedValue(
+        new Error('connect ENOENT /var/run/docker.sock')
+      );
+
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({
+        status: 'degraded',
+        checks: {
+          docker: { status: 'unreachable', error: 'connect ENOENT /var/run/docker.sock' },
+        },
+      });
+    });
+  });
+});

--- a/backend/src/modules/health/controllers/healthController.ts
+++ b/backend/src/modules/health/controllers/healthController.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express';
+import docker from '../../../infrastructure/docker/DockerClient';
+
+export class HealthController {
+  static async check(_req: Request, res: Response): Promise<void> {
+    try {
+      await docker.ping();
+      res.status(200).json({
+        status: 'ok',
+        checks: { docker: { status: 'ok' } },
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      res.status(503).json({
+        status: 'degraded',
+        checks: { docker: { status: 'unreachable', error } },
+      });
+    }
+  }
+}

--- a/backend/src/modules/health/routes/healthRoutes.ts
+++ b/backend/src/modules/health/routes/healthRoutes.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { HealthController } from '../controllers/healthController';
+
+const router = Router();
+router.get('/', HealthController.check);
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import { ENV } from './config/env';
 import projectRouter from './modules/projects/routes/projectRoutes';
 import containerRouter from './modules/containers/routes/containerRoutes';
+import healthRouter from './modules/health/routes/healthRoutes';
 import { TerminalGateway } from './modules/terminal/gateway/terminalGateway';
 import { DockerInitializer } from './infrastructure/docker/DockerInitializer';
 
@@ -16,6 +17,9 @@ app.use(cors({
   methods: ['GET', 'POST', 'DELETE']
 }));
 app.use(express.json());
+
+// Health probe
+app.use('/health', healthRouter);
 
 // Scoped APIs
 app.use('/api/projects', projectRouter);


### PR DESCRIPTION

## Summary of Changes

Adds GET /health that pings the Docker daemon and returns 200 ok or 503 degraded. Includes unit tests covering both the healthy and unreachable Docker paths.

<!--
Provide a brief summary of what this PR introduces and the problem it solves.
-->

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

<!--
Describe how you tested this change locally (e.g. "Simulated network config, ran ping node-2 from terminal modal").
-->
'''
curl -i localhost:23233/health
'''

## Checklist

- [x] My code follows the repository's code style and lint standards
- [ ] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
