### PR TITLE
test: document and verify iptables/iproute2 requirement in node images

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,52 @@
+# Verifies that every node image ships iptables/iproute2 (required for Security
+# Group enforcement) — see docs/adding-a-node.md#required-tooling-inside-every-node-image.
+#
+# This pulls the real images from Docker Hub, so it only runs when something that
+# affects them changes. Image pushes to Docker Hub happen outside this repo and
+# can't trigger CI — use "Run workflow" (workflow_dispatch) after publishing one.
+name: Integration
+
+on:
+  push:
+    branches: [ main, dev ]
+    paths:
+      - 'backend/src/infrastructure/docker/nodeTypes.ts'
+      - 'backend/src/infrastructure/docker/imageRequirements.itest.ts'
+      - 'backend/jest.integration.config.js'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - '.github/workflows/integration.yml'
+  pull_request:
+    branches: [ main, dev ]
+    paths:
+      - 'backend/src/infrastructure/docker/nodeTypes.ts'
+      - 'backend/src/infrastructure/docker/imageRequirements.itest.ts'
+      - 'backend/jest.integration.config.js'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - '.github/workflows/integration.yml'
+  workflow_dispatch:
+
+jobs:
+  backend-integration-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: backend/package-lock.json
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Run Integration Tests
+      run: npm run test:integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This document provides guidelines and steps for contributing to this project.
 *   **Reporting Bugs:** If you find a bug, please open an issue and describe the steps to reproduce it, what you expected to happen, and what actually happened.
 *   **Suggesting Enhancements:** Have an idea for a new feature? Open an issue to discuss it before you start coding!
 *   **Code Contributions:** We welcome pull requests! Whether it's fixing a typo, resolving a bug, or building a new feature.
-*   **Adding a New Node:** Want to add a new piece of infrastructure to the canvas (a database, cache, broker, …)? Follow our step-by-step [Adding a New Node](docs/adding-a-node.md) guide, which also documents our code standards.
+*   **Adding a New Node:** Want to add a new piece of infrastructure to the canvas (a database, cache, broker, …)? Follow our step-by-step [Adding a New Node](docs/adding-a-node.md) guide, which also documents our code standards and the [tooling every node image must ship](docs/adding-a-node.md#required-tooling-inside-every-node-image) (`iptables` + `iproute2`).
 *   **Documentation:** Improving our documentation is just as important as writing code.
 
 ## Local Development Setup

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Instead of reading passive, theory-heavy documentation, you learn by *doing*:
 - **Web Terminals:** Instantly open a root shell into any Ubuntu or Database container straight from the browser.
 
 ### Architecture Overview
-*   **Backend:** Node.js, Express, TypeScript, and Dockerode. The backend acts as the supervisor—it manipulates the local Docker daemon, compiles your visual network topology into real `iptables` rules, and manages persistent state in `~/.torollo/projects.json`.
+*   **Backend:** Node.js, Express, TypeScript, and Dockerode. The backend acts as the supervisor—it manipulates the local Docker daemon, compiles your visual network topology into real `iptables` rules, and manages persistent state in `~/.torollo/projects.json`. Because those rules are applied *inside* the containers, every node image must ship with `iptables` and `iproute2` installed — see [Required tooling inside every node image](docs/adding-a-node.md#required-tooling-inside-every-node-image).
 *   **Frontend:** React, TypeScript, Vite, and React Flow. Renders the interactive visual grid, node inspector modals, database explorers, and `xterm.js` terminals.
 
 ---

--- a/backend/jest.integration.config.js
+++ b/backend/jest.integration.config.js
@@ -1,0 +1,12 @@
+// Integration tests talk to a real Docker daemon and are run explicitly via
+// `npm run test:integration` — they are kept out of the default `npm test` run.
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.itest.ts'],
+  verbose: true,
+  forceExit: true,
+  collectCoverage: false,
+  // Generous per-test budget: a cold run may need to pull multi-hundred-MB images.
+  testTimeout: 300000
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "dev": "nodemon --watch src --ext ts --exec ts-node src/server.ts",
     "lint": "eslint .",
     "test": "jest",
+    "test:integration": "jest --config jest.integration.config.js",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/backend/src/infrastructure/docker/imageRequirements.itest.ts
+++ b/backend/src/infrastructure/docker/imageRequirements.itest.ts
@@ -1,0 +1,73 @@
+import docker from './DockerClient';
+import { NODE_TYPES } from './nodeTypes';
+
+/**
+ * Integration tests (run with `npm run test:integration`, requires a Docker daemon).
+ *
+ * The backend enforces Security Groups and routing by exec-ing `iptables` and
+ * `ip route` inside every lab container (see dockerNetworkProvider.applyPlan).
+ * These tests verify that every image declared in the NODE_TYPES registry ships
+ * both tools and that iptables actually works under CAP_NET_ADMIN — the exact
+ * conditions lab containers run with (dockerContainerProvider adds NET_ADMIN,
+ * never full privileges).
+ */
+
+const images = [...new Set(Object.values(NODE_TYPES).map(t => t.image))];
+
+async function ensureImage(image: string): Promise<void> {
+  try {
+    await docker.getImage(image).inspect();
+    return;
+  } catch {
+    // Image not present locally: pull it below.
+  }
+  await new Promise<void>((resolve, reject) => {
+    docker.pull(image, {}, (err, stream) => {
+      if (err) return reject(err);
+      if (!stream) return reject(new Error('Pull stream is undefined'));
+      docker.modem.followProgress(stream, (finishedErr) =>
+        finishedErr ? reject(finishedErr) : resolve()
+      );
+    });
+  });
+}
+
+async function runInImage(image: string, cmd: string): Promise<{ exitCode: number; output: string }> {
+  const container = await docker.createContainer({
+    Image: image,
+    // Override the entrypoint so database images run our check instead of their server.
+    Entrypoint: ['sh', '-c', cmd],
+    // Tty merges stdout/stderr as plain text, so failure logs are readable as-is.
+    Tty: true,
+    HostConfig: { CapAdd: ['NET_ADMIN'] }
+  });
+  try {
+    await container.start();
+    const { StatusCode } = await container.wait();
+    const logs = await container.logs({ stdout: true, stderr: true });
+    return { exitCode: StatusCode, output: logs.toString().trim() };
+  } finally {
+    await container.remove({ force: true }).catch(() => {});
+  }
+}
+
+describe('node image requirements', () => {
+  beforeAll(async () => {
+    try {
+      await docker.ping();
+    } catch {
+      throw new Error(
+        'Docker daemon is not reachable. Integration tests require a running Docker daemon.'
+      );
+    }
+  });
+
+  it.each(images)(
+    '%s ships iptables and iproute2, and iptables works under CAP_NET_ADMIN',
+    async (image) => {
+      await ensureImage(image);
+      const result = await runInImage(image, 'command -v iptables && command -v ip && iptables -S');
+      expect(result).toMatchObject({ exitCode: 0 });
+    }
+  );
+});

--- a/backend/src/modules/network/providers/dockerNetworkProvider.ts
+++ b/backend/src/modules/network/providers/dockerNetworkProvider.ts
@@ -435,10 +435,11 @@ export class DockerNetworkProvider implements NetworkProvider {
       const containerInfo = updatedDockerContainers.find(c => c.Id === containerId);
       if (!containerInfo) return;
 
-      // Check if iptables is available inside this container
-      const hasIptables = await this.runExec(containerId, ['sh', '-c', 'command -v iptables || true']);
-      if (!hasIptables || hasIptables.includes('not found') || hasIptables.trim() === '') {
-        console.warn(`[DockerNetworkProvider] Skipping firewall configuration for container ${containerId.slice(0, 12)} (${ep.containerName}): 'iptables' is not installed.`);
+      // Check that iptables and ip (iproute2) are available inside this container:
+      // both are exec'd below, and a missing 'ip' would otherwise throw mid-plan.
+      const hasNetTools = await this.runExec(containerId, ['sh', '-c', 'command -v iptables >/dev/null 2>&1 && command -v ip >/dev/null 2>&1 && echo ok || true']);
+      if (hasNetTools.trim() !== 'ok') {
+        console.warn(`[DockerNetworkProvider] Skipping firewall configuration for container ${containerId.slice(0, 12)} (${ep.containerName}): 'iptables' and/or 'ip' (iproute2) is not installed. See docs/adding-a-node.md#required-tooling-inside-every-node-image.`);
         return;
       }
 

--- a/docs/adding-a-node.md
+++ b/docs/adding-a-node.md
@@ -74,6 +74,40 @@ Here is the complete list. Nothing else needs to change.
 | `backend/src/infrastructure/docker/ContainerManager.ts` | The image tag, an `ensure<X>Image()` pull helper, the image-selection branch, any custom container options, and the port mapping. This is the **only** file that talks to Docker. |
 | `backend/src/modules/containers/services/containerService.ts` | *(Optional)* An explorer/query method, if your node has an inspector modal (like `getRedisExplorer`). |
 
+#### Required tooling inside every node image
+
+Every image referenced in `backend/src/infrastructure/docker/nodeTypes.ts` — and any custom
+image a user supplies — **must include `iptables` and `iproute2`**. This is not optional:
+the backend enforces Security Groups by exec-ing `iptables` inside the container, and
+programs routing (NAT gateways, VPC routes) with `ip route`. Containers are started with
+`CAP_NET_ADMIN`, so only the binaries are required — the image does not need to run
+privileged.
+
+If the tools are missing, the failure is easy to miss:
+
+- **No `iptables`** → firewall configuration is silently skipped (a warning in the backend
+  logs); the node runs with **no Security Group enforcement at all**.
+- **No `ip` (iproute2)** → routing setup for the node is skipped the same way, so NAT and
+  VPC routes won't apply.
+
+The published `derssa/backend-lab-*:v1` images already ship both tools. If you build your
+own image, either base it on one of those, or add the packages in your Dockerfile:
+
+```dockerfile
+# Debian/Ubuntu-based images
+RUN apt-get update && apt-get install -y iptables iproute2 && rm -rf /var/lib/apt/lists/*
+
+# Alpine-based images
+RUN apk add --no-cache iptables iproute2
+```
+
+To verify an image is correctly configured, run the integration suite (requires a running
+Docker daemon):
+
+```bash
+cd backend && npm run test:integration
+```
+
 ### Frontend
 
 | File | What you add |
@@ -448,6 +482,9 @@ Copy this into your PR description and tick it off:
 
 - [ ] `type` string is lowercase and identical across palette, `nodeTypes`, API, labels, and unions.
 - [ ] Backend: image tag, `ensure<X>Image()`, image selection branch, port mapping, `ContainerInfo` union.
+- [ ] If you added or changed a node image: it includes `iptables` and `iproute2`
+      (see [Required tooling inside every node image](#required-tooling-inside-every-node-image)),
+      and `npm run test:integration` passes.
 - [ ] Frontend: `<X>Node.tsx` (via `BaseNode`), `nodeTypes`, `NodeLibrary`, `ContainerData` union, drop placeholder.
 - [ ] Inspector modal + backend explorer wired (or intentionally omitted).
 - [ ] README "Supported Infrastructure Nodes" list updated.


### PR DESCRIPTION
## Summary of Changes

The backend enforces Security Groups and routing by exec-ing `iptables` and `ip route`
*inside* every lab container. Every node image (the `derssa/backend-lab-*:v1` images in
`nodeTypes.ts`, and any custom image) must therefore ship `iptables` **and** `iproute2` —
this worked only because we published pre-configured images, but the requirement was
undocumented and unverified, a trap for open-source contributors.

This PR:

- **Docs** — adds a canonical [Required tooling inside every node image](/docs/adding-a-node.md#required-tooling-inside-every-node-image)
  section in `docs/adding-a-node.md` (failure modes, apt/apk Dockerfile snippets, how to
  verify), a PR-checklist item, and pointer links from `README.md` and `CONTRIBUTING.md`.
- **Integration tests** — new opt-in suite (`npm run test:integration`, separate Jest
  config, `*.itest.ts`) that runs every unique `NODE_TYPES` image under `CAP_NET_ADMIN`
  and asserts `iptables`/`ip` are present and working — the exact conditions lab
  containers run with. Auto-covers future node types; the default `npm test` is untouched.
- **CI** — dedicated path-filtered `Integration` workflow: runs only when the image
  registry, the suite, its config, or the backend manifests change, plus manual
  `workflow_dispatch` for after publishing a new image to Docker Hub. Note: don't mark it
  as a required status check (it doesn't run on every PR).
- **Fix (from audit)** — `applyPlan`'s pre-check now also detects a missing `ip` binary
  and takes the existing warn-and-skip path instead of throwing mid-plan.

## Types of Changes

- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

- `npm run test:integration` with Docker running: all 5 images pass in ~2s (also
  exercises pull-if-missing on a fresh machine).
- Confirmed `npm test` does **not** pick up the `.itest.ts` file (still 4 suites / 35 tests).
- Negative path: ran the same check against a plain `alpine` image (no iptables) —
  exits 127, so a misconfigured image fails the suite as intended.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing