### PR TITLE
Othmane/frontend test safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,32 @@ jobs:
 
     - name: Run Tests
       run: npm test
+
+  frontend-build-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Run Linter
+      run: npm run lint
+
+    - name: Compile Code
+      run: npm run build
+
+    - name: Run Tests
+      run: npm test

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -28,10 +31,81 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "jsdom": "^27.4.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.2",
-        "vite": "^8.0.12"
+        "vite": "^8.0.12",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -282,6 +356,146 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -442,6 +656,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -859,6 +1091,88 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -868,6 +1182,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-color": {
@@ -918,6 +1250,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1239,6 +1578,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -1319,6 +1771,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1334,6 +1796,49 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -1357,6 +1862,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1427,6 +1942,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
@@ -1453,6 +1978,53 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -1567,6 +2139,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1584,12 +2180,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1600,6 +2213,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.372",
@@ -1629,6 +2249,26 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1828,6 +2468,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1836,6 +2486,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1996,6 +2656,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -2003,6 +2676,34 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/i18next": {
@@ -2053,6 +2754,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2076,6 +2787,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2089,6 +2807,46 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2457,6 +3215,43 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2515,6 +3310,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2565,6 +3374,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2584,6 +3406,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2644,6 +3473,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2702,6 +3546,37 @@
         }
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -2734,6 +3609,19 @@
         "@rolldown/binding-wasm32-wasi": "1.0.3",
         "@rolldown/binding-win32-arm64-msvc": "1.0.3",
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -2775,6 +3663,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -2813,6 +3708,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2828,6 +3774,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.7.tgz",
+      "integrity": "sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.7"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
+      "integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3037,6 +4039,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -3044,6 +4136,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -3060,6 +4199,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -3092,6 +4248,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -22,6 +24,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -30,8 +35,10 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "jsdom": "^27.4.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
-    "vite": "^8.0.12"
+    "vite": "^8.0.12",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/features/nodes/NoSqlNode/NoSqlModal.test.tsx
+++ b/frontend/src/features/nodes/NoSqlNode/NoSqlModal.test.tsx
@@ -1,0 +1,181 @@
+import '../../../i18n';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import NoSqlModal from './NoSqlModal';
+import { mockFetchResponses } from '../../../test-utils/mockFetchSequence';
+
+async function renderModal(onClose = vi.fn()) {
+  const view = render(<NoSqlModal containerId="c1" nodeName="db-1" projectId="p1" onClose={onClose} />);
+  // Flush the mount effect's explorer fetch so it never resolves after the test returns.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return view;
+}
+
+describe('NoSqlModal', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('renders all 5 tabs and defaults to the details tab', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    expect(screen.getByRole('button', { name: /Details & Config/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Simulation$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /NoSQL Explorer/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mongo Shell/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mongo Cheat Sheet/i })).toBeInTheDocument();
+  });
+
+  it('switches tab content when a tab button is clicked', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Mongo Shell/i }));
+
+    expect(screen.getByPlaceholderText(/db.users.find/i)).toBeInTheDocument();
+  });
+
+  it('renders the simulation tab without throwing (smoke test only)', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    expect(() => fireEvent.click(screen.getByRole('button', { name: /^Simulation$/i }))).not.toThrow();
+    expect(screen.getByText(/Routed/i)).toBeInTheDocument();
+  });
+
+  it('fetches and renders the database/collection tree in the explorer tab, expanding to show columns', async () => {
+    mockFetchResponses([
+      { ok: true, json: [{ database: 'app_db', tables: [{ name: 'users', columns: [{ name: '_id', type: 'ObjectId' }] }] }] },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /NoSQL Explorer/i }));
+    await waitFor(() => expect(screen.getByText('app_db')).toBeInTheDocument());
+
+    // Database node starts collapsed by default (only 'test' is pre-expanded).
+    expect(screen.queryByText('users (Collection)')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('app_db'));
+    expect(screen.getByText('users (Collection)')).toBeInTheDocument();
+    expect(screen.queryByText('_id')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('users (Collection)'));
+    expect(screen.getByText('_id')).toBeInTheDocument();
+    expect(screen.getByText('ObjectId')).toBeInTheDocument();
+  });
+
+  it('shows a non-startup explorer error with no retry button (unlike Postgres/Redis)', async () => {
+    mockFetchResponses([{ ok: false, json: { error: 'connection refused' } }]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /NoSQL Explorer/i }));
+
+    await waitFor(() => expect(screen.getByText('connection refused')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /Retry Schema Scan/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the initializing state and auto-retries once after 2.5s on a "starting up" error', async () => {
+    vi.useFakeTimers();
+    const fetchMock = mockFetchResponses([
+      { ok: false, json: { error: 'Database is starting up' } },
+      { ok: true, json: [] },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /NoSQL Explorer/i }));
+    expect(screen.getByText(/initializing/i)).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('executes a query and renders the result, re-fetching explorer data', async () => {
+    const fetchMock = mockFetchResponses([
+      { ok: true, json: [] }, // mount explorer fetch
+      { ok: true, json: { result: '{ acknowledged: true }' } }, // query execute
+      { ok: true, json: [] }, // post-write re-fetch
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Mongo Shell/i }));
+    fireEvent.change(screen.getByPlaceholderText(/db.users.find/i), { target: { value: "db.users.find({})" } });
+    fireEvent.click(screen.getByRole('button', { name: /Evaluate Query/i }));
+
+    await waitFor(() => expect(screen.getByText('{ acknowledged: true }')).toBeInTheDocument());
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ query: 'db.users.find({})' });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+  });
+
+  it('renders an ERROR-prefixed message when the query fails', async () => {
+    mockFetchResponses([
+      { ok: true, json: [] },
+      { ok: false, json: { error: 'unknown operator' } },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Mongo Shell/i }));
+    fireEvent.change(screen.getByPlaceholderText(/db.users.find/i), { target: { value: 'db.users.bad()' } });
+    fireEvent.click(screen.getByRole('button', { name: /Evaluate Query/i }));
+
+    await waitFor(() => expect(screen.getByText('ERROR: unknown operator')).toBeInTheDocument());
+  });
+
+  it('clicking "View Documents" on a collection switches to the shell tab, runs a find query, and renders the result', async () => {
+    const fetchMock = mockFetchResponses([
+      { ok: true, json: [{ database: 'app_db', tables: [{ name: 'users', columns: [] }] }] }, // mount explorer fetch
+      { ok: true, json: { result: '[{ "_id": 1 }]' } }, // triggered query
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /NoSQL Explorer/i }));
+    await waitFor(() => expect(screen.getByText('app_db')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('app_db'));
+    fireEvent.click(screen.getByRole('button', { name: /View Documents/i }));
+
+    expect(screen.getByPlaceholderText(/db.users.find/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('[{ "_id": 1 }]')).toBeInTheDocument());
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      query: "JSON.stringify(db.getSiblingDB('app_db').getCollection('users').find().limit(10).toArray(), null, 2)",
+    });
+  });
+
+  it('filters the cheat sheet by search query and copies an entry to the clipboard', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Mongo Cheat Sheet/i }));
+    expect(screen.getByText('Insert Document')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/Search Mongo commands/i), { target: { value: 'Insert Document' } });
+    expect(screen.getByText('Insert Document')).toBeInTheDocument();
+
+    const card = screen.getByText('Insert Document').closest('div')!.parentElement!;
+    const copyBtn = within(card as HTMLElement).getAllByRole('button')[0];
+    fireEvent.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith('db.users.insertOne({ name: "Alice", age: 30, roles: ["admin"] })');
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    const onClose = vi.fn();
+    const { container } = await renderModal(onClose);
+
+    // The close button has no accessible name, only the lucide X icon.
+    const closeBtn = [...container.querySelectorAll('button')].find(b => b.querySelector('svg.lucide-x'))!;
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/nodes/PostgresNode/PostgresModal.test.tsx
+++ b/frontend/src/features/nodes/PostgresNode/PostgresModal.test.tsx
@@ -1,0 +1,183 @@
+import '../../../i18n';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import PostgresModal from './PostgresModal';
+import { mockFetchResponses } from '../../../test-utils/mockFetchSequence';
+
+async function renderModal(onClose = vi.fn()) {
+  const view = render(<PostgresModal containerId="c1" nodeName="db-1" projectId="p1" onClose={onClose} />);
+  // Flush the mount effect's explorer fetch so it never resolves after the test returns.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return view;
+}
+
+describe('PostgresModal', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('renders all 5 tabs and defaults to the details tab', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    expect(screen.getByRole('button', { name: /Details & Config/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Simulation/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Database Explorer/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /SQL Shell/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /SQL Cheat Sheet/i })).toBeInTheDocument();
+  });
+
+  it('switches tab content when a tab button is clicked', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /SQL Shell/i }));
+
+    expect(screen.getByText('Target Database:')).toBeInTheDocument();
+  });
+
+  it('renders the simulation tab without throwing (smoke test only)', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    expect(() => fireEvent.click(screen.getByRole('button', { name: /^Simulation$/i }))).not.toThrow();
+    expect(screen.getByText(/reads/i)).toBeInTheDocument();
+    expect(screen.getByText(/writes/i)).toBeInTheDocument();
+  });
+
+  it('fetches and renders the database/table tree in the explorer tab, expanding to show columns', async () => {
+    mockFetchResponses([
+      { ok: true, json: [{ database: 'app_db', tables: [{ name: 'users', columns: [{ name: 'id', type: 'integer' }] }] }] },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Database Explorer/i }));
+    await waitFor(() => expect(screen.getByText('app_db')).toBeInTheDocument());
+
+    // Database node starts collapsed by default (only 'postgres' is pre-expanded).
+    expect(screen.queryByText('users')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('app_db'));
+    expect(screen.getByText('users')).toBeInTheDocument();
+    expect(screen.queryByText('id')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('users'));
+    expect(screen.getByText('id')).toBeInTheDocument();
+    expect(screen.getByText('integer')).toBeInTheDocument();
+  });
+
+  it('shows an error message with a retry button on a non-startup explorer error', async () => {
+    const fetchMock = mockFetchResponses([{ ok: false, json: { error: 'connection refused' } }]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Database Explorer/i }));
+
+    await waitFor(() => expect(screen.getByText('connection refused')).toBeInTheDocument());
+    fetchMock.mockImplementationOnce(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response));
+    fireEvent.click(screen.getByRole('button', { name: /Retry Schema Scan/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows the initializing state and auto-retries once after 2.5s on a "starting up" error', async () => {
+    vi.useFakeTimers();
+    const fetchMock = mockFetchResponses([
+      { ok: false, json: { error: 'Database is starting up' } },
+      { ok: true, json: [] },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Database Explorer/i }));
+    expect(screen.getByText(/initializing/i)).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('populates the target database select from explorer data and executes a query', async () => {
+    const fetchMock = mockFetchResponses([
+      { ok: true, json: [{ database: 'app_db', tables: [] }] }, // mount explorer fetch
+      { ok: true, json: { result: 'SELECT 1' } }, // query execute
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /SQL Shell/i }));
+    expect(within(screen.getByRole('combobox')).getByRole('option', { name: 'app_db' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/Write your SQL statements/i), { target: { value: 'SELECT 1;' } });
+    fireEvent.click(screen.getByRole('button', { name: /Execute Query/i }));
+
+    await waitFor(() => expect(screen.getByText('SELECT 1')).toBeInTheDocument());
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ query: 'SELECT 1;', database: 'postgres' });
+  });
+
+  it('renders an ERROR-prefixed message when the query fails', async () => {
+    mockFetchResponses([
+      { ok: true, json: [] },
+      { ok: false, json: { error: 'syntax error' } },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /SQL Shell/i }));
+    fireEvent.change(screen.getByPlaceholderText(/Write your SQL statements/i), { target: { value: 'BAD SQL' } });
+    fireEvent.click(screen.getByRole('button', { name: /Execute Query/i }));
+
+    await waitFor(() => expect(screen.getByText('ERROR: syntax error')).toBeInTheDocument());
+  });
+
+  it('clicking "View Data" on a table switches to the shell tab, runs a SELECT, and renders the result', async () => {
+    const fetchMock = mockFetchResponses([
+      { ok: true, json: [{ database: 'app_db', tables: [{ name: 'users', columns: [] }] }] }, // mount explorer fetch
+      { ok: true, json: { result: '1 row(s)' } }, // triggered query
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Database Explorer/i }));
+    await waitFor(() => expect(screen.getByText('app_db')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('app_db'));
+    fireEvent.click(screen.getByRole('button', { name: /View Data/i }));
+
+    expect(screen.getByText('Target Database:')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('1 row(s)')).toBeInTheDocument());
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ query: 'SELECT * FROM users LIMIT 100;', database: 'app_db' });
+  });
+
+  it('filters the cheat sheet by search query and copies an entry to the clipboard', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /SQL Cheat Sheet/i }));
+    expect(screen.getByText('Connect to Database')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/Search SQL commands/i), { target: { value: 'Connect to Database' } });
+    expect(screen.getByText('Connect to Database')).toBeInTheDocument();
+
+    const card = screen.getByText('Connect to Database').closest('div')!.parentElement!;
+    const copyBtn = within(card as HTMLElement).getAllByRole('button')[0];
+    fireEvent.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith('\\c database_name');
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    const onClose = vi.fn();
+    const { container } = await renderModal(onClose);
+
+    // The close button has no accessible name, only the lucide X icon.
+    const closeBtn = [...container.querySelectorAll('button')].find(b => b.querySelector('svg.lucide-x'))!;
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/nodes/RedisNode/RedisModal.test.tsx
+++ b/frontend/src/features/nodes/RedisNode/RedisModal.test.tsx
@@ -1,0 +1,239 @@
+import '../../../i18n';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import RedisModal from './RedisModal';
+import { mockFetchResponses } from '../../../test-utils/mockFetchSequence';
+
+async function renderModal(onClose = vi.fn()) {
+  const view = render(<RedisModal containerId="c1" nodeName="cache-1" projectId="p1" onClose={onClose} />);
+  // Flush the mount effect's explorer fetch so it never resolves after the test returns.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return view;
+}
+
+describe('RedisModal', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('renders all 4 tabs and defaults to the details tab', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    expect(screen.getByRole('button', { name: /Details/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Key Explorer/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Redis Shell/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Redis Cheat Sheet/i })).toBeInTheDocument();
+    expect(screen.getByText('Cache Node Details')).toBeInTheDocument();
+  });
+
+  it('switches tab content when a tab button is clicked', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Redis Shell/i }));
+
+    expect(screen.getByText('redis-cli')).toBeInTheDocument();
+    expect(screen.queryByText('Cache Node Details')).not.toBeInTheDocument();
+  });
+
+  it('fetches and renders keys in the explorer tab on success', async () => {
+    mockFetchResponses([{ ok: true, json: [{ key: 'user:1', type: 'hash' }] }]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Key Explorer/i }));
+
+    await waitFor(() => expect(screen.getByText('user:1')).toBeInTheDocument());
+    expect(screen.getByText('hash')).toBeInTheDocument();
+  });
+
+  it('shows an error message with a retry button on a non-startup explorer error', async () => {
+    const fetchMock = mockFetchResponses([{ ok: false, json: { error: 'connection refused' } }]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Key Explorer/i }));
+
+    await waitFor(() => expect(screen.getByText('connection refused')).toBeInTheDocument());
+    const retryBtn = screen.getByRole('button', { name: /Retry Key Scan/i });
+
+    fetchMock.mockImplementationOnce(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response));
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows the initializing state and auto-retries once after 2.5s on a "starting up" error', async () => {
+    // Fake timers are required to deterministically control the 2.5s auto-retry
+    // without RTL's waitFor (which polls via real setTimeout and would hang here).
+    vi.useFakeTimers();
+    const fetchMock = mockFetchResponses([
+      { ok: false, json: { error: 'Redis is starting up' } },
+      { ok: true, json: [] },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Key Explorer/i }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByText(/initializing/i)).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not stack overlapping auto-retry timers when "starting up" fires repeatedly', async () => {
+    // Two consecutive "starting up" responses: the second must clear/replace the first
+    // timer (retryTimerRef guard) rather than scheduling a second overlapping retry.
+    vi.useFakeTimers();
+    const fetchMock = mockFetchResponses([
+      { ok: false, json: { error: 'Redis is starting up' } },
+      { ok: false, json: { error: 'Redis is starting up' } },
+      { ok: true, json: [] },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Key Explorer/i }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Manually retry before the 2.5s auto-retry fires — this re-enters the "starting up"
+    // branch and must clear the first pending timer rather than adding a second one.
+    // The "starting up" view shows no dedicated retry button, only the refresh icon
+    // button next to the section title.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    const refreshBtn = screen.getAllByRole('button').find(b => b.querySelector('svg.lucide-refresh-cw'))!;
+    fireEvent.click(refreshBtn);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Only one retry should fire at 2.5s after the second "starting up" response, not two.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // Confirm no leftover timer fires a 4th call later.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('executes a shell command and renders the result', async () => {
+    const fetchMock = mockFetchResponses([
+      { ok: true, json: [] }, // mount explorer fetch
+      { ok: true, json: { result: 'OK' } }, // query execute
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Redis Shell/i }));
+    const textarea = screen.getByPlaceholderText(/redis-cli command/i);
+    fireEvent.change(textarea, { target: { value: 'SET foo bar' } });
+    fireEvent.click(screen.getByRole('button', { name: /Run Command/i }));
+
+    await waitFor(() => expect(screen.getByText('OK')).toBeInTheDocument());
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ query: 'SET foo bar' });
+  });
+
+  it('renders an ERROR-prefixed message when the shell command fails', async () => {
+    mockFetchResponses([
+      { ok: true, json: [] },
+      { ok: false, json: { error: 'unknown command' } },
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Redis Shell/i }));
+    fireEvent.change(screen.getByPlaceholderText(/redis-cli command/i), { target: { value: 'BADCMD' } });
+    fireEvent.click(screen.getByRole('button', { name: /Run Command/i }));
+
+    await waitFor(() => expect(screen.getByText('ERROR: unknown command')).toBeInTheDocument());
+  });
+
+  it('re-fetches explorer data after a successful shell command', async () => {
+    const fetchMock = mockFetchResponses([
+      { ok: true, json: [] }, // mount explorer fetch
+      { ok: true, json: { result: 'OK' } }, // query execute
+      { ok: true, json: [{ key: 'foo', type: 'string' }] }, // post-write re-fetch
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Redis Shell/i }));
+    fireEvent.change(screen.getByPlaceholderText(/redis-cli command/i), { target: { value: 'SET foo bar' } });
+    fireEvent.click(screen.getByRole('button', { name: /Run Command/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+  });
+
+  it.each([
+    ['list', 'LRANGE mylist 0 -1'],
+    ['hash', 'HGETALL myhash'],
+    ['set', 'SMEMBERS myset'],
+    ['zset', 'ZRANGE myzset 0 -1 WITHSCORES'],
+    ['stream', 'XRANGE mystream - +'],
+    ['string', 'GET mystring'],
+  ])('handleViewValue for type "%s" switches to shell with command "%s" and runs it', async (type, expectedCommand) => {
+    const key = { string: 'mystring', list: 'mylist', hash: 'myhash', set: 'myset', zset: 'myzset', stream: 'mystream' }[type];
+    const fetchMock = mockFetchResponses([
+      { ok: true, json: [{ key, type }] }, // mount explorer fetch
+      { ok: true, json: { result: 'value' } }, // triggered query
+    ]);
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Key Explorer/i }));
+    await waitFor(() => expect(screen.getByText(key!)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /View Value/i }));
+
+    expect(screen.getByText('redis-cli')).toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ query: expectedCommand });
+  });
+
+  it('filters the cheat sheet by search query and copies an entry to the clipboard', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    await renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /Redis Cheat Sheet/i }));
+    expect(screen.getByText('Set Key')).toBeInTheDocument();
+    expect(screen.getByText('Get Key')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/Search Redis commands/i), { target: { value: 'Set Key' } });
+    expect(screen.getByText('Set Key')).toBeInTheDocument();
+    expect(screen.queryByText('Get Key')).not.toBeInTheDocument();
+
+    const card = screen.getByText('Set Key').closest('div')!.parentElement!;
+    const copyBtn = within(card as HTMLElement).getAllByRole('button')[0];
+    fireEvent.click(copyBtn);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('SET user:1:name "Alice Smith"'));
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    const onClose = vi.fn();
+    const { container } = await renderModal(onClose);
+
+    // The close button has no accessible name, only the lucide X icon.
+    const closeBtn = [...container.querySelectorAll('button')].find(b => b.querySelector('svg.lucide-x'))!;
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/terminal/hooks/useCommandSearch.test.ts
+++ b/frontend/src/features/terminal/hooks/useCommandSearch.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCommandSearch } from './useCommandSearch';
+import commandsData from '../data/linuxCommands.json';
+
+describe('useCommandSearch', () => {
+  it('returns the full command list when no query or category is set', () => {
+    const { result } = renderHook(() => useCommandSearch());
+    expect(result.current.filteredCommands).toHaveLength(commandsData.length);
+  });
+
+  it('exposes deduplicated categories derived from the raw command data', () => {
+    const { result } = renderHook(() => useCommandSearch());
+    const expected = Array.from(new Set(commandsData.map(c => c.category)));
+    expect(result.current.categories.sort()).toEqual(expected.sort());
+  });
+
+  it('filters to only the selected category', () => {
+    const { result } = renderHook(() => useCommandSearch());
+    const [category] = result.current.categories;
+
+    act(() => {
+      result.current.setSelectedCategory(category);
+    });
+
+    expect(result.current.filteredCommands.length).toBeGreaterThan(0);
+    expect(result.current.filteredCommands.every(c => c.category === category)).toBe(true);
+  });
+
+  it('matches a query against the command name', () => {
+    const { result } = renderHook(() => useCommandSearch());
+
+    act(() => {
+      result.current.setSearchQuery('ls');
+    });
+
+    expect(result.current.filteredCommands.some(c => c.name === 'ls')).toBe(true);
+  });
+
+  it('matches a query against keywords even when name/description do not contain it', () => {
+    const { result } = renderHook(() => useCommandSearch());
+    // Find a keyword-only match: present in the command's keywords but absent from its name/description.
+    let keywordOnlyMatch: { name: string; keyword: string } | undefined;
+    for (const cmd of commandsData) {
+      const nameLower = cmd.name.toLowerCase();
+      const descLower = cmd.description.toLowerCase();
+      const keyword = cmd.keywords.find(k => {
+        const kLower = k.toLowerCase();
+        return !nameLower.includes(kLower) && !descLower.includes(kLower);
+      });
+      if (keyword) {
+        keywordOnlyMatch = { name: cmd.name, keyword };
+        break;
+      }
+    }
+    expect(keywordOnlyMatch).toBeDefined();
+
+    act(() => {
+      result.current.setSearchQuery(keywordOnlyMatch!.keyword);
+    });
+
+    expect(result.current.filteredCommands.some(c => c.name === keywordOnlyMatch!.name)).toBe(true);
+  });
+
+  it('requires every space-separated term to match (AND semantics)', () => {
+    const { result } = renderHook(() => useCommandSearch());
+
+    act(() => {
+      result.current.setSearchQuery('zzznomatch anothernomatch');
+    });
+
+    expect(result.current.filteredCommands).toHaveLength(0);
+  });
+
+  it('combines category and query filters', () => {
+    const { result } = renderHook(() => useCommandSearch());
+    const [category] = result.current.categories;
+    const commandInCategory = commandsData.find(c => c.category === category)!;
+
+    act(() => {
+      result.current.setSelectedCategory(category);
+      result.current.setSearchQuery(commandInCategory.name);
+    });
+
+    expect(result.current.filteredCommands).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: commandInCategory.name })])
+    );
+    expect(result.current.filteredCommands.every(c => c.category === category)).toBe(true);
+  });
+});

--- a/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
@@ -1,0 +1,535 @@
+import '../../i18n';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, createEvent, waitFor, within, act } from '@testing-library/react';
+import CanvasPage from './CanvasPage';
+
+// KNOWN COVERAGE GAPS (accepted, see the frontend test safety net plan):
+// - onNodeDragStart/onNodeDrag/onNodeDragStop (~300 lines): drag-based nesting/
+//   reparenting/overlap logic is not exercised here. jsdom has no real layout
+//   engine, and RTL/fireEvent cannot simulate pointer-based drag sequences
+//   realistically enough to drive this logic meaningfully. Deep coverage of this
+//   logic is deferred to the CanvasPage split-up refactor, which should extract
+//   it into a testable pure function/hook first.
+// - onConnect (drawing a connection creates a default inbound ALLOW rule) and
+//   the edges-derived-from-security-rules rendering (incl. handleDeleteEdge):
+//   both require React Flow handles/edges to be laid out and hit-testable,
+//   which jsdom cannot provide (nodes are never measured — the ResizeObserver
+//   polyfill in setupTests.ts is an intentional no-op). The refactor should
+//   extract the rule<->edge mapping into pure functions so it can be
+//   unit-tested directly.
+
+function jsonResponse(ok: boolean, body: unknown) {
+  return Promise.resolve({ ok, json: () => Promise.resolve(body) } as Response);
+}
+
+function subnetFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'subnet-1',
+    name: 'Public Subnet-1',
+    type: 'public',
+    vpcId: 'root-vpc',
+    position: { x: 0, y: 0 },
+    width: 680,
+    height: 260,
+    columns: 2,
+    rows: 1,
+    routes: [],
+    ...overrides,
+  };
+}
+
+/** Bodies of every POST to /network-config, oldest first. */
+function networkConfigPosts(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls
+    .filter(c => (c[0] as string).includes('/network-config') && (c[1] as RequestInit | undefined)?.method === 'POST')
+    .map(c => JSON.parse((c[1] as RequestInit).body as string).networkConfig);
+}
+
+/** React Flow wraps each node in an element carrying data-id={node.id}. */
+function nodeEl(container: HTMLElement, id: string) {
+  return container.querySelector(`.react-flow__node[data-id="${id}"]`) as HTMLElement;
+}
+
+/**
+ * jsdom has no DragEvent, so fireEvent's option bag silently drops
+ * clientX/clientY — they must be defined onto a hand-built event for
+ * screenToFlowPosition to receive real coordinates.
+ */
+function dropOnCanvas(canvas: Element, type: string, clientX: number, clientY: number) {
+  const dataTransfer = { getData: () => type, dropEffect: '' } as unknown as DataTransfer;
+  fireEvent.dragOver(canvas, { dataTransfer });
+  const dropEvent = createEvent.drop(canvas);
+  Object.defineProperties(dropEvent, {
+    clientX: { value: clientX },
+    clientY: { value: clientY },
+    dataTransfer: { value: dataTransfer },
+  });
+  fireEvent(canvas, dropEvent);
+}
+
+const validVpcConfig = {
+  name: 'Main Network',
+  cidr: '10.0.0.0/16',
+  dnsEnabled: true,
+  igwEnabled: true,
+  description: 'Project-wide Virtual Private Cloud',
+};
+
+function buildFetchMock({ containers = [] as unknown[], networkConfig }: { containers?: unknown[]; networkConfig: unknown }) {
+  return vi.fn((url: string, init?: RequestInit) => {
+    const method = init?.method || 'GET';
+    if (url.includes('/network-config')) {
+      if (method === 'POST') return jsonResponse(true, {});
+      return jsonResponse(true, networkConfig);
+    }
+    if (url.includes('/explorer')) return jsonResponse(true, []);
+    if (url.includes('/rename')) return jsonResponse(true, {});
+    if (method === 'DELETE') return jsonResponse(true, {});
+    if (method === 'POST') return jsonResponse(true, {});
+    // GET containers list
+    return jsonResponse(true, containers);
+  });
+}
+
+async function renderCanvasPage(fetchMock: ReturnType<typeof vi.fn>, props: Partial<Parameters<typeof CanvasPage>[0]> = {}) {
+  vi.stubGlobal('fetch', fetchMock);
+  const view = render(
+    <CanvasPage
+      projectId="p1"
+      projectName="Test Project"
+      onBackToProjects={props.onBackToProjects || vi.fn()}
+      onTerminalOpen={props.onTerminalOpen || vi.fn()}
+    />
+  );
+  // Flush the mount effect's two fetches (containers + network-config).
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return view;
+}
+
+describe('CanvasPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // React Flow computes viewport/fitView and hit-testing off the pane element's
+    // real layout, which jsdom always reports as a zero-sized rect. Give it a
+    // plausible size so screenToFlowPosition produces usable coordinates.
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+      width: 1000, height: 800, top: 0, left: 0, right: 1000, bottom: 800, x: 0, y: 0, toJSON: () => {},
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('fetches containers and network config on mount and renders the project header', async () => {
+    const fetchMock = buildFetchMock({ containers: [], networkConfig: { vpcConfig: validVpcConfig, subnets: [], nodeSubnetMap: {}, nodeSecurityGroups: {}, nodeIpMap: {} } });
+    await renderCanvasPage(fetchMock);
+
+    expect(screen.getByText('Project:')).toBeInTheDocument();
+    expect(screen.getAllByText('Test Project').length).toBeGreaterThan(0);
+
+    const calledUrls = fetchMock.mock.calls.map(c => c[0] as string);
+    expect(calledUrls.some(u => u.endsWith('/api/projects/p1/containers'))).toBe(true);
+    expect(calledUrls.some(u => u.endsWith('/api/projects/p1/network-config'))).toBe(true);
+  });
+
+  it('renders a fetched container as a node on the canvas', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [{ id: 'subnet-1', name: 'Public Subnet-1', type: 'public', vpcId: 'root-vpc', position: { x: 0, y: 0 }, width: 680, height: 260, columns: 2, rows: 1, routes: [] }],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [{ id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' }],
+      networkConfig,
+    });
+    await renderCanvasPage(fetchMock);
+
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+  });
+
+  it('opens the Postgres inspector modal when clicking a running postgres node, and closes it', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [{ id: 'subnet-1', name: 'Public Subnet-1', type: 'public', vpcId: 'root-vpc', position: { x: 0, y: 0 }, width: 680, height: 260, columns: 2, rows: 1, routes: [] }],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [{ id: 'c1', name: 'db-1', state: 'running', status: 'running', type: 'postgres' }],
+      networkConfig,
+    });
+    await renderCanvasPage(fetchMock);
+
+    await waitFor(() => expect(screen.getByText('db-1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTitle('Inspect Database Explorer / Shell'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const detailsTabButton = screen.getByRole('button', { name: /Details & Config/i });
+    expect(detailsTabButton).toBeInTheDocument();
+
+    // Close via the modal's header close (X) button, which sits alongside the tab
+    // buttons but has no accessible name of its own — locate it by DOM position.
+    const header = detailsTabButton.closest('div')!.parentElement!;
+    const headerButtons = within(header as HTMLElement).getAllByRole('button');
+    fireEvent.click(headerButtons[headerButtons.length - 1]);
+
+    expect(screen.queryByRole('button', { name: /Details & Config/i })).not.toBeInTheDocument();
+  });
+
+  it('shows an error and never opens the create-node modal when dropping outside any subnet', async () => {
+    const networkConfig = { vpcConfig: validVpcConfig, subnets: [], nodeSubnetMap: {}, nodeSecurityGroups: {}, nodeIpMap: {} };
+    const fetchMock = buildFetchMock({ containers: [], networkConfig });
+    const { container } = await renderCanvasPage(fetchMock);
+
+    const canvas = container.querySelector('.react-flow')!;
+    dropOnCanvas(canvas, 'ubuntu', 100, 100);
+
+    await waitFor(() => expect(screen.getByText('Nodes must reside within a subnet.')).toBeInTheDocument());
+    expect(screen.queryByText('Give your new container a descriptive name.')).not.toBeInTheDocument();
+  });
+
+  it('shows the delete confirmation for a node, and only deletes on confirm', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [{ id: 'subnet-1', name: 'Public Subnet-1', type: 'public', vpcId: 'root-vpc', position: { x: 0, y: 0 }, width: 680, height: 260, columns: 2, rows: 1, routes: [] }],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [{ id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' }],
+      networkConfig,
+    });
+    await renderCanvasPage(fetchMock);
+
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTitle('Delete Node'));
+
+    expect(screen.getByText('Delete Container')).toBeInTheDocument();
+    expect(screen.getByText('This will permanently stop and remove this container. This action cannot be undone.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(fetchMock.mock.calls.some(c => (c[1] as RequestInit | undefined)?.method === 'DELETE')).toBe(false);
+    expect(screen.queryByText('Delete Container')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Delete Node'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(fetchMock.mock.calls.some(c => (c[1] as RequestInit | undefined)?.method === 'DELETE')).toBe(true));
+  });
+
+  it('renames a stopped node via PATCH and migrates its saved layout position to the new name', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture()],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const containers = [{ id: 'c1', name: 'web-1', state: 'stopped', status: 'stopped', type: 'ubuntu' }];
+    const fetchMock = buildFetchMock({ containers, networkConfig });
+    // Make the mock stateful: after a successful rename, subsequent container
+    // fetches must return the new name, like the real backend would.
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/rename')) {
+        containers[0] = { ...containers[0], name: JSON.parse(init!.body as string).newName };
+      }
+      return base(url, init);
+    });
+    const { container } = await renderCanvasPage(fetchMock);
+
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+    fireEvent.click(within(nodeEl(container, 'c1')).getByText((_, el) => el?.getAttribute('data-tooltip') === 'Rename node', { selector: 'button' }));
+
+    const input = screen.getByPlaceholderText('e.g. api-gateway') as HTMLInputElement;
+    expect(input.value).toBe('web-1');
+    fireEvent.change(input, { target: { value: 'web-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() => expect(screen.getByText('Node renamed to "web-2"')).toBeInTheDocument());
+    const patchCall = fetchMock.mock.calls.find(c => (c[1] as RequestInit | undefined)?.method === 'PATCH')!;
+    expect(patchCall[0]).toContain('/api/projects/p1/containers/c1/rename');
+    expect(JSON.parse((patchCall[1] as RequestInit).body as string)).toEqual({ newName: 'web-2' });
+
+    await waitFor(() => {
+      const layout = JSON.parse(localStorage.getItem('akal-lab-graph-layout-p1')!);
+      expect(layout['web-2']).toBeDefined();
+      expect(layout['web-1']).toBeUndefined();
+    });
+  });
+
+  it('blocks renaming to the same name (warning) or an existing name (error) without calling the API', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture()],
+      nodeSubnetMap: { c1: 'subnet-1', c2: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2', c2: '10.0.1.3' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [
+        { id: 'c1', name: 'web-1', state: 'stopped', status: 'stopped', type: 'ubuntu' },
+        { id: 'c2', name: 'web-2', state: 'stopped', status: 'stopped', type: 'ubuntu' },
+      ],
+      networkConfig,
+    });
+    const { container } = await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+
+    const openRename = () =>
+      fireEvent.click(nodeEl(container, 'c1').querySelector('[data-tooltip="Rename node"]')!);
+
+    // Same name: warns and closes the modal.
+    openRename();
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    await waitFor(() => expect(screen.getByText('The node is already named "web-1".')).toBeInTheDocument());
+    expect(screen.queryByText('Rename Node')).not.toBeInTheDocument();
+
+    // Duplicate name: errors and keeps the modal open.
+    openRename();
+    fireEvent.change(screen.getByPlaceholderText('e.g. api-gateway'), { target: { value: 'web-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    await waitFor(() => expect(screen.getByText('A node named "web-2" already exists in this project.')).toBeInTheDocument());
+    expect(screen.getByText('Rename Node')).toBeInTheDocument();
+
+    expect(fetchMock.mock.calls.some(c => (c[1] as RequestInit | undefined)?.method === 'PATCH')).toBe(false);
+  });
+
+  it('surfaces the server error message when the rename request fails', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture()],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [{ id: 'c1', name: 'web-1', state: 'stopped', status: 'stopped', type: 'ubuntu' }],
+      networkConfig,
+    });
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/rename')) return jsonResponse(false, { error: 'Container is locked by the runtime' });
+      return base(url, init);
+    });
+    const { container } = await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+
+    fireEvent.click(nodeEl(container, 'c1').querySelector('[data-tooltip="Rename node"]')!);
+    fireEvent.change(screen.getByPlaceholderText('e.g. api-gateway'), { target: { value: 'web-9' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() => expect(screen.getByText('Container is locked by the runtime')).toBeInTheDocument());
+  });
+
+  it('deleting a node cascades cleanup of its subnet mapping, security groups, rules targeting it, and IP', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture()],
+      nodeSubnetMap: { c1: 'subnet-1', c2: 'subnet-1' },
+      nodeSecurityGroups: {
+        c1: [{ id: 'r0', type: 'inbound', action: 'DENY', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' }],
+        c2: [
+          { id: 'r1', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'c1' },
+          { id: 'r2', type: 'outbound', action: 'ALLOW', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
+        ],
+      },
+      nodeIpMap: { c1: '10.0.1.2', c2: '10.0.1.3' },
+    };
+    const containers = [
+      { id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' },
+      { id: 'c2', name: 'db-1', state: 'running', status: 'running', type: 'postgres' },
+    ];
+    const fetchMock = buildFetchMock({ containers, networkConfig });
+    // Stateful delete: refetches after the DELETE must no longer return c1.
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        const id = (url as string).split('/').pop();
+        containers.splice(containers.findIndex(c => c.id === id), 1);
+      }
+      return base(url, init);
+    });
+    const { container } = await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+
+    fireEvent.click(within(nodeEl(container, 'c1')).getByTitle('Delete Node'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(networkConfigPosts(fetchMock).length).toBeGreaterThan(0));
+    const posted = networkConfigPosts(fetchMock).at(-1);
+    expect(posted.nodeSubnetMap).toEqual({ c2: 'subnet-1' });
+    expect(posted.nodeSecurityGroups.c1).toBeUndefined();
+    expect(posted.nodeSecurityGroups.c2).toEqual([
+      { id: 'r2', type: 'outbound', action: 'ALLOW', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
+    ]);
+    expect(posted.nodeIpMap).toEqual({ c2: '10.0.1.3' });
+    expect(JSON.parse(localStorage.getItem('akal-lab-network-config-p1')!)).toEqual(posted);
+  });
+
+  it('blocks deleting a subnet that still contains nodes', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture()],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [{ id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' }],
+      networkConfig,
+    });
+    await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTitle('Delete Subnet'));
+
+    await waitFor(() => expect(screen.getByText('Cannot delete subnet: Move or delete all nodes inside the subnet first.')).toBeInTheDocument());
+    expect(networkConfigPosts(fetchMock)).toHaveLength(0);
+    expect(screen.getByText('Public Subnet-1')).toBeInTheDocument();
+  });
+
+  it('deletes an empty subnet and removes it from the persisted network config', async () => {
+    const networkConfig = { vpcConfig: validVpcConfig, subnets: [subnetFixture()], nodeSubnetMap: {}, nodeSecurityGroups: {}, nodeIpMap: {} };
+    const fetchMock = buildFetchMock({ containers: [], networkConfig });
+    await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('Public Subnet-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTitle('Delete Subnet'));
+
+    await waitFor(() => expect(networkConfigPosts(fetchMock).length).toBeGreaterThan(0));
+    const posted = networkConfigPosts(fetchMock).at(-1);
+    expect(posted.subnets).toEqual([]);
+    expect(JSON.parse(localStorage.getItem('akal-lab-network-config-p1')!).subnets).toEqual([]);
+    await waitFor(() => expect(screen.queryByText('Public Subnet-1')).not.toBeInTheDocument());
+  });
+
+  it('growing a subnet grid recomputes its columns, width and height in the persisted config', async () => {
+    const networkConfig = { vpcConfig: validVpcConfig, subnets: [subnetFixture()], nodeSubnetMap: {}, nodeSecurityGroups: {}, nodeIpMap: {} };
+    const fetchMock = buildFetchMock({ containers: [], networkConfig });
+    await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('Public Subnet-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTitle('Increase Columns'));
+
+    await waitFor(() => expect(networkConfigPosts(fetchMock).length).toBeGreaterThan(0));
+    const posted = networkConfigPosts(fetchMock).at(-1);
+    expect(posted.subnets[0]).toMatchObject({ columns: 3, rows: 1, width: 3 * 340, height: 70 + 1 * 190 });
+  });
+
+  it('blocks shrinking a subnet grid over an occupied cell, naming the blocking node', async () => {
+    // The shrink guard reads positions keyed by container ID, while the canvas
+    // sync effect keys them by name — seed the saved layout with both so the
+    // fixture stays valid regardless of which key each code path reads.
+    localStorage.setItem('akal-lab-graph-layout-p1', JSON.stringify({
+      c1: { x: 60 + 2 * 340, y: 60 },
+      'web-1': { x: 60 + 2 * 340, y: 60 },
+    }));
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture({ columns: 3, width: 1020 })],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [{ id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' }],
+      networkConfig,
+    });
+    await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTitle('Reduce Columns'));
+
+    await waitFor(() => expect(screen.getByText(`Cannot shrink grid. You should remove the node with name 'web-1' to be able to reduce the size`)).toBeInTheDocument());
+    expect(networkConfigPosts(fetchMock)).toHaveLength(0);
+  });
+
+  it('shows only the highest-priority audit message: errors win over warnings', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture()],
+      // "ghost" maps to a subnet that does not exist (error); "db-1" is a data
+      // store sitting in a public subnet (warning).
+      nodeSubnetMap: { c1: 'subnet-1', c2: 'subnet-missing' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [
+        { id: 'c1', name: 'db-1', state: 'running', status: 'running', type: 'postgres' },
+        { id: 'c2', name: 'ghost', state: 'running', status: 'running', type: 'ubuntu' },
+      ],
+      networkConfig,
+    });
+    await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('db-1')).toBeInTheDocument());
+
+    // Any config-mutating action re-runs the audit; growing the grid is the simplest.
+    fireEvent.click(screen.getByTitle('Increase Columns'));
+
+    await waitFor(() => expect(screen.getByText('Node "ghost" is assigned to a subnet that does not exist.')).toBeInTheDocument());
+    expect(screen.queryByText(/is in a public subnet/)).not.toBeInTheDocument();
+  });
+
+  it('polls the containers endpoint every 4 seconds', async () => {
+    vi.useFakeTimers();
+    const networkConfig = { vpcConfig: validVpcConfig, subnets: [], nodeSubnetMap: {}, nodeSecurityGroups: {}, nodeIpMap: {} };
+    const fetchMock = buildFetchMock({ containers: [], networkConfig });
+    await renderCanvasPage(fetchMock);
+
+    const containerFetches = () =>
+      fetchMock.mock.calls.filter(c => (c[0] as string).endsWith('/api/projects/p1/containers') && !(c[1] as RequestInit | undefined)?.method).length;
+    expect(containerFetches()).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(containerFetches()).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(containerFetches()).toBe(3);
+  });
+
+  it('dropping a service inside a subnet opens the create modal, which blocks duplicate names', async () => {
+    const networkConfig = {
+      vpcConfig: validVpcConfig,
+      subnets: [subnetFixture()],
+      nodeSubnetMap: { c1: 'subnet-1' },
+      nodeSecurityGroups: {},
+      nodeIpMap: { c1: '10.0.1.2' },
+    };
+    const fetchMock = buildFetchMock({
+      containers: [{ id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' }],
+      networkConfig,
+    });
+    const { container } = await renderCanvasPage(fetchMock);
+    await waitFor(() => expect(screen.getByText('web-1')).toBeInTheDocument());
+
+    const canvas = container.querySelector('.react-flow')!;
+    // The subnet occupies flow coordinates (0,0)-(680,260); with jsdom's identity
+    // viewport a drop at client (200,100) lands inside it.
+    dropOnCanvas(canvas, 'ubuntu', 200, 100);
+
+    expect(screen.getByText('Create Ubuntu Node')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. server-1'), { target: { value: 'web-1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Node' }));
+
+    await waitFor(() => expect(screen.getByText('A node named "web-1" already exists in this project.')).toBeInTheDocument());
+    expect(fetchMock.mock.calls.some(c => (c[0] as string).endsWith('/containers') && (c[1] as RequestInit | undefined)?.method === 'POST')).toBe(false);
+  });
+});

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Testing Library's automatic cleanup relies on a global afterEach, which is
+// absent when Vitest runs without `globals: true` — register it explicitly.
+afterEach(cleanup);
+
+// @xyflow/react measures nodes via ResizeObserver, which jsdom does not implement.
+// A minimal polyfill is sufficient — tests never depend on real observed sizes.
+class ResizeObserverPolyfill {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserverPolyfill }).ResizeObserver =
+  ResizeObserverPolyfill;
+
+// jsdom does not implement matchMedia.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/frontend/src/shared/hooks/useContainers.test.ts
+++ b/frontend/src/shared/hooks/useContainers.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useContainers } from './useContainers';
+import type { ContainerData } from '../types';
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as Response;
+}
+
+describe('useContainers', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('populates containers from a successful fetch', async () => {
+    const containers: ContainerData[] = [{ id: 'c1', name: 'web-1', state: 'running', status: 'running' }];
+    fetchMock.mockResolvedValueOnce(jsonResponse(true, containers));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1' }));
+    await act(async () => {
+      await result.current.fetchContainers();
+    });
+
+    expect(result.current.containers).toEqual(containers);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/projects/p1/containers'));
+  });
+
+  it('ignores a non-array response body defensively', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(true, { unexpected: 'shape' }));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1' }));
+    await act(async () => {
+      await result.current.fetchContainers();
+    });
+
+    expect(result.current.containers).toEqual([]);
+  });
+
+  it('toggles loading around a fetch', async () => {
+    let resolveFetch: (value: Response) => void;
+    fetchMock.mockReturnValueOnce(new Promise<Response>(resolve => { resolveFetch = resolve; }));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1' }));
+
+    let fetchPromise: Promise<void>;
+    act(() => {
+      fetchPromise = result.current.fetchContainers();
+    });
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolveFetch(jsonResponse(true, []));
+      await fetchPromise;
+    });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('on successful create, toasts success and re-fetches containers', async () => {
+    const onToast = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(true, {})) // POST create
+      .mockResolvedValueOnce(jsonResponse(true, [])); // GET re-fetch
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1', onToast }));
+    await act(async () => {
+      await result.current.createContainer('web-1', 'ubuntu');
+    });
+
+    expect(onToast).toHaveBeenCalledWith('Node "web-1" created successfully');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'POST' });
+  });
+
+  it('on failed create, toasts the backend error message and does not re-fetch', async () => {
+    const onToast = vi.fn();
+    fetchMock.mockResolvedValueOnce(jsonResponse(false, { error: 'name already exists' }));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1', onToast }));
+    await act(async () => {
+      await result.current.createContainer('web-1');
+    });
+
+    expect(onToast).toHaveBeenCalledWith('Failed: name already exists');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('startContainer re-fetches containers only when the start request succeeds', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(true, {})) // POST start
+      .mockResolvedValueOnce(jsonResponse(true, [])); // GET re-fetch
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1' }));
+    await act(async () => {
+      await result.current.startContainer('c1');
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toContain('/c1/start');
+  });
+
+  it('startContainer does not re-fetch when the start request fails', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(false, {}));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1' }));
+    await act(async () => {
+      await result.current.startContainer('c1');
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stopContainer re-fetches containers only when the stop request succeeds', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(true, {}))
+      .mockResolvedValueOnce(jsonResponse(true, []));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1' }));
+    await act(async () => {
+      await result.current.stopContainer('c1');
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toContain('/c1/stop');
+  });
+
+  it('deleteContainer optimistically removes the container, toasts, re-fetches, and resolves true on success', async () => {
+    const onToast = vi.fn();
+    const containers: ContainerData[] = [
+      { id: 'c1', name: 'web-1', state: 'running', status: 'running' },
+      { id: 'c2', name: 'web-2', state: 'running', status: 'running' },
+    ];
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(true, containers)) // initial fetch
+      .mockResolvedValueOnce(jsonResponse(true, {})) // DELETE
+      .mockResolvedValueOnce(jsonResponse(true, containers.filter(c => c.id !== 'c1'))); // re-fetch
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1', onToast }));
+    await act(async () => {
+      await result.current.fetchContainers();
+    });
+
+    let deleteResult: boolean | undefined;
+    await act(async () => {
+      deleteResult = await result.current.deleteContainer('c1');
+    });
+
+    expect(deleteResult).toBe(true);
+    expect(result.current.containers.find(c => c.id === 'c1')).toBeUndefined();
+    expect(onToast).toHaveBeenCalledWith('Container deleted');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('deleteContainer resolves false and does not toast when the delete request fails', async () => {
+    const onToast = vi.fn();
+    fetchMock.mockResolvedValueOnce(jsonResponse(false, {}));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1', onToast }));
+
+    let deleteResult: boolean | undefined;
+    await act(async () => {
+      deleteResult = await result.current.deleteContainer('c1');
+    });
+
+    expect(deleteResult).toBe(false);
+    expect(onToast).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a generic error toast when createContainer throws (network failure)', async () => {
+    const onToast = vi.fn();
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useContainers({ projectId: 'p1', onToast }));
+    await act(async () => {
+      await result.current.createContainer('web-1');
+    });
+
+    expect(onToast).toHaveBeenCalledWith('Error creating container node');
+  });
+});

--- a/frontend/src/shared/hooks/useToast.test.ts
+++ b/frontend/src/shared/hooks/useToast.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useToast } from './useToast';
+
+describe('useToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('showNotification sets the toast immediately and clears it after the default duration', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.showNotification({ type: 'success', message: 'Saved' });
+    });
+    expect(result.current.toast).toEqual({ type: 'success', message: 'Saved' });
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(result.current.toast).toBeNull();
+  });
+
+  it('showNotification respects a custom duration', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.showNotification({ type: 'warning', message: 'Careful' }, 1000);
+    });
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(result.current.toast).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.toast).toBeNull();
+  });
+
+  it.each([
+    ['Save failed', 'error'],
+    ['An error occurred', 'error'],
+    ['Invalid configuration', 'error'],
+    ['Cannot delete node', 'error'],
+  ])('showToast classifies "%s" as %s', (message, expectedType) => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast(message);
+    });
+    expect(result.current.toast?.type).toBe(expectedType);
+  });
+
+  it.each([
+    ['This is a warning', 'warning'],
+    ['Database is exposed publicly', 'warning'],
+    ['Security risk detected', 'warning'],
+    ['Alert: check your config', 'warning'],
+  ])('showToast classifies "%s" as %s', (message, expectedType) => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast(message);
+    });
+    expect(result.current.toast?.type).toBe(expectedType);
+  });
+
+  it('showToast defaults to success when no error/warning keywords match', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('Node created successfully');
+    });
+    expect(result.current.toast?.type).toBe('success');
+  });
+
+  it('dismissToast clears the toast immediately, independent of the timer', () => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.showToast('Node created successfully');
+    });
+    expect(result.current.toast).not.toBeNull();
+
+    act(() => {
+      result.current.dismissToast();
+    });
+    expect(result.current.toast).toBeNull();
+  });
+});

--- a/frontend/src/shared/utils/architectureValidator.test.ts
+++ b/frontend/src/shared/utils/architectureValidator.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { validateArchitecture } from './architectureValidator';
+import type { NetworkConfig } from './architectureValidator';
+import type { ContainerData } from '../types';
+
+function container(overrides: Partial<ContainerData> & { id: string; name: string }): ContainerData {
+  return { state: 'running', status: 'running', ...overrides };
+}
+
+function baseConfig(overrides: Partial<NetworkConfig> = {}): NetworkConfig {
+  return {
+    subnets: [],
+    nodeSubnetMap: {},
+    nodeSecurityGroups: {},
+    ...overrides,
+  };
+}
+
+describe('validateArchitecture', () => {
+  it('errors when a node maps to a subnet id that does not exist', () => {
+    const node = container({ id: 'n1', name: 'App Server' });
+    const config = baseConfig({ nodeSubnetMap: { n1: 'subnet-missing' } });
+
+    const result = validateArchitecture(config, [node]);
+
+    expect(result.errors).toContain('Node "App Server" is assigned to a subnet that does not exist.');
+  });
+
+  it('does not error when a node maps to a vpc- prefixed id (not a subnet)', () => {
+    const node = container({ id: 'n1', name: 'App Server' });
+    const config = baseConfig({ nodeSubnetMap: { n1: 'vpc-1' } });
+
+    const result = validateArchitecture(config, [node]);
+
+    expect(result.errors).toEqual([]);
+  });
+
+  it('warns when a data store sits in a public subnet', () => {
+    const db = container({ id: 'db1', name: 'Primary DB', type: 'postgres' });
+    const config = baseConfig({
+      subnets: [{ id: 'sub-pub', name: 'Public', type: 'public', vpcId: null, position: { x: 0, y: 0 }, width: 1, height: 1, routes: [] }],
+      nodeSubnetMap: { db1: 'sub-pub' },
+    });
+
+    const result = validateArchitecture(config, [db]);
+
+    expect(result.warnings).toContain('Data store "Primary DB" is in a public subnet. For safety, data store instances should be kept in private subnets.');
+  });
+
+  it('does not warn about public subnet placement for non-sensitive node types', () => {
+    const app = container({ id: 'app1', name: 'App', type: 'ubuntu' });
+    const config = baseConfig({
+      subnets: [{ id: 'sub-pub', name: 'Public', type: 'public', vpcId: null, position: { x: 0, y: 0 }, width: 1, height: 1, routes: [] }],
+      nodeSubnetMap: { app1: 'sub-pub' },
+    });
+
+    const result = validateArchitecture(config, [app]);
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns when a data store security group allows inbound from 0.0.0.0/0', () => {
+    const db = container({ id: 'db1', name: 'Cache', type: 'redis' });
+    const config = baseConfig({
+      nodeSecurityGroups: {
+        db1: [{ id: 'r1', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '6379', source: '0.0.0.0/0' }],
+      },
+    });
+
+    const result = validateArchitecture(config, [db]);
+
+    expect(result.warnings).toContain('Data store "Cache" is exposed to the public internet (0.0.0.0/0) in its security group.');
+  });
+
+  it('does not warn about public exposure when the matching rule is outbound', () => {
+    const db = container({ id: 'db1', name: 'Cache', type: 'redis' });
+    const config = baseConfig({
+      nodeSecurityGroups: {
+        db1: [{ id: 'r1', type: 'outbound', action: 'ALLOW', protocol: 'TCP', port: '6379', source: '0.0.0.0/0' }],
+      },
+    });
+
+    const result = validateArchitecture(config, [db]);
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns when there is a database but no caching tier', () => {
+    const db = container({ id: 'db1', name: 'Primary DB', type: 'postgres' });
+
+    const result = validateArchitecture(baseConfig(), [db]);
+
+    expect(result.warnings).toContain('No caching tier (e.g., Redis or Memcached) detected. Consider adding one to optimize database loads.');
+  });
+
+  it('does not warn about a missing caching tier when a redis node is present', () => {
+    const db = container({ id: 'db1', name: 'Primary DB', type: 'postgres' });
+    const cache = container({ id: 'c1', name: 'Cache', type: 'redis' });
+
+    const result = validateArchitecture(baseConfig(), [db, cache]);
+
+    expect(result.warnings).not.toContain('No caching tier (e.g., Redis or Memcached) detected. Consider adding one to optimize database loads.');
+  });
+
+  it('does not warn about a missing caching tier when there is no database at all', () => {
+    const app = container({ id: 'app1', name: 'App', type: 'ubuntu' });
+
+    const result = validateArchitecture(baseConfig(), [app]);
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns when a database receives a direct connection from a public-facing node', () => {
+    const gateway = container({ id: 'gw1', name: 'api-gateway', type: 'ubuntu' });
+    const db = container({ id: 'db1', name: 'Primary DB', type: 'postgres' });
+    const config = baseConfig({
+      nodeSubnetMap: { gw1: 'sub-pub' },
+      subnets: [{ id: 'sub-pub', name: 'Public', type: 'public', vpcId: null, position: { x: 0, y: 0 }, width: 1, height: 1, routes: [] }],
+      nodeSecurityGroups: {
+        db1: [{ id: 'r1', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'gw1' }],
+      },
+    });
+
+    const result = validateArchitecture(config, [gateway, db]);
+
+    expect(result.warnings).toContain(
+      'Database "Primary DB" receives direct connections from public-facing node "api-gateway". Traffic should go through a backend application layer.'
+    );
+  });
+
+  it('reports a secure 3-tier success when frontend -> backend -> db flow is properly isolated', () => {
+    const frontend = container({ id: 'fe1', name: 'gateway', type: 'ubuntu' });
+    const backend = container({ id: 'be1', name: 'app-server', type: 'ubuntu' });
+    const db = container({ id: 'db1', name: 'Primary DB', type: 'postgres' });
+    const config = baseConfig({
+      subnets: [
+        { id: 'sub-pub', name: 'Public', type: 'public', vpcId: null, position: { x: 0, y: 0 }, width: 1, height: 1, routes: [] },
+        { id: 'sub-priv', name: 'Private', type: 'private', vpcId: null, position: { x: 0, y: 0 }, width: 1, height: 1, routes: [] },
+      ],
+      nodeSubnetMap: { fe1: 'sub-pub', be1: 'sub-priv', db1: 'sub-priv' },
+      nodeSecurityGroups: {
+        be1: [{ id: 'r1', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '80', source: 'fe1' }],
+        db1: [{ id: 'r2', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'be1' }],
+      },
+    });
+
+    const result = validateArchitecture(config, [frontend, backend, db]);
+
+    expect(result.successes).toContain(
+      'Secure 3-Tier VPC Architecture detected! (Public Gateway -> Private App Server -> Private Isolated Database)'
+    );
+  });
+
+  it('produces the generic success message when a valid multi-node config has no errors or warnings', () => {
+    const a = container({ id: 'a', name: 'node-a', type: 'ubuntu' });
+    const b = container({ id: 'b', name: 'node-b', type: 'ubuntu' });
+
+    const result = validateArchitecture(baseConfig(), [a, b]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.successes).toContain('VPC Network is fully valid and adheres to basic system design security guidelines!');
+  });
+
+  it('produces no successes for an empty container list', () => {
+    const result = validateArchitecture(baseConfig(), []);
+
+    expect(result.successes).toEqual([]);
+  });
+});

