### PR TITLE
Fix/redis iptables

### DIFF
--- a/backend/src/infrastructure/docker/ContainerManager.ts
+++ b/backend/src/infrastructure/docker/ContainerManager.ts
@@ -38,7 +38,7 @@ export class ContainerManager {
   private static readonly POSTGRES_IMAGE_TAG = 'derssa/backend-lab-postgres:v1';
   private static readonly MONGO_IMAGE_TAG = 'derssa/backend-lab-mongo:v1';
   private static readonly NGINX_IMAGE_TAG = 'derssa/backend-lab-nginx:v1';
-  private static readonly REDIS_IMAGE_TAG = 'redis:7-alpine';
+  private static readonly REDIS_IMAGE_TAG = 'derssa/backend-lab-redis:v1';
 
   /**
    * Ensures that the custom prebuilt Ubuntu image exists locally.

--- a/backend/src/infrastructure/docker/DockerInitializer.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.ts
@@ -4,6 +4,7 @@ export class DockerInitializer {
   private static readonly UBUNTU_IMAGE_TAG = 'derssa/backend-lab-ubuntu:v1';
   private static readonly POSTGRES_IMAGE_TAG = 'derssa/backend-lab-postgres:v1';
   private static readonly MONGO_IMAGE_TAG = 'derssa/backend-lab-mongo:v1';
+  private static readonly REDIS_IMAGE_TAG = 'derssa/backend-lab-redis:v1';
   private static isInitializing = false;
 
   /**
@@ -80,6 +81,7 @@ export class DockerInitializer {
       await this.ensureImage(tags, this.UBUNTU_IMAGE_TAG, 'Ubuntu');
       await this.ensureImage(tags, this.POSTGRES_IMAGE_TAG, 'PostgreSQL');
       await this.ensureImage(tags, this.MONGO_IMAGE_TAG, 'MongoDB');
+      await this.ensureImage(tags, this.REDIS_IMAGE_TAG, 'Redis');
     } catch (err) {
       console.error('[DockerInitializer] Docker check failed. Is Docker running?');
       throw err;
@@ -189,6 +191,65 @@ export class DockerInitializer {
         console.log(`[DockerInitializer] Cleaning up temporary build container...`);
         await tempContainer.remove({ force: true });
         console.log(`[DockerInitializer] Custom MongoDB image with iptables created successfully.`);
+      } else if (tag === this.REDIS_IMAGE_TAG) {
+        const fallbackTag = 'redis:7-alpine';
+        console.log(`[DockerInitializer] Tag ${tag} not found. Building custom Redis image locally...`);
+        
+        // Ensure base redis:7-alpine is pulled
+        const imagesList = await docker.listImages();
+        const localTags = imagesList.flatMap(img => img.RepoTags || []);
+        if (!localTags.includes(fallbackTag)) {
+          console.log(`[DockerInitializer] Pulling base redis:7-alpine image...`);
+          await new Promise<void>((resolve, reject) => {
+            docker.pull(fallbackTag, {}, (err, stream) => {
+              if (err) return reject(err);
+              if (!stream) return reject(new Error('Pull stream is undefined'));
+              docker.modem.followProgress(stream, (finishedErr) => finishedErr ? reject(finishedErr) : resolve());
+            });
+          });
+        }
+        
+        // Clean up any stale temp containers from previous runs
+        try {
+          const oldContainer = docker.getContainer('akal-lab-temp-redis-build');
+          await oldContainer.remove({ force: true });
+        } catch {
+          // Ignore if old container doesn't exist
+        }
+
+        console.log(`[DockerInitializer] Creating temporary build container for Redis...`);
+        const tempContainer = await docker.createContainer({
+          Image: fallbackTag,
+          name: 'akal-lab-temp-redis-build',
+          Entrypoint: ['tail', '-f', '/dev/null']
+        });
+        await tempContainer.start();
+        
+        console.log(`[DockerInitializer] Installing iptables inside build container...`);
+        const exec = await tempContainer.exec({
+          Cmd: ['sh', '-c', 'apk update && apk add --no-cache iptables iproute2'],
+          AttachStdout: true,
+          AttachStderr: true
+        });
+        const stream = await exec.start({});
+        await new Promise<void>((resolve) => {
+          stream.on('data', () => {});
+          stream.on('end', () => resolve());
+        });
+
+        console.log(`[DockerInitializer] Committing custom Redis image as ${tag}...`);
+        await tempContainer.commit({
+          repo: 'derssa/backend-lab-redis',
+          tag: 'v1',
+          changes: [
+            'ENTRYPOINT ["docker-entrypoint.sh"]',
+            'CMD ["redis-server"]'
+          ]
+        });
+
+        console.log(`[DockerInitializer] Cleaning up temporary build container...`);
+        await tempContainer.remove({ force: true });
+        console.log(`[DockerInitializer] Custom Redis image with iptables created successfully.`);
       } else {
         throw pullErr;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torollo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torollo",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "chokidar": "^3.6.0",
         "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torollo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Interactive visual system design learning lab and container supervisor.",
   "keywords": [
     "system-design",


### PR DESCRIPTION
# Summary of Changes

## Description
This PR fixes a critical bug where real-time Security Group rules (like blocking or allowing traffic on the fly) were silently failing to apply to Redis nodes.

### The Bug
The base `redis:7-alpine` Docker image does not have `iptables` installed by default. Because Torollo's network engine injects firewall intents directly into containers using `docker exec iptables`, all dynamic firewall commands targeting Redis nodes were silently failing. This caused Redis nodes to accept all traffic (e.g., `redis-cli ping` returning `PONG` even after a rule was deleted).

### The Fix
* Updated `DockerInitializer.ts` to automatically build a custom Redis image (`derssa/backend-lab-redis:v1`) locally on first run.
* The builder pulls the base Alpine image, installs `iptables` and `iproute2`, and commits the new image.
* Updated `ContainerManager.ts` to use this new custom image for all Redis nodes moving forward.

### Verification
Real-time firewall enforcement is now fully functional on Redis nodes, accurately mimicking stateful firewall behavior (dropping new connections immediately when a rule is removed).

## Types of Changes

- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

## Manual Verification

### How I Tested This Locally
1. **Verified Build:** Started the backend and verified the logs correctly triggered the local build of `derssa/backend-lab-redis:v1` with `iptables` installed.
2. **Setup Canvas:** Spun up a new project with an Ubuntu node and a Redis node connected to the same subnet.
3. **Simulated State:** Added an `ALLOW TCP 6379` Inbound Security Group rule to the Redis node.
4. **Terminal Verification:** Opened the Ubuntu terminal modal and connected using `redis-cli -h redis-1 -p 6379`. Verified the connection was successful (`PONG`).
5. **Real-time Enforcement:** Kept the terminal connection open, went back to the Canvas UI, and deleted the ALLOW rule.
6. **Stateful Firewall Check:** Verified that the *existing* connection was correctly kept alive (`PONG`), but upon exiting `redis-cli` and attempting a *new* connection, the terminal successfully hung/timed out, proving the iptables rules were injected and enforced dynamically.


## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
