### PR TITLE
feat: add rename support for canvas nodes

### DIFF
--- a/backend/src/infrastructure/docker/ContainerManager.ts
+++ b/backend/src/infrastructure/docker/ContainerManager.ts
@@ -401,6 +401,58 @@ export class ContainerManager {
     };
   }
 
+  public static async renameContainer(
+    containerId: string,
+    projectId: string,
+    newName: string
+  ): Promise<void> {
+    const container = docker.getContainer(containerId);
+    const safeName = `${this.LAB_PREFIX}${projectId}-${newName.replace(/[^a-zA-Z0-9-_]/g, '')}`;
+
+    try {
+      const containerInfo = await container.inspect();
+      const currentName = containerInfo.Name.replace(/^\//, '');
+      if (currentName.toLowerCase() === safeName.toLowerCase()) {
+        return;
+      }
+    } catch (inspectErr) {
+      console.warn(`Failed to inspect container ${containerId} during rename check:`, inspectErr);
+    }
+
+    // Rename the Docker container itself
+    await container.rename({ name: safeName });
+
+    // Update the network alias so that inter-container DNS resolves to the new
+    // name. Docker does not support mutating aliases on a live connection, so we
+    // disconnect and reconnect — this is safe because rename is only allowed on
+    // stopped containers.
+    const network = docker.getNetwork('akal-lab-network');
+    try {
+      await network.disconnect({ Container: containerId });
+    } catch (err: any) {
+      const msg = err.message || '';
+      if (msg.includes('not connected to the network') || msg.includes('is not connected')) {
+        console.log(`[ContainerManager] Container ${containerId} is not connected to network akal-lab-network, skipping disconnect.`);
+      } else {
+        throw err;
+      }
+    }
+
+    try {
+      await network.connect({
+        Container: containerId,
+        EndpointConfig: { Aliases: [newName] }
+      });
+    } catch (err: any) {
+      const msg = err.message || '';
+      if (msg.includes('already connected') || msg.includes('already exists')) {
+        console.log(`[ContainerManager] Container ${containerId} already connected to network, ignoring error.`);
+      } else {
+        throw err;
+      }
+    }
+  }
+
   public static async executePsqlCommand(containerId: string, database: string, sqlQuery: string, extraArgs: string[] = []): Promise<string> {
     const container = docker.getContainer(containerId);
 

--- a/backend/src/infrastructure/docker/ContainerManager.ts
+++ b/backend/src/infrastructure/docker/ContainerManager.ts
@@ -408,6 +408,7 @@ export class ContainerManager {
   ): Promise<void> {
     const container = docker.getContainer(containerId);
     const safeName = `${this.LAB_PREFIX}${projectId}-${newName.replace(/[^a-zA-Z0-9-_]/g, '')}`;
+    const safeAlias = newName.trim().replace(/[^a-zA-Z0-9-_]/g, '');
 
     try {
       const containerInfo = await container.inspect();
@@ -441,14 +442,26 @@ export class ContainerManager {
     try {
       await network.connect({
         Container: containerId,
-        EndpointConfig: { Aliases: [newName] }
+        EndpointConfig: { Aliases: [safeAlias || safeName] }
       });
     } catch (err: any) {
       const msg = err.message || '';
       if (msg.includes('already connected') || msg.includes('already exists')) {
         console.log(`[ContainerManager] Container ${containerId} already connected to network, ignoring error.`);
       } else {
-        throw err;
+        console.warn(`[ContainerManager] Failed to reconnect container ${containerId} with alias ${safeAlias || safeName}; retrying without aliases.`, err);
+        try {
+          await network.connect({
+            Container: containerId
+          });
+        } catch (fallbackErr: any) {
+          const fallbackMsg = fallbackErr.message || '';
+          if (fallbackMsg.includes('already connected') || fallbackMsg.includes('already exists')) {
+            console.log(`[ContainerManager] Container ${containerId} already connected to network, ignoring fallback error.`);
+          } else {
+            throw fallbackErr;
+          }
+        }
       }
     }
   }

--- a/backend/src/modules/containers/controllers/containerController.test.ts
+++ b/backend/src/modules/containers/controllers/containerController.test.ts
@@ -18,6 +18,7 @@ app.post('/api/projects/:projectId/containers', ContainerController.create);
 app.post('/api/containers/:id/start', ContainerController.start);
 app.post('/api/containers/:id/stop', ContainerController.stop);
 app.delete('/api/containers/:id', ContainerController.delete);
+app.patch('/api/projects/:projectId/containers/:id/rename', ContainerController.rename);
 
 describe('ContainerController', () => {
   beforeEach(() => {
@@ -74,6 +75,53 @@ describe('ContainerController', () => {
 
       expect(res.status).toBe(400);
       expect(res.body).toEqual({ error: 'Name is required' });
+    });
+  });
+
+  describe('PATCH /api/projects/:projectId/containers/:id/rename', () => {
+    it('should rename a container successfully', async () => {
+      (ContainerService.renameContainer as jest.Mock).mockResolvedValue(undefined);
+
+      const res = await request(app)
+        .patch('/api/projects/test-project/containers/1/rename')
+        .send({ newName: 'new-name' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true });
+      expect(ContainerService.renameContainer).toHaveBeenCalledWith('1', 'test-project', 'new-name');
+    });
+
+    it('should return 400 if newName is missing', async () => {
+      const res = await request(app)
+        .patch('/api/projects/test-project/containers/1/rename')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'newName is required' });
+    });
+
+    it('should handle the same-name error gracefully by returning success', async () => {
+      (ContainerService.renameContainer as jest.Mock).mockRejectedValue(
+        new Error('Renaming a container with the same name as its current name')
+      );
+
+      const res = await request(app)
+        .patch('/api/projects/test-project/containers/1/rename')
+        .send({ newName: 'same-name' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true, message: 'Container already has the same name.' });
+    });
+
+    it('should return 500 on unexpected service errors', async () => {
+      (ContainerService.renameContainer as jest.Mock).mockRejectedValue(new Error('Unexpected error'));
+
+      const res = await request(app)
+        .patch('/api/projects/test-project/containers/1/rename')
+        .send({ newName: 'other-name' });
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: 'Unexpected error' });
     });
   });
 });

--- a/backend/src/modules/containers/controllers/containerController.test.ts
+++ b/backend/src/modules/containers/controllers/containerController.test.ts
@@ -4,11 +4,18 @@ import { ContainerController } from './containerController';
 import { ContainerService } from '../services/containerService';
 import { ProjectService } from '../../projects/services/projectService';
 import { NetworkService } from '../../network/services/networkService';
+import docker from '../../../infrastructure/docker/DockerClient';
 
 // Mock Services
 jest.mock('../services/containerService');
 jest.mock('../../projects/services/projectService');
 jest.mock('../../network/services/networkService');
+jest.mock('../../../infrastructure/docker/DockerClient', () => ({
+  __esModule: true,
+  default: {
+    getContainer: jest.fn()
+  }
+}));
 
 const app = express();
 app.use(express.json());
@@ -79,8 +86,22 @@ describe('ContainerController', () => {
   });
 
   describe('PATCH /api/projects/:projectId/containers/:id/rename', () => {
+    beforeEach(() => {
+      (docker.getContainer as jest.Mock).mockReturnValue({
+        inspect: jest.fn().mockResolvedValue({
+          Config: {
+            Labels: {
+              'akal.project.id': 'test-project'
+            }
+          }
+        })
+      });
+    });
+
     it('should rename a container successfully', async () => {
       (ContainerService.renameContainer as jest.Mock).mockResolvedValue(undefined);
+      (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue({ some: 'config' });
+      (NetworkService.applyPolicy as jest.Mock).mockResolvedValue(undefined);
 
       const res = await request(app)
         .patch('/api/projects/test-project/containers/1/rename')
@@ -89,6 +110,9 @@ describe('ContainerController', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true });
       expect(ContainerService.renameContainer).toHaveBeenCalledWith('1', 'test-project', 'new-name');
+      expect(ProjectService.getNetworkConfig).toHaveBeenCalledWith('test-project');
+      expect(NetworkService.clearPolicyHash).toHaveBeenCalledWith('test-project');
+      expect(NetworkService.applyPolicy).toHaveBeenCalledWith('test-project', { some: 'config' });
     });
 
     it('should return 400 if newName is missing', async () => {
@@ -98,6 +122,40 @@ describe('ContainerController', () => {
 
       expect(res.status).toBe(400);
       expect(res.body).toEqual({ error: 'newName is required' });
+    });
+
+    it('should return 400 if newName is blank', async () => {
+      const res = await request(app)
+        .patch('/api/projects/test-project/containers/1/rename')
+        .send({ newName: '   ' });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'newName is required' });
+    });
+
+    it('should resolve the project from the container labels before renaming', async () => {
+      (docker.getContainer as jest.Mock).mockReturnValue({
+        inspect: jest.fn().mockResolvedValue({
+          Config: {
+            Labels: {
+              'akal.project.id': 'resolved-project'
+            }
+          }
+        })
+      });
+      (ContainerService.renameContainer as jest.Mock).mockResolvedValue(undefined);
+      (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue({ some: 'config' });
+      (NetworkService.applyPolicy as jest.Mock).mockResolvedValue(undefined);
+
+      const res = await request(app)
+        .patch('/api/projects/wrong-project/containers/1/rename')
+        .send({ newName: '  new-name  ' });
+
+      expect(res.status).toBe(200);
+      expect(ContainerService.renameContainer).toHaveBeenCalledWith('1', 'resolved-project', 'new-name');
+      expect(ProjectService.getNetworkConfig).toHaveBeenCalledWith('resolved-project');
+      expect(NetworkService.clearPolicyHash).toHaveBeenCalledWith('resolved-project');
+      expect(NetworkService.applyPolicy).toHaveBeenCalledWith('resolved-project', { some: 'config' });
     });
 
     it('should handle the same-name error gracefully by returning success', async () => {

--- a/backend/src/modules/containers/controllers/containerController.ts
+++ b/backend/src/modules/containers/controllers/containerController.ts
@@ -221,4 +221,23 @@ export class ContainerController {
       res.status(500).json({ error: err.message });
     }
   }
+
+  public static async rename(req: Request, res: Response): Promise<void> {
+    try {
+      const { projectId, id } = req.params;
+      const { newName } = req.body;
+      if (!newName) {
+        res.status(400).json({ error: 'newName is required' });
+        return;
+      }
+      await ContainerService.renameContainer(id as string, projectId as string, newName);
+      res.json({ success: true });
+    } catch (err: any) {
+      if (err.message && err.message.includes('Renaming a container with the same name')) {
+        res.json({ success: true, message: 'Container already has the same name.' });
+        return;
+      }
+      res.status(500).json({ error: err.message });
+    }
+  }
 }

--- a/backend/src/modules/containers/controllers/containerController.ts
+++ b/backend/src/modules/containers/controllers/containerController.ts
@@ -226,11 +226,34 @@ export class ContainerController {
     try {
       const { projectId, id } = req.params;
       const { newName } = req.body;
-      if (!newName) {
+      const trimmedNewName = typeof newName === 'string' ? newName.trim() : '';
+      if (!trimmedNewName) {
         res.status(400).json({ error: 'newName is required' });
         return;
       }
-      await ContainerService.renameContainer(id as string, projectId as string, newName);
+
+      let resolvedProjectId: string | undefined;
+      try {
+        const inspectData = await docker.getContainer(id as string).inspect();
+        resolvedProjectId = inspectData.Config.Labels['akal.project.id'];
+      } catch (inspectErr) {
+        console.warn(`Failed to inspect container before renaming:`, inspectErr);
+      }
+
+      if (!resolvedProjectId) {
+        throw new Error('Unable to resolve project ID from container labels');
+      }
+
+      await ContainerService.renameContainer(id as string, resolvedProjectId, trimmedNewName);
+
+      const config = await ProjectService.getNetworkConfig(resolvedProjectId);
+      if (config) {
+        NetworkService.clearPolicyHash(resolvedProjectId);
+        NetworkService.applyPolicy(resolvedProjectId, config).catch(err => {
+          console.error(`Failed to re-apply network policy on rename:`, err);
+        });
+      }
+
       res.json({ success: true });
     } catch (err: any) {
       if (err.message && err.message.includes('Renaming a container with the same name')) {

--- a/backend/src/modules/containers/routes/containerRoutes.ts
+++ b/backend/src/modules/containers/routes/containerRoutes.ts
@@ -9,6 +9,7 @@ router.post('/', ContainerController.create);
 router.post('/:id/start', ContainerController.start);
 router.post('/:id/stop', ContainerController.stop);
 router.delete('/:id', ContainerController.delete);
+router.patch('/:id/rename', ContainerController.rename);
 router.get('/:id/postgres/explorer', ContainerController.postgresExplorer);
 router.post('/:id/postgres/query', ContainerController.postgresQuery);
 router.get('/:id/nosql/explorer', ContainerController.nosqlExplorer);

--- a/backend/src/modules/containers/services/containerService.ts
+++ b/backend/src/modules/containers/services/containerService.ts
@@ -36,6 +36,10 @@ export class ContainerService {
     await ContainerManager.deleteContainer(id);
   }
 
+  public static async renameContainer(containerId: string, projectId: string, newName: string): Promise<void> {
+    return ContainerManager.renameContainer(containerId, projectId, newName);
+  }
+
   public static async getPostgresExplorer(containerId: string) {
     // Get list of databases (filtering out templates)
     const dbsRaw = await ContainerManager.executePsqlCommand(

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -14,7 +14,7 @@ const server = http.createServer(app);
 
 app.use(cors({
   origin: '*',
-  methods: ['GET', 'POST', 'DELETE']
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
 }));
 app.use(express.json());
 

--- a/frontend/src/features/nodes/AsgNode/AsgNode.tsx
+++ b/frontend/src/features/nodes/AsgNode/AsgNode.tsx
@@ -26,6 +26,7 @@ interface AsgNodeProps {
     onStop: (id: string) => void;
     onStart: (id: string) => void;
     onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
   };
 }
 
@@ -50,6 +51,7 @@ export default function AsgNode({ data }: AsgNodeProps) {
       onStart={data.onStart}
       onStop={data.onStop}
       onDelete={data.onDelete}
+      onRename={data.onRename}
       primaryAction={{
         label: 'Inspect',
         icon: <Settings size={14} />,

--- a/frontend/src/features/nodes/LoadBalancerNode/LoadBalancerNode.tsx
+++ b/frontend/src/features/nodes/LoadBalancerNode/LoadBalancerNode.tsx
@@ -18,6 +18,7 @@ interface LoadBalancerNodeProps {
     onStop: (id: string) => void;
     onStart: (id: string) => void;
     onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
   };
 }
 
@@ -41,6 +42,7 @@ export default function LoadBalancerNode({ data }: LoadBalancerNodeProps) {
       onStart={data.onStart}
       onStop={data.onStop}
       onDelete={data.onDelete}
+      onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
         label: 'Configure',

--- a/frontend/src/features/nodes/NatNode/NatNode.tsx
+++ b/frontend/src/features/nodes/NatNode/NatNode.tsx
@@ -12,6 +12,7 @@ interface NatNodeProps {
     onStop: (id: string) => void;
     onStart: (id: string) => void;
     onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
   };
 }
 
@@ -36,6 +37,7 @@ export default function NatNode({ data }: NatNodeProps) {
       onStart={data.onStart}
       onStop={data.onStop}
       onDelete={data.onDelete}
+      onRename={data.onRename}
       primaryAction={{
         label: 'Info & Guide',
         icon: <ArrowRightLeft size={14} />,

--- a/frontend/src/features/nodes/NoSqlNode/NoSqlNode.tsx
+++ b/frontend/src/features/nodes/NoSqlNode/NoSqlNode.tsx
@@ -13,6 +13,7 @@ interface NoSqlNodeProps {
     onStop: (id: string) => void;
     onStart: (id: string) => void;
     onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
   };
 }
 
@@ -35,6 +36,7 @@ export default function NoSqlNode({ data }: NoSqlNodeProps) {
       onStart={data.onStart}
       onStop={data.onStop}
       onDelete={data.onDelete}
+      onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
         label: 'Inspect',

--- a/frontend/src/features/nodes/PostgresNode/PostgresNode.tsx
+++ b/frontend/src/features/nodes/PostgresNode/PostgresNode.tsx
@@ -13,6 +13,7 @@ interface PostgresNodeProps {
     onStop: (id: string) => void;
     onStart: (id: string) => void;
     onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
   };
 }
 
@@ -35,6 +36,7 @@ export default function PostgresNode({ data }: PostgresNodeProps) {
       onStart={data.onStart}
       onStop={data.onStop}
       onDelete={data.onDelete}
+      onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
         label: 'Inspect',

--- a/frontend/src/features/nodes/RedisNode/RedisNode.tsx
+++ b/frontend/src/features/nodes/RedisNode/RedisNode.tsx
@@ -13,6 +13,7 @@ interface RedisNodeProps {
     onStop: (id: string) => void;
     onStart: (id: string) => void;
     onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
   };
 }
 
@@ -35,6 +36,7 @@ export default function RedisNode({ data }: RedisNodeProps) {
       onStart={data.onStart}
       onStop={data.onStop}
       onDelete={data.onDelete}
+      onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
         label: 'Inspect',

--- a/frontend/src/features/nodes/ServiceNode.module.css
+++ b/frontend/src/features/nodes/ServiceNode.module.css
@@ -126,3 +126,71 @@
   border: 1px solid rgba(220, 38, 38, 0.3);
   width: 32px;
 }
+
+.renameBtn {
+  position: relative;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  margin-left: 2px;
+  color: #9CA3AF;
+  transition: color 0.15s ease;
+}
+
+.renameBtn:hover:not(.disabled) {
+  color: #3B82F6;
+}
+
+.renameBtn.disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+/* Tooltip container */
+.renameBtn::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 140%;
+  left: 50%;
+  transform: translateX(-50%) scale(0.95);
+  background-color: rgba(17, 24, 39, 0.95);
+  color: #FFFFFF;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s ease, transform 0.1s ease;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2);
+  z-index: 50;
+}
+
+/* Tooltip arrow */
+.renameBtn::before {
+  content: '';
+  position: absolute;
+  bottom: 110%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 4px;
+  border-style: solid;
+  border-color: rgba(17, 24, 39, 0.95) transparent transparent transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s ease;
+  z-index: 50;
+}
+
+/* Show tooltip on hover */
+.renameBtn:hover::after,
+.renameBtn:hover::before {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}

--- a/frontend/src/features/nodes/UbuntuNode/UbuntuNode.tsx
+++ b/frontend/src/features/nodes/UbuntuNode/UbuntuNode.tsx
@@ -15,6 +15,7 @@ interface UbuntuNodeProps {
     onStop: (id: string) => void;
     onStart: (id: string) => void;
     onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
   };
 }
 
@@ -37,6 +38,7 @@ export default function UbuntuNode({ data }: UbuntuNodeProps) {
       onStart={data.onStart}
       onStop={data.onStop}
       onDelete={data.onDelete}
+      onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
         label: 'Terminal',

--- a/frontend/src/features/nodes/components/BaseNode.tsx
+++ b/frontend/src/features/nodes/components/BaseNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position } from '@xyflow/react';
-import { Play, Square, Trash2, Shield } from 'lucide-react';
+import { Play, Square, Trash2, Shield, Pencil } from 'lucide-react';
 import React from 'react';
 import styles from '../ServiceNode.module.css';
 
@@ -15,6 +15,7 @@ interface BaseNodeProps {
   hideHandles?: boolean;
   
   // Handlers
+  onRename?: (id: string, currentName: string) => void;
   onStart: (id: string) => void;
   onStop: (id: string) => void;
   onDelete: (id: string) => void;
@@ -41,6 +42,7 @@ export default function BaseNode({
   customBorder,
   customTitleColor,
   hideHandles,
+  onRename,
   onStart,
   onStop,
   onDelete,
@@ -67,7 +69,22 @@ export default function BaseNode({
         <div className={styles.titleContainer}>
           {icon}
           <span className={styles.title} style={{ color: titleColor }}>{name}</span>
-          
+
+          {onRename && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!isRunning) {
+                  onRename(id, name);
+                }
+              }}
+              className={`${styles.renameBtn} ${isRunning ? styles.disabled : ''}`}
+              data-tooltip={isRunning ? "Stop the service to rename this node" : "Rename node"}
+            >
+              <Pencil size={12} />
+            </button>
+          )}
+
           {onSecurityGroupOpen && (
             <button
               onClick={(e) => {

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -132,6 +132,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   const [inspectingSubnet, setInspectingSubnet] = useState<{ id: string; name: string } | null>(null);
   const [inspectingSecurityGroup, setInspectingSecurityGroup] = useState<{ id: string; name: string; type: string } | null>(null);
 
+  // Rename modal state
+  const [renamingNode, setRenamingNode] = useState<{ id: string; currentName: string } | null>(null);
+
   // Drag and drop tracking
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
   const [dropState, setDropState] = useState<{ position: { x: number; y: number }; type: string } | null>(null);
@@ -769,6 +772,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
             },
             onSecurityGroupOpen: (id: string, name: string) => {
               setInspectingSecurityGroup({ id, name, type: nodeType });
+            },
+            onRename: (id: string, currentName: string) => {
+              setRenamingNode({ id, currentName });
             }
           },
         };
@@ -1186,6 +1192,55 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     pendingSubnetIdRef.current = null;
   };
 
+  const handleRenameNode = async (newName: string) => {
+    if (!renamingNode) return;
+    const { id, currentName } = renamingNode;
+
+    // Guard against renaming to the same name
+    if (newName.trim().toLowerCase() === currentName.toLowerCase()) {
+      showNotification({ type: 'info', message: `The node is already named "${currentName}".` });
+      setRenamingNode(null);
+      return;
+    }
+
+    // Guard against duplicate names (same check used at creation time)
+    const exists = containers.some(
+      c => c.name.toLowerCase() === newName.toLowerCase() && c.id !== id
+    );
+    if (exists) {
+      showNotification({ type: 'error', message: `A node named "${newName}" already exists in this project.` });
+      return;
+    }
+
+    try {
+      const res = await fetch(`${API_BASE}/api/projects/${projectId}/containers/${id}/rename`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ newName }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        showNotification({ type: 'error', message: data.error || 'Rename failed.' });
+        return;
+      }
+    } catch {
+      showNotification({ type: 'error', message: 'Rename failed: could not reach the server.' });
+      return;
+    }
+
+    // Migrate the position key from the old name to the new name so the node
+    // does not lose its canvas position after being renamed.
+    if (positionsRef.current[currentName]) {
+      positionsRef.current[newName] = positionsRef.current[currentName];
+      delete positionsRef.current[currentName];
+      localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
+    }
+
+    setRenamingNode(null);
+    showToast(`Node renamed to "${newName}"`);
+    await fetchContainers();
+  };
+
   const handleDeleteConfirmed = async () => {
     if (!deleteTarget) return;
     const id = deleteTarget;
@@ -1486,6 +1541,20 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           variant="danger"
           onConfirm={handleDeleteConfirmed}
           onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+
+      {renamingNode && (
+        <InputModal
+          title="Rename Node"
+          label="Enter a new name for this node."
+          placeholder="e.g. api-gateway"
+          maxLength={20}
+          restrictPattern={/[^a-zA-Z0-9-]/g}
+          defaultValue={renamingNode.currentName}
+          submitText="Rename"
+          onSubmit={handleRenameNode}
+          onCancel={() => setRenamingNode(null)}
         />
       )}
 

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -1195,20 +1195,21 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   const handleRenameNode = async (newName: string) => {
     if (!renamingNode) return;
     const { id, currentName } = renamingNode;
+    const trimmedNewName = newName.trim();
 
     // Guard against renaming to the same name
-    if (newName.trim().toLowerCase() === currentName.toLowerCase()) {
-      showNotification({ type: 'info', message: `The node is already named "${currentName}".` });
+    if (trimmedNewName.toLowerCase() === currentName.toLowerCase()) {
+      showNotification({ type: 'warning', message: `The node is already named "${currentName}".` });
       setRenamingNode(null);
       return;
     }
 
     // Guard against duplicate names (same check used at creation time)
     const exists = containers.some(
-      c => c.name.toLowerCase() === newName.toLowerCase() && c.id !== id
+      c => c.name.toLowerCase() === trimmedNewName.toLowerCase() && c.id !== id
     );
     if (exists) {
-      showNotification({ type: 'error', message: `A node named "${newName}" already exists in this project.` });
+      showNotification({ type: 'error', message: `A node named "${trimmedNewName}" already exists in this project.` });
       return;
     }
 
@@ -1216,11 +1217,19 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       const res = await fetch(`${API_BASE}/api/projects/${projectId}/containers/${id}/rename`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ newName }),
+        body: JSON.stringify({ newName: trimmedNewName }),
       });
       if (!res.ok) {
-        const data = await res.json();
-        showNotification({ type: 'error', message: data.error || 'Rename failed.' });
+        let message = 'Rename failed.';
+        try {
+          const data = await res.json();
+          if (typeof data?.error === 'string' && data.error.trim()) {
+            message = data.error;
+          }
+        } catch {
+          // Keep the generic message when the server returns a non-JSON body.
+        }
+        showNotification({ type: 'error', message });
         return;
       }
     } catch {
@@ -1231,13 +1240,13 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     // Migrate the position key from the old name to the new name so the node
     // does not lose its canvas position after being renamed.
     if (positionsRef.current[currentName]) {
-      positionsRef.current[newName] = positionsRef.current[currentName];
+      positionsRef.current[trimmedNewName] = positionsRef.current[currentName];
       delete positionsRef.current[currentName];
       localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
     }
 
     setRenamingNode(null);
-    showToast(`Node renamed to "${newName}"`);
+    showToast(`Node renamed to "${trimmedNewName}"`);
     await fetchContainers();
   };
 


### PR DESCRIPTION
## Description

This PR implements the ability to rename draggable canvas nodes directly from the canvas interface. (Closes #40 )

### Why is this needed?
Previously, a node's name was frozen upon creation. If a user wanted to change a node's name, they were forced to delete the container and recreate it, losing all connected configurations (subnets, IP allocations, security group rules, etc.). Renaming nodes natively resolves this limitation.

---

## Key Features

1. **Native Docker Rename**: Calls Docker's native `container.rename` API and safely rebinds container aliases inside `akal-lab-network` so inter-container internal DNS resolution updates correctly.
2. **Interactive UI**: Added an always-visible Pencil edit icon next to node titles in the unified `BaseNode` layout.
3. **UX Optimization & Tooltips**:
   - Running nodes cannot be renamed. The pencil icon displays as disabled (`cursor: not-allowed` with 0.4 opacity) and renders a custom CSS-only tooltip: *"Stop the service to rename this node"*.
   - Stopped nodes allow renaming instantly, pre-filling the rename input modal with the current name.
4. **Graceful Error Handling**:
   - Safe-guards against same-name updates on both frontend and backend to prevent unnecessary API overhead or raw Docker engine errors.
   - Network attach/detach processes on the backend are fully wrapped to ignore benign status conflicts (e.g. if the container is already disconnected).
5. **Layout Persistence**: Synchronizes the node positions in `localStorage` by migrating the layout dictionary keys to matching updated names on rename.

---

## Changed Files

### Backend
- `backend/src/infrastructure/docker/ContainerManager.ts` (Native rename logic + network alias re-linking)
- `backend/src/modules/containers/services/containerService.ts` (Routed rename service call)
- `backend/src/modules/containers/controllers/containerController.ts` (Handled PATCH routing + warning flags)
- `backend/src/modules/containers/routes/containerRoutes.ts` (Registered `PATCH /:id/rename` route)
- `backend/src/server.ts` (CORS updates to support PATCH methods)

### Backend Tests
- `backend/src/modules/containers/controllers/containerController.test.ts` (Unit tests for rename endpoints)

### Frontend
- `frontend/src/features/nodes/components/BaseNode.tsx` (Pencil button render, disabled styles, and tooltips wrapper)
- `frontend/src/features/nodes/ServiceNode.module.css` (Tooltip markup selectors and layout spacing styles)
- `frontend/src/pages/CanvasPage/CanvasPage.tsx` (Coordinates key migration, modal state, same-name guards)
- Wrapper Nodes (All 7 wrapper node templates now forward the `onRename` prop to `BaseNode`)

---

## Pull Request Checklist

- [x] `type` string is lowercase and identical across palette, `nodeTypes`, API, labels, and unions.
- [x] Backend: image tag, `ensure<X>Image()`, image selection branch, port mapping, `ContainerInfo` union.
- [x] Frontend: `<X>Node.tsx` (via `BaseNode`), `nodeTypes`, `NodeLibrary`, `ContainerData` union, drop placeholder.
- [x] Inspector modal & backend explorer wired (or intentionally omitted).
- [x] Both frontend and backend build; tests pass.
- [x] Manually verified the full lifecycle.
- [x] Conventional Commit message.