--- a/frontend/src/test-utils/mockFetchSequence.ts
+++ b/frontend/src/test-utils/mockFetchSequence.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest';
+
+interface MockedFetchResponse {
+  ok: boolean;
+  json: unknown;
+}
+
+/** Queues a sequence of fetch responses for a test. Not used by production code. */
+export function mockFetchResponses(responses: MockedFetchResponse[]) {
+  const fetchMock = vi.fn();
+  responses.forEach(r => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve({ ok: r.ok, json: () => Promise.resolve(r.json) } as Response)
+    );
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 import fs from 'fs'
@@ -15,5 +15,9 @@ export default defineConfig({
   server: {
     port: 23232,
     strictPort: true
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts']
   }
 })


### PR DESCRIPTION
## Summary of Changes

Adds a frontend test safety net (98 Vitest tests) ahead of the two upcoming refactors — **splitting the ~1800-line `CanvasPage.tsx` god component and deduplicating the three near-identical database modals** — so behavior is locked in before restructuring begins.

- **Test infrastructure**: test tooling (vitest, jsdom, testing-library) declared in `package.json`/lockfile, `test`/`test:watch` scripts, jsdom environment + setup file wired in `vite.config.ts`, explicit Testing Library cleanup (Vitest runs without globals).
- **Unit tests**: `useToast`, `useContainers`, `useCommandSearch`, `validateArchitecture`.
- **Component tests** for the Postgres/NoSQL/Redis inspector modals: tabs, explorer tree with the 2.5s starting-up retry, query execution success/error, cheat-sheet filter + clipboard, close. Buttons without an accessible name are located via their lucide icon rather than DOM position so the tests survive the upcoming modal dedup.
- **CanvasPage integration tests** (16): mount fetches, node rendering, inspector open/close, rename flow (PATCH, same-name/duplicate guards, server errors, layout-key migration), delete cascade across subnet/security-group/IP maps, subnet delete guards, grid resize grow/shrink rules, audit message priority (error > warning), 4s container polling, drop-to-create flow with its duplicate-name guard.
- **CI**: new `frontend-build-and-test` job mirroring the backend one (existing job name untouched to preserve required checks).

Known jsdom coverage gaps (`onConnect`, rule→edge mapping, drag/reparent) are documented in the CanvasPage test header as extraction targets for the refactor. No production source code was changed.

## Types of Changes

- [ ] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [x] Refactoring / structural cleanup (test safety net + CI wiring — no production code changes)
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

- Ran the full suite twice in a row (98/98 green both times) to rule out timer/cleanup flakiness.
- Ran a fresh `npm ci && npm test` to confirm the lockfile now carries the test tooling (previously it lived only in `node_modules` and a clean install would have wiped it).
- `git diff` confirms zero changes under `frontend/src/` outside `*.test.*`, `setupTests.ts` and `test-utils/`.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [ ] I have updated the documentation or instructions if necessary (not needed — no behavior or API changes)
- [x] All unit and integration tests are passing