### PR TITLE
feat: add RabbitMQ message broker node type with security policy enfo…

### DIFF
--- a/backend/src/infrastructure/docker/DockerInitializer.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.ts
@@ -25,6 +25,19 @@ export class DockerInitializer {
   }
 
   /**
+   * Ensures a single node image is available locally, applying the same
+   * pull-then-build fallback as startup: the custom `derssa/*` images may not
+   * be published to a registry, so when the pull fails they are rebuilt from
+   * their public base + iptables. Lets callers (e.g. integration tests) get one
+   * image ready without running the full startup routine.
+   */
+  public static async ensureImageAvailable(tag: string): Promise<void> {
+    const images = await docker.listImages();
+    const existingTags = images.flatMap(img => img.RepoTags || []);
+    await this.ensureImage(existingTags, tag, tag);
+  }
+
+  /**
    * Names of subnet networks referenced by current projects, or null when
    * projects.json exists but cannot be parsed. A missing file means no
    * projects, so every subnet network is a genuine orphan.
@@ -132,6 +145,7 @@ export class DockerInitializer {
       await this.ensureImage(tags, NODE_TYPES.postgres.image, 'PostgreSQL');
       await this.ensureImage(tags, NODE_TYPES.mongo.image, 'MongoDB');
       await this.ensureImage(tags, NODE_TYPES.redis.image, 'Redis');
+      await this.ensureImage(tags, NODE_TYPES.rabbitmq.image, 'RabbitMQ');
     } catch (err) {
       console.error('[DockerInitializer] Docker check failed. Is Docker running?');
       throw err;
@@ -300,6 +314,65 @@ export class DockerInitializer {
         console.log(`[DockerInitializer] Cleaning up temporary build container...`);
         await tempContainer.remove({ force: true });
         console.log(`[DockerInitializer] Custom Redis image with iptables created successfully.`);
+      } else if (tag === NODE_TYPES.rabbitmq.image) {
+        const fallbackTag = 'rabbitmq:3-management-alpine';
+        console.log(`[DockerInitializer] Tag ${tag} not found. Building custom RabbitMQ image locally...`);
+
+        // Ensure base rabbitmq:3-management-alpine is pulled
+        const imagesList = await docker.listImages();
+        const localTags = imagesList.flatMap(img => img.RepoTags || []);
+        if (!localTags.includes(fallbackTag)) {
+          console.log(`[DockerInitializer] Pulling base rabbitmq:3-management-alpine image...`);
+          await new Promise<void>((resolve, reject) => {
+            docker.pull(fallbackTag, {}, (err, stream) => {
+              if (err) return reject(err);
+              if (!stream) return reject(new Error('Pull stream is undefined'));
+              docker.modem.followProgress(stream, (finishedErr) => finishedErr ? reject(finishedErr) : resolve());
+            });
+          });
+        }
+
+        // Clean up any stale temp containers from previous runs
+        try {
+          const oldContainer = docker.getContainer('akal-lab-temp-rabbitmq-build');
+          await oldContainer.remove({ force: true });
+        } catch {
+          // Ignore if old container doesn't exist
+        }
+
+        console.log(`[DockerInitializer] Creating temporary build container for RabbitMQ...`);
+        const tempContainer = await docker.createContainer({
+          Image: fallbackTag,
+          name: 'akal-lab-temp-rabbitmq-build',
+          Entrypoint: ['tail', '-f', '/dev/null']
+        });
+        await tempContainer.start();
+
+        console.log(`[DockerInitializer] Installing iptables inside build container...`);
+        const exec = await tempContainer.exec({
+          Cmd: ['sh', '-c', 'apk update && apk add --no-cache iptables iproute2'],
+          AttachStdout: true,
+          AttachStderr: true
+        });
+        const stream = await exec.start({});
+        await new Promise<void>((resolve) => {
+          stream.on('data', () => {});
+          stream.on('end', () => resolve());
+        });
+
+        console.log(`[DockerInitializer] Committing custom RabbitMQ image as ${tag}...`);
+        await tempContainer.commit({
+          repo: 'derssa/backend-lab-rabbitmq',
+          tag: 'v1',
+          changes: [
+            'ENTRYPOINT ["docker-entrypoint.sh"]',
+            'CMD ["rabbitmq-server"]'
+          ]
+        });
+
+        console.log(`[DockerInitializer] Cleaning up temporary build container...`);
+        await tempContainer.remove({ force: true });
+        console.log(`[DockerInitializer] Custom RabbitMQ image with iptables created successfully.`);
       } else {
         throw pullErr;
       }

--- a/backend/src/infrastructure/docker/imageRequirements.itest.ts
+++ b/backend/src/infrastructure/docker/imageRequirements.itest.ts
@@ -1,5 +1,6 @@
 import docker from './DockerClient';
 import { NODE_TYPES } from './nodeTypes';
+import { DockerInitializer } from './DockerInitializer';
 
 /**
  * Integration tests (run with `npm run test:integration`, requires a Docker daemon).
@@ -13,24 +14,6 @@ import { NODE_TYPES } from './nodeTypes';
  */
 
 const images = [...new Set(Object.values(NODE_TYPES).map(t => t.image))];
