### PR TITLE
Othmane/canvas position id keying

### DIFF
--- a/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
@@ -86,8 +86,10 @@ function buildFetchMock({ containers = [] as unknown[], networkConfig }: { conta
     if (url.includes('/rename')) return jsonResponse(true, {});
     if (method === 'DELETE') return jsonResponse(true, {});
     if (method === 'POST') return jsonResponse(true, {});
-    // GET containers list
-    return jsonResponse(true, containers);
+    // GET containers list — return a fresh array each time, like res.json()
+    // on a real response, so stateful mutations of `containers` in a test are
+    // seen as a new state by React instead of bailing out on the same ref.
+    return jsonResponse(true, [...containers]);
   });
 }
 

--- a/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
@@ -200,7 +200,8 @@ describe('CanvasPage', () => {
     expect(screen.queryByText('Give your new container a descriptive name.')).not.toBeInTheDocument();
   });
 
-  it('shows the delete confirmation for a node, and only deletes on confirm', async () => {
+  it('shows the delete confirmation for a node, only deletes on confirm, and drops its saved layout position', async () => {
+    localStorage.setItem('akal-lab-graph-layout-p1', JSON.stringify({ c1: { x: 60, y: 60 } }));
     const networkConfig = {
       vpcConfig: validVpcConfig,
       subnets: [{ id: 'subnet-1', name: 'Public Subnet-1', type: 'public', vpcId: 'root-vpc', position: { x: 0, y: 0 }, width: 680, height: 260, columns: 2, rows: 1, routes: [] }],
@@ -208,9 +209,14 @@ describe('CanvasPage', () => {
       nodeSecurityGroups: {},
       nodeIpMap: { c1: '10.0.1.2' },
     };
-    const fetchMock = buildFetchMock({
-      containers: [{ id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' }],
-      networkConfig,
+    const containers = [{ id: 'c1', name: 'web-1', state: 'running', status: 'running', type: 'ubuntu' }];
+    const fetchMock = buildFetchMock({ containers, networkConfig });
+    // Stateful mock: after a successful delete, subsequent container fetches
+    // must no longer return the node, like the real backend would.
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') containers.length = 0;
+      return base(url, init);
     });
     await renderCanvasPage(fetchMock);
 
@@ -228,9 +234,13 @@ describe('CanvasPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     await waitFor(() => expect(fetchMock.mock.calls.some(c => (c[1] as RequestInit | undefined)?.method === 'DELETE')).toBe(true));
+    await waitFor(() => {
+      const layout = JSON.parse(localStorage.getItem('akal-lab-graph-layout-p1')!);
+      expect(layout['c1']).toBeUndefined();
+    });
   });
 
-  it('renames a stopped node via PATCH and migrates its saved layout position to the new name', async () => {
+  it('renames a stopped node via PATCH and keeps its saved layout position under the container id', async () => {
     const networkConfig = {
       vpcConfig: validVpcConfig,
       subnets: [subnetFixture()],
@@ -266,8 +276,9 @@ describe('CanvasPage', () => {
 
     await waitFor(() => {
       const layout = JSON.parse(localStorage.getItem('akal-lab-graph-layout-p1')!);
-      expect(layout['web-2']).toBeDefined();
+      expect(layout['c1']).toBeDefined();
       expect(layout['web-1']).toBeUndefined();
+      expect(layout['web-2']).toBeUndefined();
     });
   });
 
@@ -460,12 +471,8 @@ describe('CanvasPage', () => {
   });
 
   it('blocks shrinking a subnet grid over an occupied cell, naming the blocking node', async () => {
-    // The shrink guard reads positions keyed by container ID, while the canvas
-    // sync effect keys them by name — seed the saved layout with both so the
-    // fixture stays valid regardless of which key each code path reads.
     localStorage.setItem('akal-lab-graph-layout-p1', JSON.stringify({
       c1: { x: 60 + 2 * 340, y: 60 },
-      'web-1': { x: 60 + 2 * 340, y: 60 },
     }));
     const networkConfig = {
       vpcConfig: validVpcConfig,

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -641,10 +641,13 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         const defaultX = 150 + (index % 3) * 280;
         const defaultY = 150 + Math.floor(index / 3) * 220;
 
-        const savedPos = positionsRef.current[c.name];
+        const savedPos = positionsRef.current[c.id];
+        // dropPositionsRef is keyed by name: at drop time the container does
+        // not exist yet, so the name is the only handle. Consume it here and
+        // re-key the position by id like everything else.
         const dropPos = dropPositionsRef.current[c.name];
         if (dropPos) {
-          positionsRef.current[c.name] = dropPos;
+          positionsRef.current[c.id] = dropPos;
           delete dropPositionsRef.current[c.name];
         }
 
@@ -659,7 +662,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           const cols = subnet?.columns || 2;
           const rows = subnet?.rows || 1;
 
-          const pos = positionsRef.current[c.name];
+          const pos = positionsRef.current[c.id];
           let col = -1;
           let row = -1;
           if (pos) {
@@ -671,7 +674,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
             return containers.filter(node => !node.isAsgInstance).some(node => {
               if (node.id === excludeId) return false;
               if (updatedNodeSubnetMap[node.id] !== parentId) return false;
-              const nodePos = positionsRef.current[node.name];
+              const nodePos = positionsRef.current[node.id];
               if (!nodePos) return false;
               const nCol = Math.round((nodePos.x - 60) / 340);
               const nRow = Math.round((nodePos.y - 60) / 190);
@@ -702,7 +705,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
             x: 60 + col * 340,
             y: 60 + row * 190
           };
-          positionsRef.current[c.name] = position;
+          positionsRef.current[c.id] = position;
         }
 
         const nodeType = c.type || 'ubuntu';
@@ -1043,8 +1046,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         const col = Math.max(0, Math.min(cols - 1, Math.round((relX - 60) / 340)));
         const row = Math.max(0, Math.min(rows - 1, Math.round((relY - 60) / 190)));
 
-        const key = (draggedNode.type === 'subnet' ? draggedNode.id : draggedNode.data?.name) as string;
-        positionsRef.current[key] = {
+        positionsRef.current[draggedNode.id] = {
           x: 60 + col * 340,
           y: 60 + row * 190
         };
@@ -1239,14 +1241,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     } catch {
       showNotification({ type: 'error', message: 'Rename failed: could not reach the server.' });
       return;
-    }
-
-    // Migrate the position key from the old name to the new name so the node
-    // does not lose its canvas position after being renamed.
-    if (positionsRef.current[currentName]) {
-      positionsRef.current[trimmedNewName] = positionsRef.current[currentName];
-      delete positionsRef.current[currentName];
-      localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
     }
 
     setRenamingNode(null);


### PR DESCRIPTION
## Summary of Changes

Canvas node positions (`positionsRef`, persisted to `localStorage['akal-lab-graph-layout-<projectId>']`) were keyed by container **name** in the main flow (sync effect, drag handler, rename migration) but by Docker container **id** in three other paths (subnet shrink guard, delete cleanup, Save Graph). This mixed keying caused entity-continuity bugs on the canvas:

- the subnet shrink guard read id keys the normal flow never wrote, so it was inoperative unless "Save Graph" had been clicked;
- after "Save Graph", the persisted layout switched to id keys, so positions were not restored on reload;
- deleting a container removed the (usually absent) id key and left a ghost name key behind.

This PR standardizes on the **Docker container id**, which is stable across renames and already keys `nodeSubnetMap`/`nodeSecurityGroups`/`nodeIpMap`:

- the sync effect and drag-stop handler now read/write positions by id (the drag-stop `subnet ? id : name` ternary was dead code — the subnet branch returns earlier — and was removed);
- the rename position-migration block is deleted: id-keyed positions survive renames on their own;
- `dropPositionsRef` intentionally stays name-keyed as the drop-to-creation bridge (no id exists at drop time); it is consumed in the sync effect and re-keyed by id.

Old name-keyed layouts in localStorage are deliberately **not migrated** (clean break): nodes fall back once to the grid auto-layout, then re-persist under ids.

Also fixes a test-fixture bug: the fetch mock returned the same `containers` array reference on every GET, so stateful fixture mutations (rename/delete) never re-triggered the canvas sync effect (`setContainers` bailed out on `Object.is`), unlike the real backend which returns fresh JSON per response.

## Types of Changes

- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Test updates: the rename test now asserts the position stays under the container id (no name-keyed entries), the shrink-guard fixture no longer needs to seed both key shapes, and the delete test now asserts the persisted layout entry
is removed (previously uncovered). Suite: 107 tests green.

### Manual Verification

Drove the real app end-to-end (backend + Vite + real Docker containers, headless Chrome via CDP):

- seeded a layout keyed by container id at grid column 2 → node rendered at the seeded position, and er a page reload;
- clicked "Reduce Columns" over the occupied cell → the shrink guard blocked with the expected notification, without having clicked "Save Graph" first (previously broken);
- renamed the container via `PATCH /rename` → position kept under the (unchanged) id, no name-keyed e
- deleted the node via the UI → its entry disappeared from the persisted layout.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing