### PR TITLE
fix(ci): store CLA signatures on a dedicated branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           path-to-signatures: '.github/signatures/cla.json'
           path-to-document: 'https://github.com/Derssa/Torollo/blob/main/CLA.md'
-          branch: 'main'
+          branch: 'cla-signatures'
           allowlist: 'Derssa,OthmaneZ05,dependabot[bot],*[bot]'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,8 @@ node ./bin/cli.js start
 
 ## Contributor License Agreement (CLA)
 
+By submitting a pull request, you agree to the terms of our [CLA](CLA.md).
+
 Before we can merge your first pull request, you must sign our [Contributor License Agreement](CLA.md). It protects both you and the project, and does not change your rights to use your own contributions for any other purpose.
 
 Signing is fully automated: when you open a pull request, the CLA Assistant bot will comment on it with instructions. To sign, simply reply to the bot with:


### PR DESCRIPTION
## Summary
- The CLA Assistant workflow was writing signatures directly to `main`, which is protected (blocks direct pushes, requires `build-and-test`), so the CLA check always failed.
- Point it at a dedicated `cla-signatures` branch instead.
- Add a short note to CONTRIBUTING.md that submitting a PR implies agreement to the CLA.

## Test plan
- [ ] Merge and confirm the CLA check goes green on open PRs (e.g. #46) after a recheck.