-
-async function ensureImage(image: string): Promise<void> {
-  try {
-    await docker.getImage(image).inspect();
-    return;
-  } catch {
-    // Image not present locally: pull it below.
-  }
-  await new Promise<void>((resolve, reject) => {
-    docker.pull(image, {}, (err, stream) => {
-      if (err) return reject(err);
-      if (!stream) return reject(new Error('Pull stream is undefined'));
-      docker.modem.followProgress(stream, (finishedErr) =>
-        finishedErr ? reject(finishedErr) : resolve()
-      );
-    });
-  });
-}
 
 async function runInImage(image: string, cmd: string): Promise<{ exitCode: number; output: string }> {
   const container = await docker.createContainer({
@@ -65,7 +48,9 @@ describe('node image requirements', () => {
   it.each(images)(
     '%s ships iptables and iproute2, and iptables works under CAP_NET_ADMIN',
     async (image) => {
-      await ensureImage(image);
+      // Build the custom `derssa/*` images locally when they are not published
+      // to a registry (same pull-then-build fallback the backend runs at startup).
+      await DockerInitializer.ensureImageAvailable(image);
       const result = await runInImage(image, 'command -v iptables && command -v ip && iptables -S');
       expect(result).toMatchObject({ exitCode: 0 });
     }

--- a/backend/src/infrastructure/docker/nodeTypes.ts
+++ b/backend/src/infrastructure/docker/nodeTypes.ts
@@ -16,9 +16,9 @@ export interface NodeTypeDescriptor {
   interactiveTty?: boolean;
   /** Merged into HostConfig after the common base (AutoRemove/NetworkMode/CapAdd). */
   hostConfigExtras?: Record<string, unknown>;
-  /** When to publish container port 80 to a random host port. */
+  /** When to publish the container's `defaultPrivatePort` to a random host port. */
   publicPort: 'always' | 'whenPublic' | 'never';
-  /** Private port whose PublicPort is surfaced in container listings. */
+  /** Private port that is published to / surfaced from the host (defaults to 80). */
   defaultPrivatePort?: number;
 }
 
@@ -69,7 +69,13 @@ export const NODE_TYPES = {
     hostConfigExtras: { Privileged: true, Sysctls: { 'net.ipv4.ip_forward': '1' } },
     publicPort: 'never'
   },
-  autoscalinggroup: { ...ubuntu, label: 'Auto Scaling Group' }
+  autoscalinggroup: { ...ubuntu, label: 'Auto Scaling Group' },
+  rabbitmq: {
+    label: 'RabbitMQ',
+    image: 'derssa/backend-lab-rabbitmq:v1',
+    publicPort: 'always',
+    defaultPrivatePort: 15672
+  }
 } satisfies Record<string, NodeTypeDescriptor>;
 
 /** Alternate type names accepted from callers, kept verbatim in container labels. */

--- a/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
+++ b/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
@@ -173,6 +173,7 @@ export class DockerContainerProvider implements ContainerProvider {
     }
 
     const publishPublicPort = desc.publicPort === 'always' || (desc.publicPort === 'whenPublic' && isPublic);
+    const portKey = `${desc.defaultPrivatePort ?? 80}/tcp`;
 
     const createOpts: any = {
       Image: image,
@@ -191,7 +192,7 @@ export class DockerContainerProvider implements ContainerProvider {
         NetworkMode: 'akal-lab-network',
         CapAdd: ['NET_ADMIN'],
         ...(desc.hostConfigExtras || {}),
-        ...(publishPublicPort ? { PortBindings: { '80/tcp': [{ HostPort: '' }] } } : {})
+        ...(publishPublicPort ? { PortBindings: { [portKey]: [{ HostPort: '' }] } } : {})
       },
       NetworkingConfig: {
         EndpointsConfig: {
@@ -211,7 +212,7 @@ export class DockerContainerProvider implements ContainerProvider {
     const inspectData = await container.inspect();
     if (publishPublicPort) {
       const ports = inspectData.NetworkSettings.Ports;
-      const targetPortKey = '80/tcp';
+      const targetPortKey = portKey;
       if (ports && ports[targetPortKey] && ports[targetPortKey][0]) {
         port = ports[targetPortKey][0].HostPort;
       }

--- a/backend/src/modules/network/providers/dockerNetworkProvider.ts
+++ b/backend/src/modules/network/providers/dockerNetworkProvider.ts
@@ -212,11 +212,14 @@ export class DockerNetworkProvider implements NetworkProvider {
     const nodeType = containerInfo.Labels?.['akal.node.type'] || 'ubuntu';
     const isLoadBalancer = nodeType === 'loadbalancer';
     const isPublicUbuntu = nodeType === 'ubuntu' && subnet.type === 'public';
+    // RabbitMQ publishes its management console (15672) to a host port, which
+    // requires staying attached to the default bridge network.
+    const isRabbitMq = nodeType === 'rabbitmq';
 
     for (const netName of currentNetworks) {
       if (netName === targetNetwork || (!netName.startsWith('akal-subnet-') && netName !== 'akal-lab-network')) continue;
 
-      if (netName === 'akal-lab-network' && (isLoadBalancer || isPublicUbuntu)) {
+      if (netName === 'akal-lab-network' && (isLoadBalancer || isPublicUbuntu || isRabbitMq)) {
         continue; // Keep connected to default bridge network for port mappings
       }
 
@@ -274,8 +277,9 @@ export class DockerNetworkProvider implements NetworkProvider {
       }
     }
 
-    // Reconnect to default akal-lab-network if node is public (loadbalancer or public ubuntu) and disconnected
-    if ((isLoadBalancer || isPublicUbuntu) && !currentNetworks.includes('akal-lab-network')) {
+    // Reconnect to default akal-lab-network if node needs a host port mapping
+    // (loadbalancer, public ubuntu, or rabbitmq) and it was disconnected.
+    if ((isLoadBalancer || isPublicUbuntu || isRabbitMq) && !currentNetworks.includes('akal-lab-network')) {
       console.log(`[DockerNetworkProvider] Reconnecting public container ${ep.containerName} to default network akal-lab-network...`);
       try {
         await docker.getNetwork('akal-lab-network').connect({ Container: containerInfo.Id });

--- a/frontend/src/features/nodes/RabbitMqNode/RabbitMqModal.tsx
+++ b/frontend/src/features/nodes/RabbitMqNode/RabbitMqModal.tsx
@@ -1,0 +1,476 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X, Server, BookOpen, Search, Copy, Check, ExternalLink, AlertCircle, HelpCircle } from 'lucide-react';
+import rabbitmqCheatSheet from './data/rabbitmqCheatSheet.json';
+
+interface RabbitMqModalProps {
+  nodeName: string;
+  port?: string;
+  ipAddress?: string;
+  state: string;
+  onClose: () => void;
+}
+
+const CHEAT_SHEET_DATA = rabbitmqCheatSheet;
+const RABBITMQ_IMAGE = 'derssa/backend-lab-rabbitmq:v1';
+
+export default function RabbitMqModal({ nodeName, port, ipAddress, state, onClose }: RabbitMqModalProps) {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<'details' | 'cheatsheet'>('details');
+  const [cheatQuery, setCheatQuery] = useState('');
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const handleCopyCheat = (code: string, idx: number) => {
+    navigator.clipboard?.writeText(code)
+      .then(() => {
+        setCopiedIndex(idx);
+        setTimeout(() => setCopiedIndex(null), 2000);
+      })
+      .catch(() => { /* clipboard unavailable */ });
+  };
+
+  const filteredCheatSheet = CHEAT_SHEET_DATA.filter(item => {
+    const query = cheatQuery.toLowerCase();
+    return (
+      item.name.toLowerCase().includes(query) ||
+      item.description.toLowerCase().includes(query) ||
+      item.category.toLowerCase().includes(query)
+    );
+  });
+
+  const isRunning = state === 'running';
+  // Dynamic host port mapped to RabbitMQ 15672/tcp management console
+  const managementConsoleUrl = port ? `http://localhost:${port}` : '';
+
+  return (
+    <div style={styles.overlay}>
+      <div style={styles.container} className="glass">
+        {/* Header Tabs */}
+        <div style={styles.header}>
+          <div style={styles.tabs}>
+            <button
+              style={{ ...styles.tabBtn, ...(activeTab === 'details' ? styles.activeTabBtn : {}) }}
+              onClick={() => setActiveTab('details')}
+            >
+              <Server size={15} style={{ marginRight: 6 }} />
+              {t('rabbitmq.tabs.details')}
+            </button>
+            <button
+              style={{ ...styles.tabBtn, ...(activeTab === 'cheatsheet' ? styles.activeTabBtn : {}) }}
+              onClick={() => setActiveTab('cheatsheet')}
+            >
+              <BookOpen size={15} style={{ marginRight: 6 }} />
+              {t('rabbitmq.tabs.cheatsheet')}
+            </button>
+          </div>
+          <button onClick={onClose} style={styles.closeBtn}>
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Modal Body */}
+        <div style={styles.body}>
+          {/* TAB: Details */}
+          {activeTab === 'details' && (
+            <div style={styles.tabContent}>
+              <h3 style={styles.title}>{t('rabbitmq.details.title')}</h3>
+              <p style={styles.desc}>{t('rabbitmq.details.desc')}</p>
+
+              <div style={styles.infoCard}>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.stateLabel')}</span>
+                  <span style={{
+                    ...styles.detailValue,
+                    color: isRunning ? '#10B981' : '#EF4444',
+                    fontWeight: 700
+                  }}>
+                    {isRunning ? t('rabbitmq.details.running') : t('rabbitmq.details.stopped')}
+                  </span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.imageLabel')}</span>
+                  <span style={styles.detailValue}>{RABBITMQ_IMAGE}</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.nodeNameLabel')}</span>
+                  <span style={styles.detailValue}>{nodeName}</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.internalIpLabel')}</span>
+                  <span style={styles.detailValue}>{ipAddress || t('rabbitmq.details.notAssigned')}</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.amqpPortLabel')}</span>
+                  <span style={styles.detailValue}>5672</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.mgmtPortLabel')}</span>
+                  <span style={styles.detailValue}>15672</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.usernameLabel')}</span>
+                  <span style={styles.detailValue}>guest</span>
+                </div>
+                <div style={styles.detailRow}>
+                  <span style={styles.detailLabel}>{t('rabbitmq.details.passwordLabel')}</span>
+                  <span style={styles.detailValue}>guest</span>
+                </div>
+                {port && (
+                  <div style={styles.detailRow}>
+                    <span style={styles.detailLabel}>{t('rabbitmq.details.consoleUrlLabel')}</span>
+                    <span style={styles.detailValue}>{managementConsoleUrl}</span>
+                  </div>
+                )}
+              </div>
+
+              {isRunning && (
+                <div style={styles.warningCard}>
+                  <AlertCircle size={18} color="#B45309" style={{ marginRight: '10px', flexShrink: 0, marginTop: '2px' }} />
+                  <div style={{ fontSize: '13px', color: '#B45309', lineHeight: '1.5' }}>
+                    <strong>{t('rabbitmq.details.warning.title')}</strong>
+                    <ul style={{ margin: '4px 0 0 0', paddingLeft: '20px' }}>
+                      <li>
+                        {t('rabbitmq.details.warning.sgRule')}
+                        <span
+                          onMouseEnter={() => setShowTooltip(true)}
+                          onMouseLeave={() => setShowTooltip(false)}
+                          style={{ position: 'relative', cursor: 'pointer', marginLeft: '6px', display: 'inline-flex', alignItems: 'center', verticalAlign: 'middle' }}
+                        >
+                          <HelpCircle size={13} color="#B45309" />
+                          {showTooltip && (
+                            <span style={styles.tooltip}>
+                              {t('rabbitmq.details.warning.tooltip')}
+                            </span>
+                          )}
+                        </span>
+                      </li>
+                      <li>{t('rabbitmq.details.warning.bootDelay')}</li>
+                      <li>{t('rabbitmq.details.warning.amqpRule')}</li>
+                    </ul>
+                  </div>
+                </div>
+              )}
+
+              {isRunning && port ? (
+                <div style={{ marginTop: '24px', display: 'flex', justifyContent: 'center' }}>
+                  <a
+                    href={managementConsoleUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={styles.actionBtn}
+                  >
+                    <ExternalLink size={14} style={{ marginRight: 8 }} />
+                    {t('rabbitmq.details.openConsoleBtn')}
+                  </a>
+                </div>
+              ) : (
+                <div style={styles.alertCard}>
+                  <p style={{ margin: 0, fontSize: '13px', color: '#64748B', textAlign: 'center' }}>
+                    {t('rabbitmq.details.startPrompt')}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* TAB: Cheat Sheet */}
+          {activeTab === 'cheatsheet' && (
+            <div style={{ ...styles.tabContent, display: 'flex', flexDirection: 'column' }}>
+              <div style={styles.searchBar}>
+                <div style={styles.searchWrapper}>
+                  <Search size={15} color="var(--color-text-muted)" style={styles.searchIcon} />
+                  <input
+                    type="text"
+                    placeholder={t('rabbitmq.cheatsheet.placeholder')}
+                    value={cheatQuery}
+                    onChange={(e) => setCheatQuery(e.target.value)}
+                    style={styles.searchInput}
+                  />
+                </div>
+              </div>
+
+              <div style={styles.cheatSheetList}>
+                {filteredCheatSheet.map((item, idx) => (
+                  <div key={item.name} style={styles.cheatCard}>
+                    <div style={styles.cheatHeader}>
+                      <span style={styles.cheatName}>{item.name}</span>
+                      <span style={styles.cheatCategory}>{item.category}</span>
+                    </div>
+                    <p style={styles.cheatDesc}>{item.description}</p>
+                    <div style={styles.codeContainer}>
+                      <pre style={styles.code}>
+                        <code>{item.example}</code>
+                      </pre>
+                      <button
+                        onClick={() => handleCopyCheat(item.example, idx)}
+                        style={styles.copyBtn}
+                      >
+                        {copiedIndex === idx ? <Check size={14} color="#10B981" /> : <Copy size={14} />}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+                {filteredCheatSheet.length === 0 && (
+                  <div style={{ textAlign: 'center', padding: '20px', color: 'var(--color-text-muted)' }}>
+                    {t('rabbitmq.cheatsheet.noMatch')}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100vw',
+    height: '100vh',
+    backgroundColor: 'rgba(0, 0, 0, 0.65)',
+    zIndex: 1000,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '24px',
+    boxSizing: 'border-box',
+  },
+  container: {
+    width: '900px',
+    maxWidth: '100%',
+    height: '600px',
+    maxHeight: '100%',
+    borderRadius: '12px',
+    display: 'flex',
+    flexDirection: 'column',
+    boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.5)',
+    overflow: 'hidden',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '12px 20px',
+    borderBottom: '1px solid var(--border-color)',
+    backgroundColor: 'var(--bg-surface-solid)',
+    borderTopLeftRadius: '12px',
+    borderTopRightRadius: '12px',
+  },
+  tabs: {
+    display: 'flex',
+    gap: '8px',
+  },
+  tabBtn: {
+    backgroundColor: 'transparent',
+    border: 'none',
+    borderRadius: '6px',
+    color: 'var(--color-text-secondary)',
+    cursor: 'pointer',
+    padding: '8px 14px',
+    fontSize: '13px',
+    fontWeight: 600,
+    display: 'flex',
+    alignItems: 'center',
+    transition: 'all 0.2s',
+  },
+  activeTabBtn: {
+    backgroundColor: 'var(--color-accent-glow)',
+    color: 'var(--color-accent)',
+  },
+  closeBtn: {
+    background: 'none',
+    border: 'none',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    padding: '6px',
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: 'background-color 0.2s, color 0.2s',
+  },
+  body: {
+    flex: 1,
+    overflow: 'hidden',
+    backgroundColor: '#FFFFFF',
+  },
+  tabContent: {
+    height: '100%',
+    overflowY: 'auto',
+    padding: '20px',
+    boxSizing: 'border-box',
+  },
+  title: {
+    margin: '0 0 8px 0',
+    fontSize: '16px',
+    color: '#1E293B',
+  },
+  desc: {
+    margin: '0 0 20px 0',
+    fontSize: '13px',
+    color: '#64748B',
+  },
+  infoCard: {
+    border: '1px solid #E2E8F0',
+    borderRadius: '8px',
+    padding: '16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    backgroundColor: '#FAFAFA'
+  },
+  detailRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    fontSize: '13px',
+  },
+  detailLabel: {
+    color: 'var(--color-text-secondary)',
+    fontWeight: 600,
+  },
+  detailValue: {
+    color: 'var(--color-text-primary)',
+    fontFamily: 'var(--font-mono)',
+  },
+  actionBtn: {
+    backgroundColor: '#FF6600',
+    color: '#FFF',
+    border: 'none',
+    borderRadius: '6px',
+    padding: '10px 20px',
+    fontSize: '13px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    textDecoration: 'none',
+    boxShadow: '0 4px 6px -1px rgba(255, 102, 0, 0.2), 0 2px 4px -1px rgba(255, 102, 0, 0.1)',
+    transition: 'background-color 0.2s, transform 0.2s',
+  },
+  alertCard: {
+    border: '1px dashed #E2E8F0',
+    borderRadius: '8px',
+    padding: '20px',
+    marginTop: '24px',
+    backgroundColor: '#FAFAFA'
+  },
+  searchBar: {
+    marginBottom: '16px',
+  },
+  searchWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.03)',
+    border: '1px solid var(--border-color)',
+    borderRadius: '6px',
+    padding: '6px 10px',
+  },
+  searchIcon: {
+    marginRight: '6px',
+  },
+  searchInput: {
+    border: 'none',
+    background: 'transparent',
+    outline: 'none',
+    fontSize: '12px',
+    width: '100%',
+    color: 'var(--color-text-primary)',
+  },
+  cheatSheetList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    overflowY: 'auto',
+    flex: 1,
+  },
+  cheatCard: {
+    border: '1px solid var(--border-color)',
+    borderRadius: '8px',
+    padding: '16px',
+    backgroundColor: 'var(--bg-surface-solid)',
+  },
+  cheatHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '8px',
+  },
+  cheatName: {
+    fontSize: '14px',
+    fontWeight: 700,
+    color: '#FF6600',
+  },
+  cheatCategory: {
+    fontSize: '11px',
+    color: 'var(--color-text-secondary)',
+    backgroundColor: 'rgba(0, 0, 0, 0.04)',
+    border: '1px solid var(--border-color)',
+    padding: '2px 6px',
+    borderRadius: '4px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+  },
+  cheatDesc: {
+    fontSize: '13px',
+    color: 'var(--color-text-secondary)',
+    margin: '0 0 12px 0',
+  },
+  codeContainer: {
+    position: 'relative',
+  },
+  code: {
+    margin: 0,
+    padding: '10px 14px',
+    backgroundColor: 'var(--bg-main)',
+    color: 'var(--color-text-primary)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: '13px',
+    borderRadius: '6px',
+    overflowX: 'auto',
+    border: '1px solid var(--border-color)',
+  },
+  copyBtn: {
+    position: 'absolute',
+    right: '8px',
+    top: '8px',
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    color: 'var(--color-text-muted)',
+    padding: '4px',
+    borderRadius: '4px',
+  },
+  warningCard: {
+    border: '1px solid #FDE68A',
+    borderRadius: '8px',
+    padding: '12px 16px',
+    marginTop: '16px',
+    backgroundColor: '#FFFBEB',
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
+  tooltip: {
+    position: 'absolute',
+    bottom: '135%',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    backgroundColor: '#1E293B',
+    color: '#FFFFFF',
+    padding: '8px 12px',
+    borderRadius: '6px',
+    fontSize: '11px',
+    width: '200px',
+    textAlign: 'center',
+    zIndex: 10,
+    boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+    pointerEvents: 'none',
+    lineHeight: '1.4',
+    fontWeight: 500,
+  }
+};

--- a/frontend/src/features/nodes/RabbitMqNode/RabbitMqNode.tsx
+++ b/frontend/src/features/nodes/RabbitMqNode/RabbitMqNode.tsx
@@ -1,0 +1,57 @@
+import { MessageSquare, Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import BaseNode from '../components/BaseNode';
+import styles from '../ServiceNode.module.css';
+
+interface RabbitMqNodeProps {
+  data: {
+    id: string;
+    name: string;
+    state?: string;
+    lastError?: string;
+    ip?: string;
+    onSecurityGroupOpen?: (id: string, name: string) => void;
+    onInspect: (id: string, name: string) => void;
+    onStop: (id: string) => void;
+    onStart: (id: string) => void;
+    onDelete: (id: string) => void;
+    onRename?: (id: string, currentName: string) => void;
+  };
+}
+
+export default function RabbitMqNode({ data }: RabbitMqNodeProps) {
+  const { t } = useTranslation();
+  const isRunning = data.state === 'running';
+  const accentColor = '#FF6600'; // RabbitMQ Orange
+
+  return (
+    <BaseNode
+      id={data.id}
+      name={data.name}
+      isRunning={isRunning}
+      errorMessage={data.lastError}
+      icon={<MessageSquare size={18} color={isRunning ? accentColor : '#6B7280'} />}
+      customBorder={isRunning ? `1px solid ${accentColor}` : undefined}
+      subtitle={
+        <>
+          <span className={styles.label}>{t('nodeviz.ipPort')}</span>
+          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>
+            {data.ip ? `${data.ip}:5672` : '5672 / 15672'}
+          </span>
+        </>
+      }
+      onStart={data.onStart}
+      onStop={data.onStop}
+      onDelete={data.onDelete}
+      onRename={data.onRename}
+      onSecurityGroupOpen={data.onSecurityGroupOpen}
+      primaryAction={{
+        label: t('nodeviz.inspect'),
+        icon: <Search size={14} />,
+        color: accentColor,
+        onClick: data.onInspect,
+        title: t('nodeviz.inspectRabbitmqTitle'),
+      }}
+    />
+  );
+}

--- a/frontend/src/features/nodes/RabbitMqNode/data/rabbitmqCheatSheet.json
+++ b/frontend/src/features/nodes/RabbitMqNode/data/rabbitmqCheatSheet.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "Exchange",
+    "category": "Concepts",
+    "description": "Receives messages from producers and routes them to queues based on exchange type and bindings.",
+    "example": "Types: Direct (routing key match), Fanout (broadcast), Topic (pattern match), Headers."
+  },
+  {
+    "name": "Queue",
+    "category": "Concepts",
+    "description": "A buffer that stores messages. Messages are pushed to queues by exchanges and consumed by clients.",
+    "example": "Queues can be Durable (survive broker restart), Auto-delete, or Exclusive."
+  },
+  {
+    "name": "Binding",
+    "category": "Concepts",
+    "description": "A link that connects a queue to an exchange. It defines the routing rules for incoming messages.",
+    "example": "Queue 'orders-queue' bound to exchange 'amq.direct' with routing key 'order.created'."
+  },
+  {
+    "name": "List Queues",
+    "category": "CLI Administration",
+    "description": "List all active queues along with the count of ready and unacknowledged messages.",
+    "example": "rabbitmqctl list_queues name messages_ready messages_unacknowledged"
+  },
+  {
+    "name": "List Exchanges",
+    "category": "CLI Administration",
+    "description": "List all declared exchanges along with their type and durability settings.",
+    "example": "rabbitmqctl list_exchanges name type durable"
+  },
+  {
+    "name": "List Bindings",
+    "category": "CLI Administration",
+    "description": "List all bindings showing how exchanges route messages to queues.",
+    "example": "rabbitmqctl list_bindings"
+  },
+  {
+    "name": "Broker Status",
+    "category": "CLI Administration",
+    "description": "Check the health and runtime status of the RabbitMQ node.",
+    "example": "rabbitmqctl status"
+  },
+  {
+    "name": "Node.js Publish",
+    "category": "JavaScript (amqplib)",
+    "description": "Publish a message to an exchange with a routing key using the amqplib package.",
+    "example": "const amqp = require('amqplib');\nconst conn = await amqp.connect('amqp://localhost');\nconst ch = await conn.createChannel();\nconst ex = 'logs';\nawait ch.assertExchange(ex, 'fanout', { durable: false });\nch.publish(ex, '', Buffer.from('Hello World!'));\nconsole.log('Sent Hello World!');\nsetTimeout(() => { conn.close(); }, 500);"
+  },
+  {
+    "name": "Node.js Consume",
+    "category": "JavaScript (amqplib)",
+    "description": "Declare a queue and consume messages asynchronously from it.",
+    "example": "const amqp = require('amqplib');\nconst conn = await amqp.connect('amqp://localhost');\nconst ch = await conn.createChannel();\nconst q = 'hello';\nawait ch.assertQueue(q, { durable: false });\nconsole.log('Waiting for messages...');\nch.consume(q, (msg) => {\n  console.log('Received:', msg.content.toString());\n}, { noAck: true });"
+  },
+  {
+    "name": "Python Publish",
+    "category": "Python (pika)",
+    "description": "Connect to RabbitMQ and publish a message to a direct queue using pika.",
+    "example": "import pika\nconnection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))\nchannel = connection.channel()\nchannel.queue_declare(queue='hello')\nchannel.basic_publish(exchange='', routing_key='hello', body='Hello World!')\nprint(\"Sent 'Hello World!'\")\nconnection.close()"
+  },
+  {
+    "name": "Python Consume",
+    "category": "Python (pika)",
+    "description": "Subscribe to a queue and print received messages.",
+    "example": "import pika, sys\nconnection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))\nchannel = connection.channel()\nchannel.queue_declare(queue='hello')\ndef callback(ch, method, properties, body):\n    print(f\"Received {body.decode()}\")\nchannel.basic_consume(queue='hello', on_message_callback=callback, auto_ack=True)\nprint('Waiting for messages. To exit press CTRL+C')\nchannel.start_consuming()"
+  }
+]

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -236,6 +236,41 @@
       "placeholder": "Search Redis commands or concepts..."
     }
   },
+  "rabbitmq": {
+    "tabs": {
+      "details": "Details",
+      "cheatsheet": "Cheat Sheet"
+    },
+    "details": {
+      "title": "RabbitMQ Broker Details",
+      "desc": "Message broker and queues backed by a real RabbitMQ container with the Management Console enabled.",
+      "imageLabel": "Image",
+      "nodeNameLabel": "Node Name",
+      "internalIpLabel": "Internal IP",
+      "notAssigned": "Not Assigned",
+      "amqpPortLabel": "AMQP Port",
+      "mgmtPortLabel": "Management Port",
+      "consoleUrlLabel": "Console URL",
+      "usernameLabel": "Username",
+      "passwordLabel": "Password",
+      "stateLabel": "State",
+      "openConsoleBtn": "Open Management Console",
+      "running": "Running",
+      "stopped": "Stopped",
+      "startPrompt": "Start the node to access the RabbitMQ Management Console link.",
+      "warning": {
+        "title": "Console connection issue?",
+        "tooltip": "Click the security shield icon on the node in the canvas to configure it",
+        "sgRule": "Ensure you have configured an Inbound Security Group Rule allowing TCP/ALL traffic on port 15672 from source 0.0.0.0/0.",
+        "bootDelay": "Allow 10-15 seconds after starting the container for the RabbitMQ Management UI server to fully initialize.",
+        "amqpRule": "Applications in other subnets connecting via AMQP must have an inbound Security Group rule allowing traffic on port 5672."
+      }
+    },
+    "cheatsheet": {
+      "placeholder": "Search RabbitMQ concepts or commands...",
+      "noMatch": "No matching cheat sheet items found."
+    }
+  },
   "nosql": {
     "tabs": {
       "details": "Details & Config",
@@ -562,6 +597,7 @@
     "natInfoGuideTitle": "View NAT Gateway details & guide",
     "inspectDatabaseTitle": "Inspect Database Explorer / Shell",
     "inspectRedisTitle": "Inspect Redis Keys / Shell",
+    "inspectRabbitmqTitle": "Inspect RabbitMQ / Console",
     "terminal": "Terminal",
     "openTerminal": "Open Terminal",
     "publicSubnet": "Public Subnet",
@@ -646,7 +682,8 @@
     "categories": {
       "networking": "Networking",
       "compute": "Compute",
-      "databases": "Databases"
+      "databases": "Databases",
+      "messageBrokers": "Message Brokers"
     },
     "types": {
       "subnet-public": {
@@ -684,6 +721,10 @@
       "redis": {
         "name": "Cache Store",
         "desc": "In-memory key-value cache"
+      },
+      "rabbitmq": {
+        "name": "RabbitMQ",
+        "desc": "Message broker & queues"
       }
     },
     "createNode": {
@@ -694,6 +735,7 @@
         "postgres": "Create SQL Database Node",
         "nosql": "Create NoSQL Database Node",
         "redis": "Create Cache Store Node",
+        "rabbitmq": "Create Message Broker Node",
         "nat": "Create NAT Gateway Node",
         "loadbalancer": "Create Load Balancer Node",
         "autoscalinggroup": "Create Auto Scaling Group Node"
@@ -703,6 +745,7 @@
         "postgres": "e.g. sql-1",
         "nosql": "e.g. nosql-1",
         "redis": "e.g. redis-1",
+        "rabbitmq": "e.g. mq-1",
         "nat": "e.g. nat-1",
         "loadbalancer": "e.g. alb-1",
         "autoscalinggroup": "e.g. asg-1"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -236,6 +236,41 @@
       "placeholder": "Rechercher des commandes ou concepts Redis..."
     }
   },
+  "rabbitmq": {
+    "tabs": {
+      "details": "Détails",
+      "cheatsheet": "Aide-mémoire"
+    },
+    "details": {
+      "title": "Détails du Courtier RabbitMQ",
+      "desc": "Courtier de messages et files d'attente adossé à un vrai conteneur RabbitMQ avec la console de gestion activée.",
+      "imageLabel": "Image",
+      "nodeNameLabel": "Nom du Nœud",
+      "internalIpLabel": "IP Interne",
+      "notAssigned": "Non assignée",
+      "amqpPortLabel": "Port AMQP",
+      "mgmtPortLabel": "Port de Gestion",
+      "consoleUrlLabel": "URL de la Console",
+      "usernameLabel": "Identifiant",
+      "passwordLabel": "Mot de passe",
+      "stateLabel": "État",
+      "openConsoleBtn": "Ouvrir la Console de Gestion",
+      "running": "En cours d'exécution",
+      "stopped": "Arrêté",
+      "startPrompt": "Démarrez le nœud pour accéder au lien de la Console de Gestion RabbitMQ.",
+      "warning": {
+        "title": "Problème de connexion à la console ?",
+        "tooltip": "Cliquez sur l'icône du bouclier de sécurité sur le nœud dans le canvas pour la configurer",
+        "sgRule": "Assurez-vous d'avoir configuré une règle de groupe de sécurité entrante autorisant le trafic TCP/ALL sur le port 15672 depuis la source 0.0.0.0/0.",
+        "bootDelay": "Laissez 10 à 15 secondes après le démarrage du conteneur pour que le serveur de l'interface de gestion RabbitMQ s'initialise complètement.",
+        "amqpRule": "Les applications d'autres sous-réseaux se connectant via AMQP doivent avoir une règle de groupe de sécurité entrante autorisant le trafic sur le port 5672."
+      }
+    },
+    "cheatsheet": {
+      "placeholder": "Rechercher des concepts ou commandes RabbitMQ...",
+      "noMatch": "Aucun élément d'aide-mémoire correspondant trouvé."
+    }
+  },
   "nosql": {
     "tabs": {
       "details": "Détails & Config",
@@ -562,6 +597,7 @@
     "natInfoGuideTitle": "Voir les détails et le guide de la passerelle NAT",
     "inspectDatabaseTitle": "Inspecter l'explorateur de base de données / le shell",
     "inspectRedisTitle": "Inspecter les clés Redis / le shell",
+    "inspectRabbitmqTitle": "Inspecter RabbitMQ / la console",
     "terminal": "Terminal",
     "openTerminal": "Ouvrir le terminal",
     "publicSubnet": "Sous-réseau public",
@@ -646,7 +682,8 @@
     "categories": {
       "networking": "Réseau",
       "compute": "Calcul",
-      "databases": "Bases de données"
+      "databases": "Bases de données",
+      "messageBrokers": "Courtiers de messages"
     },
     "types": {
       "subnet-public": {
@@ -684,6 +721,10 @@
       "redis": {
         "name": "Cache",
         "desc": "Cache clé-valeur en mémoire"
+      },
+      "rabbitmq": {
+        "name": "RabbitMQ",
+        "desc": "Courtier de messages & files"
       }
     },
     "createNode": {
@@ -694,6 +735,7 @@
         "postgres": "Créer un nœud Base de données SQL",
         "nosql": "Créer un nœud Base de données NoSQL",
         "redis": "Créer un nœud Cache",
+        "rabbitmq": "Créer un nœud Courtier de messages",
         "nat": "Créer un nœud Passerelle NAT",
         "loadbalancer": "Créer un nœud Répartiteur de charge",
         "autoscalinggroup": "Créer un nœud Groupe d'auto-scaling"
@@ -703,6 +745,7 @@
         "postgres": "ex. sql-1",
         "nosql": "ex. nosql-1",
         "redis": "ex. redis-1",
+        "rabbitmq": "ex. mq-1",
         "nat": "ex. nat-1",
         "loadbalancer": "ex. alb-1",
         "autoscalinggroup": "ex. asg-1"

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -9,6 +9,7 @@ import NatNode from '../../features/nodes/NatNode/NatNode';
 import PostgresNode from '../../features/nodes/PostgresNode/PostgresNode';
 import NoSqlNode from '../../features/nodes/NoSqlNode/NoSqlNode';
 import RedisNode from '../../features/nodes/RedisNode/RedisNode';
+import RabbitMqNode from '../../features/nodes/RabbitMqNode/RabbitMqNode';
 import LoadBalancerNode from '../../features/nodes/LoadBalancerNode/LoadBalancerNode';
 import AsgNode from '../../features/nodes/AsgNode/AsgNode';
 import VpcNode from '../../features/nodes/VpcNode/VpcNode';
@@ -50,6 +51,7 @@ const INSPECTOR_KIND_BY_NODE_TYPE: Record<string, InspectorState['kind']> = {
   sql: 'postgres',
   nosql: 'nosql',
   redis: 'redis',
+  rabbitmq: 'rabbitmq',
   nat: 'nat',
   loadbalancer: 'loadbalancer',
   autoscalinggroup: 'asg',
@@ -129,6 +131,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     sql: PostgresNode,
     nosql: NoSqlNode,
     redis: RedisNode,
+    rabbitmq: RabbitMqNode,
     nat: NatNode,
     vpc: VpcNode,
     subnet: SubnetNode,

--- a/frontend/src/pages/CanvasPage/components/CanvasModals.tsx
+++ b/frontend/src/pages/CanvasPage/components/CanvasModals.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import PostgresModal from '../../../features/nodes/PostgresNode/PostgresModal';
 import NoSqlModal from '../../../features/nodes/NoSqlNode/NoSqlModal';
 import RedisModal from '../../../features/nodes/RedisNode/RedisModal';
+import RabbitMqModal from '../../../features/nodes/RabbitMqNode/RabbitMqModal';
 import NatGatewayModal from '../../../features/nodes/NatNode/NatGatewayModal';
 import LoadBalancerModal from '../../../features/nodes/LoadBalancerNode/LoadBalancerModal';
 import AsgModal from '../../../features/nodes/AsgNode/AsgModal';
@@ -16,7 +17,7 @@ import type { NetworkConfig } from '../../../shared/types/network';
 
 /** Which inspector modal is open. They are mutually exclusive, hence one state. */
 export interface InspectorState {
-  kind: 'postgres' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'asg' | 'subnet-routes' | 'security-group';
+  kind: 'postgres' | 'nosql' | 'redis' | 'rabbitmq' | 'nat' | 'loadbalancer' | 'asg' | 'subnet-routes' | 'security-group';
   id: string;
   name: string;
   /** Only set for kind 'security-group' (the modal displays the node type). */
@@ -136,6 +137,16 @@ export default function CanvasModals({
           containerId={inspector.id}
           nodeName={inspector.name}
           projectId={projectId}
+          onClose={onCloseInspector}
+        />
+      )}
+
+      {inspector?.kind === 'rabbitmq' && (
+        <RabbitMqModal
+          nodeName={inspector.name}
+          port={containers.find(c => c.id === inspector.id)?.port}
+          ipAddress={networkConfig.nodeIpMap?.[inspector.id]}
+          state={containers.find(c => c.id === inspector.id)?.state || 'stopped'}
           onClose={onCloseInspector}
         />
       )}

--- a/frontend/src/pages/CanvasPage/components/CreateNodeModal.tsx
+++ b/frontend/src/pages/CanvasPage/components/CreateNodeModal.tsx
@@ -8,6 +8,7 @@ const META_BY_TYPE: Record<string, { titleKey: string; placeholderKey: string; p
   sql: { titleKey: 'nodeLibrary.createNode.titles.postgres', placeholderKey: 'nodeLibrary.createNode.placeholders.postgres', prefix: 'sql-' },
   nosql: { titleKey: 'nodeLibrary.createNode.titles.nosql', placeholderKey: 'nodeLibrary.createNode.placeholders.nosql', prefix: 'nosql-' },
   redis: { titleKey: 'nodeLibrary.createNode.titles.redis', placeholderKey: 'nodeLibrary.createNode.placeholders.redis', prefix: 'redis-' },
+  rabbitmq: { titleKey: 'nodeLibrary.createNode.titles.rabbitmq', placeholderKey: 'nodeLibrary.createNode.placeholders.rabbitmq', prefix: 'mq-' },
   nat: { titleKey: 'nodeLibrary.createNode.titles.nat', placeholderKey: 'nodeLibrary.createNode.placeholders.nat', prefix: 'nat-' },
   loadbalancer: { titleKey: 'nodeLibrary.createNode.titles.loadbalancer', placeholderKey: 'nodeLibrary.createNode.placeholders.loadbalancer', prefix: 'alb-' },
   autoscalinggroup: { titleKey: 'nodeLibrary.createNode.titles.autoscalinggroup', placeholderKey: 'nodeLibrary.createNode.placeholders.autoscalinggroup', prefix: 'asg-' },

--- a/frontend/src/pages/CanvasPage/components/NodeLibrary.tsx
+++ b/frontend/src/pages/CanvasPage/components/NodeLibrary.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronLeft, ChevronRight, Database, Library, Network, Search, GitFork, Braces, Layers, ArrowRightLeft, Cpu } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Database, Library, Network, Search, GitFork, Braces, Layers, ArrowRightLeft, Cpu, MessageSquare } from 'lucide-react';
 
 interface NodeLibraryProps {
   onCollapseChange?: (collapsed: boolean) => void;
@@ -98,6 +98,18 @@ export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
           desc: t('nodeLibrary.types.redis.desc'),
           icon: <Database size={18} color="#DC2626" />,
           collapsedIcon: <Database size={20} color="#DC2626" />
+        }
+      ]
+    },
+    {
+      title: t('nodeLibrary.categories.messageBrokers'),
+      nodes: [
+        {
+          type: 'rabbitmq',
+          name: t('nodeLibrary.types.rabbitmq.name'),
+          desc: t('nodeLibrary.types.rabbitmq.desc'),
+          icon: <MessageSquare size={18} color="#FF6600" />,
+          collapsedIcon: <MessageSquare size={20} color="#FF6600" />
         }
       ]
     }

--- a/frontend/src/pages/CanvasPage/utils/securityRules.ts
+++ b/frontend/src/pages/CanvasPage/utils/securityRules.ts
@@ -32,12 +32,13 @@ export function createDefaultRules(): SecurityGroupRule[] {
 
 /** Inbound ALLOW rule for a manual connection, with the target type's default port. */
 export function buildConnectionRule(sourceId: string, targetType: string): SecurityGroupRule {
-  const isDb = ['postgres', 'sql', 'nosql', 'mysql', 'redis'].includes(targetType);
+  const isDb = ['postgres', 'sql', 'nosql', 'mysql', 'redis', 'rabbitmq'].includes(targetType);
   const port =
     (targetType === 'postgres' || targetType === 'sql') ? '5432'
       : targetType === 'nosql' ? '27017'
       : targetType === 'mysql' ? '3306'
       : targetType === 'redis' ? '6379'
+      : targetType === 'rabbitmq' ? '5672'
       : 'ALL';
 
   return {

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -5,7 +5,7 @@ export interface ContainerData {
   name: string;
   state: string;
   status: string;
-  type?: 'ubuntu' | 'postgres' | 'mysql' | 'sql' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'autoscalinggroup';
+  type?: 'ubuntu' | 'postgres' | 'mysql' | 'sql' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'autoscalinggroup' | 'rabbitmq';
   port?: string;
   ip?: string;
   image?: string;

--- a/frontend/src/shared/utils/architectureValidator.ts
+++ b/frontend/src/shared/utils/architectureValidator.ts
@@ -30,9 +30,10 @@ export function validateArchitecture(
   const successes: ValidationMessage[] = [];
 
   const dbTypes = ['postgres', 'sql', 'nosql', 'mysql'];
-  // Data stores that should be kept private and never exposed publicly. Redis is a
-  // cache rather than a relational DB tier, so it is tracked separately from dbTypes.
-  const sensitiveTypes = [...dbTypes, 'redis'];
+  // Data stores and message brokers that should be kept private and never exposed
+  // publicly. Redis (cache) and RabbitMQ (broker) are not relational DB tiers, so
+  // they are tracked separately from dbTypes.
+  const sensitiveTypes = [...dbTypes, 'redis', 'rabbitmq'];
 
   // --- 1. ERROR CHECKS ---
   


### PR DESCRIPTION
## Description

This PR implements and integrates the **RabbitMQ message broker** node type into the system architecture canvas.

closes #45 

### Why is this needed?
Previously, users were unable to practice designing systems with asynchronous queues, publish-subscribe topologies, or message routing keys on the canvas. Adding a dedicated RabbitMQ broker node enables these learning flows with an integrated management dashboard and interactive cheat sheets.

---

## Key Features

1. **Official RabbitMQ Integration**: Pulls and provisions `rabbitmq:3-management` containers, enabling the AMQP protocol on port `5672` and the HTTP management web interface on port `15672`.
2. **Network Bridge Persistence**: Adjusts the `dockerNetworkProvider.ts` policy mapping so RabbitMQ containers retain their connection to the default `akal-lab-network` bridge. This prevents port forwarding/mapped host links (`http://localhost:<mapped_port>`) from being disconnected by subnet isolation policies.
3. **Interactive Inspection Modal**: Features a two-tab drawer (`RabbitMqModal.tsx`):
   - **Details**: Exposes node state, dynamic console ports, default administrative credentials (`guest` / `guest`), and a launch button.
   - **Cheat Sheet**: Explains core concepts (Exchanges, Queues, Bindings) and provides copy-pasteable client code snippets for Node.js (`amqplib`) and Python (`pika`).
4. **UX Tooltips & Connection Warnings**:
   - Includes a state-driven, instant hover tooltip built with React next to the inbound firewall warning directing users where to configure security rules.
   - Alerts users of container boot latency (~15 seconds) and the list of ports that must be opened in security groups (port `15672` for host console access, and port `5672` for client applications in other subnets).
5. **Security Group Validation**: Registers `rabbitmq` as a sensitive infrastructure type in the `architectureValidator.ts` engine, flagging warnings if placed in a public subnet or directly exposed to `0.0.0.0/0`.

---

## Changed Files

### Backend
- `backend/src/infrastructure/docker/ContainerManager.ts` (RabbitMQ image constants, pull helper, and container options configuration)
- `backend/src/modules/network/providers/dockerNetworkProvider.ts` (Bridged network policy retention and reconnect exemptions)

### Frontend
- `frontend/src/features/nodes/RabbitMqNode/RabbitMqNode.tsx` [NEW] (RabbitMQ card component composing `BaseNode` layout)
- `frontend/src/features/nodes/RabbitMqNode/RabbitMqModal.tsx` [NEW] (Inspector overlay with details, warnings, and code cheat sheets)
- `frontend/src/features/nodes/RabbitMqNode/data/rabbitmqCheatSheet.json` [NEW] (Concepts definitions and client developer snippets)
- `frontend/src/pages/CanvasPage/components/NodeLibrary.tsx` (Added a new "Message Brokers" category for palette placement)
- `frontend/src/pages/CanvasPage/CanvasPage.tsx` (Wired node type hooks, inspected modals hooks, drop defaults)
- `frontend/src/shared/types/index.ts` (Extended `ContainerData` type union to include `'rabbitmq'`)
- `frontend/src/shared/utils/architectureValidator.ts` (Added `rabbitmq` type to `sensitiveTypes` array)

### Localization / Resources
- `frontend/src/locales/en.json` (English translation keys for tabs, labels, and tooltips)
- `frontend/src/locales/fr.json` (French translation keys matching English specifications)

---

## Pull Request Checklist

- [x] `type` string is lowercase and identical across palette, `nodeTypes`, API, labels, and unions.
- [x] Backend: image tag, `ensure<X>Image()`, image selection branch, port mapping, `ContainerInfo` union.
- [x] Frontend: `<X>Node.tsx` (via `BaseNode`), `nodeTypes`, `NodeLibrary`, `ContainerData` union, drop placeholder.
- [x] Inspector modal & backend explorer wired (or intentionally omitted).
- [x] Both frontend and backend build; tests pass.
- [x] Manually verified the full lifecycle.
- [x] Manually ran `npm run lint` on frontend & backend and verified that there are no lint warnings
- [x] Conventional Commit message.