### PR TITLE
Feature/cidr persistence and validation

### DIFF
--- a/backend/src/infrastructure/docker/DockerInitializer.test.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.test.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import { DockerInitializer } from './DockerInitializer';
+import docker from './DockerClient';
+
+jest.mock('fs');
+jest.mock('./DockerClient', () => ({
+  __esModule: true,
+  default: {
+    listNetworks: jest.fn(),
+    getNetwork: jest.fn(),
+    createNetwork: jest.fn()
+  }
+}));
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+const mockedDocker = docker as jest.Mocked<typeof docker>;
+
+const ensureSharedNetwork = () => (DockerInitializer as any).ensureSharedNetwork();
+
+describe('DockerInitializer.ensureSharedNetwork', () => {
+  const networkHandle = {
+    inspect: jest.fn(),
+    disconnect: jest.fn(),
+    remove: jest.fn()
+  };
+
+  beforeEach(() => {
+    networkHandle.inspect.mockResolvedValue({ Containers: { c1: {} } });
+    networkHandle.disconnect.mockResolvedValue(undefined);
+    networkHandle.remove.mockResolvedValue(undefined);
+    (mockedDocker.getNetwork as jest.Mock).mockReturnValue(networkHandle);
+    (mockedDocker.listNetworks as jest.Mock).mockResolvedValue([
+      { Id: 'n1', Name: 'akal-subnet-project-1-subnet-1' },
+      { Id: 'n2', Name: 'akal-subnet-project-2-subnet-9' },
+      { Id: 'n3', Name: 'akal-lab-network' }
+    ]);
+  });
+
+  it('removes only subnet networks not referenced by any project', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    (mockedFs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify([
+      { id: 'project-1', networkConfig: { subnets: [{ id: 'subnet-1' }] } }
+    ]));
+
+    await ensureSharedNetwork();
+
+    expect(mockedDocker.getNetwork).toHaveBeenCalledTimes(1);
+    expect(mockedDocker.getNetwork).toHaveBeenCalledWith('n2');
+    expect(networkHandle.disconnect).toHaveBeenCalledWith({ Container: 'c1', Force: true });
+    expect(networkHandle.remove).toHaveBeenCalledTimes(1);
+    expect(mockedDocker.createNetwork).not.toHaveBeenCalled();
+  });
+
+  it('skips cleanup entirely when projects.json is corrupt, but still ensures the shared network', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    (mockedFs.readFileSync as jest.Mock).mockReturnValue('{ not valid json');
+    (mockedDocker.listNetworks as jest.Mock).mockResolvedValue([
+      { Id: 'n1', Name: 'akal-subnet-project-1-subnet-1' }
+    ]);
+
+    await ensureSharedNetwork();
+
+    expect(networkHandle.remove).not.toHaveBeenCalled();
+    expect(networkHandle.disconnect).not.toHaveBeenCalled();
+    expect(mockedDocker.createNetwork).toHaveBeenCalledWith({
+      Name: 'akal-lab-network',
+      Driver: 'bridge'
+    });
+  });
+
+  it('skips cleanup when projects.json is not an array', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    (mockedFs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({}));
+
+    await ensureSharedNetwork();
+
+    expect(networkHandle.remove).not.toHaveBeenCalled();
+  });
+
+  it('treats all subnet networks as orphaned when projects.json does not exist', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    await ensureSharedNetwork();
+
+    expect(networkHandle.remove).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/infrastructure/docker/DockerInitializer.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 import docker from './DockerClient';
 import { NODE_TYPES } from './nodeTypes';
 
@@ -24,7 +27,40 @@ export class DockerInitializer {
     try {
       const networks = await docker.listNetworks();
 
-      // Subnet network cleanup removed to allow persistence between npx runs
+      // Clean up orphaned subnet networks (from deleted/wiped projects) on startup
+      const TOROLLO_DIR = path.join(os.homedir(), '.torollo');
+      const DB_PATH = path.join(TOROLLO_DIR, 'projects.json');
+      const activeSubnetNetNames = new Set<string>();
+      if (fs.existsSync(DB_PATH)) {
+        try {
+          const projects = JSON.parse(fs.readFileSync(DB_PATH, 'utf-8'));
+          for (const p of projects) {
+            const subnets = p.networkConfig?.subnets || [];
+            for (const s of subnets) {
+              activeSubnetNetNames.add(`akal-subnet-${p.id}-${s.id}`);
+            }
+          }
+        } catch (err) {
+          console.error('[DockerInitializer] Failed to parse projects.json for orphaned network cleanup:', err);
+        }
+      }
+
+      for (const net of networks) {
+        if (net.Name.startsWith('akal-subnet-') && !activeSubnetNetNames.has(net.Name)) {
+          console.log(`[DockerInitializer] Cleaning up orphaned subnet network: ${net.Name}`);
+          try {
+            const network = docker.getNetwork(net.Id);
+            const netInspect = await network.inspect();
+            const connectedContainers = Object.keys(netInspect.Containers || {});
+            for (const cId of connectedContainers) {
+              await network.disconnect({ Container: cId, Force: true });
+            }
+            await network.remove();
+          } catch (err) {
+            console.error(`Failed to clean up orphaned network ${net.Name}:`, err);
+          }
+        }
+      }
 
       const hasNetwork = networks.some(n => n.Name === 'akal-lab-network');
       if (!hasNetwork) {

--- a/backend/src/infrastructure/docker/DockerInitializer.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.ts
@@ -23,41 +23,53 @@ export class DockerInitializer {
       });
   }
 
+  /**
+   * Names of subnet networks referenced by current projects, or null when
+   * projects.json exists but cannot be parsed. A missing file means no
+   * projects, so every subnet network is a genuine orphan.
+   */
+  private static readActiveSubnetNetworkNames(): Set<string> | null {
+    const dbPath = path.join(os.homedir(), '.torollo', 'projects.json');
+    const names = new Set<string>();
+    if (!fs.existsSync(dbPath)) return names;
+    try {
+      const projects = JSON.parse(fs.readFileSync(dbPath, 'utf-8'));
+      if (!Array.isArray(projects)) throw new Error('projects.json is not an array');
+      for (const p of projects) {
+        for (const s of p.networkConfig?.subnets || []) {
+          names.add(`akal-subnet-${p.id}-${s.id}`);
+        }
+      }
+      return names;
+    } catch (err) {
+      console.error('[DockerInitializer] Failed to parse projects.json for orphaned network cleanup:', err);
+      return null;
+    }
+  }
+
   private static async ensureSharedNetwork(): Promise<void> {
     try {
       const networks = await docker.listNetworks();
 
-      // Clean up orphaned subnet networks (from deleted/wiped projects) on startup
-      const TOROLLO_DIR = path.join(os.homedir(), '.torollo');
-      const DB_PATH = path.join(TOROLLO_DIR, 'projects.json');
-      const activeSubnetNetNames = new Set<string>();
-      if (fs.existsSync(DB_PATH)) {
-        try {
-          const projects = JSON.parse(fs.readFileSync(DB_PATH, 'utf-8'));
-          for (const p of projects) {
-            const subnets = p.networkConfig?.subnets || [];
-            for (const s of subnets) {
-              activeSubnetNetNames.add(`akal-subnet-${p.id}-${s.id}`);
+      // Clean up orphaned subnet networks (from deleted/wiped projects) on
+      // startup. When project metadata is unreadable, skip the cleanup rather
+      // than treating every subnet network as orphaned and deleting them all.
+      const activeSubnetNetNames = this.readActiveSubnetNetworkNames();
+      if (activeSubnetNetNames) {
+        for (const net of networks) {
+          if (net.Name.startsWith('akal-subnet-') && !activeSubnetNetNames.has(net.Name)) {
+            console.log(`[DockerInitializer] Cleaning up orphaned subnet network: ${net.Name}`);
+            try {
+              const network = docker.getNetwork(net.Id);
+              const netInspect = await network.inspect();
+              const connectedContainers = Object.keys(netInspect.Containers || {});
+              for (const cId of connectedContainers) {
+                await network.disconnect({ Container: cId, Force: true });
+              }
+              await network.remove();
+            } catch (err) {
+              console.error(`Failed to clean up orphaned network ${net.Name}:`, err);
             }
-          }
-        } catch (err) {
-          console.error('[DockerInitializer] Failed to parse projects.json for orphaned network cleanup:', err);
-        }
-      }
-
-      for (const net of networks) {
-        if (net.Name.startsWith('akal-subnet-') && !activeSubnetNetNames.has(net.Name)) {
-          console.log(`[DockerInitializer] Cleaning up orphaned subnet network: ${net.Name}`);
-          try {
-            const network = docker.getNetwork(net.Id);
-            const netInspect = await network.inspect();
-            const connectedContainers = Object.keys(netInspect.Containers || {});
-            for (const cId of connectedContainers) {
-              await network.disconnect({ Container: cId, Force: true });
-            }
-            await network.remove();
-          } catch (err) {
-            console.error(`Failed to clean up orphaned network ${net.Name}:`, err);
           }
         }
       }

--- a/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
+++ b/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
@@ -93,7 +93,10 @@ export class DockerContainerProvider implements ContainerProvider {
             key = Object.keys(networks).find(k => k.startsWith('akal-'));
           }
           if (key && networks[key]) {
-            ip = networks[key].IPAddress;
+            const tempIp = networks[key].IPAddress;
+            if (tempIp && !tempIp.startsWith('172.')) {
+              ip = tempIp;
+            }
           }
         }
         const asgId = c.Labels['akal.asg.id'];

--- a/backend/src/modules/network/providers/cidrCorrections.test.ts
+++ b/backend/src/modules/network/providers/cidrCorrections.test.ts
@@ -1,0 +1,143 @@
+import { buildCidrCorrections, applyCidrCorrections } from './cidrCorrections';
+
+const baseConfig = () => ({
+  vpcConfig: { name: 'Main Network', cidr: '10.0.0.0/16' },
+  subnets: [
+    {
+      id: 'subnet-1',
+      cidr: '10.0.1.0/24',
+      routes: [{ destination: '10.0.0.0/16', target: 'local' }]
+    },
+    { id: 'subnet-2', cidr: '10.0.2.0/24', routes: [] }
+  ],
+  nodeSubnetMap: { 'node-a': 'subnet-1' },
+  nodeSecurityGroups: {},
+  nodeIpMap: { 'node-a': '10.0.1.2' }
+});
+
+describe('buildCidrCorrections', () => {
+  it('returns null when resolved values echo the requested config', () => {
+    const config = baseConfig();
+    const patch = buildCidrCorrections(
+      config,
+      '10.0.0.0/16',
+      { 'subnet-1': '10.0.1.0/24', 'subnet-2': '10.0.2.0/24' },
+      { 'node-a': '10.0.1.2' }
+    );
+
+    expect(patch).toBeNull();
+  });
+
+  it('includes only the values that actually shifted', () => {
+    const config = baseConfig();
+    const patch = buildCidrCorrections(
+      config,
+      '10.112.0.0/16',
+      { 'subnet-1': '10.112.1.0/24', 'subnet-2': '10.0.2.0/24' },
+      { 'node-a': '10.112.1.2' }
+    );
+
+    expect(patch).toEqual({
+      vpcCidr: '10.112.0.0/16',
+      subnetCidrs: { 'subnet-1': '10.112.1.0/24' },
+      nodeIps: { 'node-a': '10.112.1.2' }
+    });
+  });
+
+  it('heals stale local routes even when the VPC CIDR did not shift in this run', () => {
+    // A subnet added after a shift was already persisted still carries the
+    // default 10.0.0.0/16 local route while the VPC sits at 10.112.0.0/16.
+    const config = {
+      vpcConfig: { name: 'Main Network', cidr: '10.112.0.0/16' },
+      subnets: [
+        { id: 'subnet-1', cidr: '10.112.1.0/24', routes: [{ destination: '10.112.0.0/16', target: 'local' }] },
+        { id: 'subnet-2', cidr: '10.0.2.0/24', routes: [{ destination: '10.0.0.0/16', target: 'local' }] }
+      ],
+      nodeIpMap: {}
+    };
+
+    const patch = buildCidrCorrections(
+      config,
+      '10.112.0.0/16',
+      { 'subnet-1': '10.112.1.0/24', 'subnet-2': '10.112.2.0/24' },
+      {}
+    );
+
+    expect(patch).toEqual({
+      vpcCidr: '10.112.0.0/16',
+      subnetCidrs: { 'subnet-2': '10.112.2.0/24' },
+      nodeIps: {}
+    });
+
+    applyCidrCorrections(config, patch!);
+    expect(config.subnets[1].routes[0].destination).toBe('10.112.0.0/16');
+    expect(config.subnets[1].cidr).toBe('10.112.2.0/24');
+  });
+
+  it('reports newly assigned IPs missing from nodeIpMap', () => {
+    const config = baseConfig();
+    const patch = buildCidrCorrections(
+      config,
+      '10.0.0.0/16',
+      { 'subnet-1': '10.0.1.0/24' },
+      { 'node-a': '10.0.1.2', 'node-b': '10.0.1.3' }
+    );
+
+    expect(patch).toEqual({
+      subnetCidrs: {},
+      nodeIps: { 'node-b': '10.0.1.3' }
+    });
+  });
+});
+
+describe('applyCidrCorrections', () => {
+  it('overlays corrections onto a newer config without touching other fields', () => {
+    // Simulates a save that landed while the plan was running: the user added
+    // a security-group rule and a subnet after enforcement started.
+    const newerConfig = baseConfig();
+    (newerConfig.nodeSecurityGroups as any)['node-a'] = [
+      { type: 'inbound', source: '0.0.0.0/0', protocol: 'tcp', port: '80' }
+    ];
+    newerConfig.subnets.push({ id: 'subnet-3', cidr: '10.0.3.0/24', routes: [] });
+
+    applyCidrCorrections(newerConfig, {
+      vpcCidr: '10.112.0.0/16',
+      subnetCidrs: { 'subnet-1': '10.112.1.0/24' },
+      nodeIps: { 'node-a': '10.112.1.2' }
+    });
+
+    expect(newerConfig.vpcConfig.cidr).toBe('10.112.0.0/16');
+    expect(newerConfig.subnets[0].cidr).toBe('10.112.1.0/24');
+    expect(newerConfig.subnets[0].routes[0].destination).toBe('10.112.0.0/16');
+    expect(newerConfig.nodeIpMap['node-a']).toBe('10.112.1.2');
+    // The newer edits survive the merge.
+    expect((newerConfig.nodeSecurityGroups as any)['node-a']).toHaveLength(1);
+    expect(newerConfig.subnets[2]).toEqual({ id: 'subnet-3', cidr: '10.0.3.0/24', routes: [] });
+    expect(newerConfig.subnets[1].cidr).toBe('10.0.2.0/24');
+  });
+
+  it('leaves local routes untouched when the VPC CIDR did not shift', () => {
+    const config = baseConfig();
+
+    applyCidrCorrections(config, {
+      subnetCidrs: { 'subnet-2': '10.112.2.0/24' },
+      nodeIps: {}
+    });
+
+    expect(config.subnets[0].routes[0].destination).toBe('10.0.0.0/16');
+    expect(config.subnets[1].cidr).toBe('10.112.2.0/24');
+  });
+
+  it('ignores corrections for subnets deleted in the meantime', () => {
+    const config = baseConfig();
+    config.subnets = config.subnets.filter(s => s.id !== 'subnet-1');
+
+    expect(() =>
+      applyCidrCorrections(config, {
+        subnetCidrs: { 'subnet-1': '10.112.1.0/24' },
+        nodeIps: {}
+      })
+    ).not.toThrow();
+    expect(config.subnets).toHaveLength(1);
+  });
+});

--- a/backend/src/modules/network/providers/cidrCorrections.ts
+++ b/backend/src/modules/network/providers/cidrCorrections.ts
@@ -1,0 +1,88 @@
+/**
+ * When Docker cannot honor a requested CIDR (address pool overlap), enforcement
+ * shifts to a free range and the shifted values must be persisted. Saving the
+ * whole in-flight config back would clobber any save that landed while the
+ * plan was running, so instead we diff what enforcement actually produced
+ * against what was requested and merge only those corrections into a freshly
+ * read config.
+ */
+
+export interface CidrCorrections {
+  vpcCidr?: string;
+  subnetCidrs: Record<string, string>;
+  nodeIps: Record<string, string>;
+}
+
+/**
+ * Builds the correction patch for a finished plan. A resolved value that
+ * merely echoes the requested one never enters the patch, so applying it can
+ * never revert a newer user-chosen value. Returns null when nothing shifted.
+ */
+export function buildCidrCorrections(
+  config: any,
+  vpcCidr: string,
+  resolvedCidrs: Record<string, string>,
+  ipMap: Record<string, string>
+): CidrCorrections | null {
+  const patch: CidrCorrections = { subnetCidrs: {}, nodeIps: {} };
+  let changed = false;
+
+  // 'local' routes represent the VPC route, so they must track the enforced
+  // VPC CIDR. A stale destination can appear even when the VPC did not shift
+  // in this run: subnets created after a shift was persisted still carry the
+  // default 10.0.0.0/16 destination.
+  const vpcStale =
+    (config.vpcConfig && config.vpcConfig.cidr !== vpcCidr) ||
+    (config.subnets || []).some((s: any) =>
+      (s.routes || []).some((r: any) => r.target === 'local' && r.destination !== vpcCidr)
+    );
+  if (vpcStale) {
+    patch.vpcCidr = vpcCidr;
+    changed = true;
+  }
+
+  for (const subnet of config.subnets || []) {
+    const resolved = resolvedCidrs[subnet.id];
+    if (resolved && subnet.cidr !== resolved) {
+      patch.subnetCidrs[subnet.id] = resolved;
+      changed = true;
+    }
+  }
+
+  for (const [nodeId, ip] of Object.entries(ipMap)) {
+    if (config.nodeIpMap?.[nodeId] !== ip) {
+      patch.nodeIps[nodeId] = ip;
+      changed = true;
+    }
+  }
+
+  return changed ? patch : null;
+}
+
+/** Merges a correction patch into a config, mutating it in place. */
+export function applyCidrCorrections(config: any, patch: CidrCorrections): void {
+  if (patch.vpcCidr) {
+    if (config.vpcConfig) {
+      config.vpcConfig.cidr = patch.vpcCidr;
+    }
+    // Routes targeting 'local' cover the whole VPC and must follow the shift.
+    for (const subnet of config.subnets || []) {
+      for (const route of subnet.routes || []) {
+        if (route.target === 'local') {
+          route.destination = patch.vpcCidr;
+        }
+      }
+    }
+  }
+
+  for (const subnet of config.subnets || []) {
+    const cidr = patch.subnetCidrs[subnet.id];
+    if (cidr) {
+      subnet.cidr = cidr;
+    }
+  }
+
+  if (Object.keys(patch.nodeIps).length > 0) {
+    config.nodeIpMap = { ...config.nodeIpMap, ...patch.nodeIps };
+  }
+}

--- a/backend/src/modules/network/providers/dockerNetworkProvider.ts
+++ b/backend/src/modules/network/providers/dockerNetworkProvider.ts
@@ -2,6 +2,7 @@ import { NetworkProvider } from './networkProvider';
 import { VirtualEndpoint } from '../mapper/virtualNetworkMapper';
 import { NetworkIntent } from '../planner/enforcementPlanner';
 import docker from '../../../infrastructure/docker/DockerClient';
+import { ProjectService } from '../../projects/services/projectService';
 
 export class DockerNetworkProvider implements NetworkProvider {
   private async runExec(containerId: string, cmd: string[]): Promise<string> {
@@ -851,6 +852,52 @@ ${locationsConfig}
         throw new Error(`Firewall verification failed inside container ${containerId.slice(0, 12)}: custom chains were not created/found.`);
       }
     }));
+
+    // Write back the updated/shifted CIDRs to projects.json
+    let configChanged = false;
+
+    if (config.vpcConfig && config.vpcConfig.cidr !== vpcCidr) {
+      config.vpcConfig.cidr = vpcCidr;
+      configChanged = true;
+    }
+
+    if (config.subnets) {
+      for (const subnet of config.subnets) {
+        const resolvedCidr = resolvedCidrs[subnet.id];
+        if (resolvedCidr && subnet.cidr !== resolvedCidr) {
+          subnet.cidr = resolvedCidr;
+          configChanged = true;
+        }
+
+        // Also update any 'local' route destinations to match the shifted VPC CIDR
+        if (subnet.routes) {
+          for (const route of subnet.routes) {
+            if (route.target === 'local' && route.destination !== vpcCidr) {
+              route.destination = vpcCidr;
+              configChanged = true;
+            }
+          }
+        }
+      }
+    }
+
+    if (config.nodeIpMap) {
+      for (const [nodeId, ip] of Object.entries(ipMap)) {
+        if (config.nodeIpMap[nodeId] !== ip) {
+          config.nodeIpMap[nodeId] = ip;
+          configChanged = true;
+        }
+      }
+    }
+
+    if (configChanged) {
+      console.log(`[DockerNetworkProvider] Persisting shifted CIDRs and IPs back to projects.json...`);
+      try {
+        await ProjectService.saveNetworkConfig(projectId, config);
+      } catch (err) {
+        console.error('[DockerNetworkProvider] Failed to persist shifted CIDRs to database:', err);
+      }
+    }
   }
 
   public async cleanupProjectPolicies(projectId: string, endpoints: VirtualEndpoint[]): Promise<void> {

--- a/backend/src/modules/network/providers/dockerNetworkProvider.ts
+++ b/backend/src/modules/network/providers/dockerNetworkProvider.ts
@@ -3,6 +3,7 @@ import { VirtualEndpoint } from '../mapper/virtualNetworkMapper';
 import { NetworkIntent } from '../planner/enforcementPlanner';
 import docker from '../../../infrastructure/docker/DockerClient';
 import { ProjectService } from '../../projects/services/projectService';
+import { buildCidrCorrections, applyCidrCorrections } from './cidrCorrections';
 
 export class DockerNetworkProvider implements NetworkProvider {
   private async runExec(containerId: string, cmd: string[]): Promise<string> {
@@ -853,47 +854,19 @@ ${locationsConfig}
       }
     }));
 
-    // Write back the updated/shifted CIDRs to projects.json
-    let configChanged = false;
-
-    if (config.vpcConfig && config.vpcConfig.cidr !== vpcCidr) {
-      config.vpcConfig.cidr = vpcCidr;
-      configChanged = true;
-    }
-
-    if (config.subnets) {
-      for (const subnet of config.subnets) {
-        const resolvedCidr = resolvedCidrs[subnet.id];
-        if (resolvedCidr && subnet.cidr !== resolvedCidr) {
-          subnet.cidr = resolvedCidr;
-          configChanged = true;
-        }
-
-        // Also update any 'local' route destinations to match the shifted VPC CIDR
-        if (subnet.routes) {
-          for (const route of subnet.routes) {
-            if (route.target === 'local' && route.destination !== vpcCidr) {
-              route.destination = vpcCidr;
-              configChanged = true;
-            }
-          }
-        }
-      }
-    }
-
-    if (config.nodeIpMap) {
-      for (const [nodeId, ip] of Object.entries(ipMap)) {
-        if (config.nodeIpMap[nodeId] !== ip) {
-          config.nodeIpMap[nodeId] = ip;
-          configChanged = true;
-        }
-      }
-    }
-
-    if (configChanged) {
+    // Persist shifted CIDRs/IPs back to projects.json. Merge the corrections
+    // into a freshly read config: this plan may have been queued behind other
+    // work, and saving the config it started from would clobber any save that
+    // landed in the meantime.
+    const corrections = buildCidrCorrections(config, vpcCidr, resolvedCidrs, ipMap);
+    if (corrections) {
       console.log(`[DockerNetworkProvider] Persisting shifted CIDRs and IPs back to projects.json...`);
       try {
-        await ProjectService.saveNetworkConfig(projectId, config);
+        const currentConfig = await ProjectService.getNetworkConfig(projectId);
+        if (currentConfig) {
+          applyCidrCorrections(currentConfig, corrections);
+          await ProjectService.saveNetworkConfig(projectId, currentConfig);
+        }
       } catch (err) {
         console.error('[DockerNetworkProvider] Failed to persist shifted CIDRs to database:', err);
       }

--- a/backend/src/modules/projects/controllers/projectController.test.ts
+++ b/backend/src/modules/projects/controllers/projectController.test.ts
@@ -1,0 +1,141 @@
+import request from 'supertest';
+import express from 'express';
+import { ProjectController } from './projectController';
+import { ProjectService } from '../services/projectService';
+import { NetworkService } from '../../network/services/networkService';
+
+// Mock Services
+jest.mock('../services/projectService');
+jest.mock('../../network/services/networkService');
+
+const app = express();
+app.use(express.json());
+
+app.get('/api/projects', ProjectController.list);
+app.post('/api/projects', ProjectController.create);
+app.delete('/api/projects/:id', ProjectController.delete);
+app.get('/api/projects/:id/network-config', ProjectController.getNetworkConfig);
+app.post('/api/projects/:id/network-config', ProjectController.saveNetworkConfig);
+
+describe('ProjectController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/projects', () => {
+    it('should return a list of projects', async () => {
+      const mockProjects = [
+        { id: 'project-1', name: 'Project 1', createdAt: '2026-07-11T12:00:00.000Z' }
+      ];
+      (ProjectService.listProjects as jest.Mock).mockResolvedValue(mockProjects);
+
+      const res = await request(app).get('/api/projects');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockProjects);
+      expect(ProjectService.listProjects).toHaveBeenCalled();
+    });
+
+    it('should handle errors and return 500 status', async () => {
+      (ProjectService.listProjects as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+      const res = await request(app).get('/api/projects');
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: 'DB error' });
+    });
+  });
+
+  describe('POST /api/projects', () => {
+    it('should create a project successfully when the name is unique', async () => {
+      const mockProject = { id: 'project-1', name: 'Project 1', createdAt: '2026-07-11T12:00:00.000Z' };
+      (ProjectService.listProjects as jest.Mock).mockResolvedValue([]);
+      (ProjectService.createProject as jest.Mock).mockResolvedValue(mockProject);
+
+      const res = await request(app)
+        .post('/api/projects')
+        .send({ name: 'Project 1' });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(mockProject);
+      expect(ProjectService.createProject).toHaveBeenCalledWith('Project 1');
+    });
+
+    it('should return 400 if name is missing', async () => {
+      const res = await request(app)
+        .post('/api/projects')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'Project name is required' });
+    });
+
+    it('should return 409 if project name is duplicate (case-insensitive)', async () => {
+      const mockProjects = [
+        { id: 'project-1', name: 'Project 1', createdAt: '2026-07-11T12:00:00.000Z' }
+      ];
+      (ProjectService.listProjects as jest.Mock).mockResolvedValue(mockProjects);
+
+      const res = await request(app)
+        .post('/api/projects')
+        .send({ name: '  project 1  ' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toContain('already exists');
+      expect(ProjectService.createProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE /api/projects/:id', () => {
+    it('should delete a project successfully', async () => {
+      (ProjectService.deleteProject as jest.Mock).mockResolvedValue(undefined);
+
+      const res = await request(app).delete('/api/projects/project-1');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true });
+      expect(ProjectService.deleteProject).toHaveBeenCalledWith('project-1');
+    });
+  });
+
+  describe('GET /api/projects/:id/network-config', () => {
+    it('should return network config of a project', async () => {
+      const mockConfig = { vpcConfig: { name: 'VPC' } };
+      (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue(mockConfig);
+
+      const res = await request(app).get('/api/projects/project-1/network-config');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockConfig);
+      expect(ProjectService.getNetworkConfig).toHaveBeenCalledWith('project-1');
+    });
+  });
+
+  describe('POST /api/projects/:id/network-config', () => {
+    it('should save config, enforce policies and return the updated config', async () => {
+      const mockConfig = { vpcConfig: { name: 'VPC', cidr: '10.0.0.0/16' } };
+      (ProjectService.saveNetworkConfig as jest.Mock).mockResolvedValue(undefined);
+      (NetworkService.applyPolicy as jest.Mock).mockResolvedValue(undefined);
+      (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue(mockConfig);
+
+      const res = await request(app)
+        .post('/api/projects/project-1/network-config')
+        .send({ networkConfig: mockConfig });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockConfig);
+      expect(ProjectService.saveNetworkConfig).toHaveBeenCalledWith('project-1', mockConfig);
+      expect(NetworkService.applyPolicy).toHaveBeenCalledWith('project-1', mockConfig);
+      expect(ProjectService.getNetworkConfig).toHaveBeenCalledWith('project-1');
+    });
+
+    it('should return 400 if networkConfig is missing', async () => {
+      const res = await request(app)
+        .post('/api/projects/project-1/network-config')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'networkConfig is required' });
+    });
+  });
+});

--- a/backend/src/modules/projects/controllers/projectController.ts
+++ b/backend/src/modules/projects/controllers/projectController.ts
@@ -19,6 +19,14 @@ export class ProjectController {
         res.status(400).json({ error: 'Project name is required' });
         return;
       }
+      
+      const db = await ProjectService.listProjects();
+      const nameExists = db.some(p => p.name.trim().toLowerCase() === name.trim().toLowerCase());
+      if (nameExists) {
+        res.status(409).json({ error: `A project named "${name}" already exists.` });
+        return;
+      }
+
       const project = await ProjectService.createProject(name);
       res.status(201).json(project);
     } catch (err: any) {
@@ -54,12 +62,12 @@ export class ProjectController {
       }
       await ProjectService.saveNetworkConfig(projectId, networkConfig);
       
-      // Enforce the logic asynchronously
-      NetworkService.applyPolicy(projectId, networkConfig).catch(err => {
-        console.error(`Failed to apply network policy for project ${projectId}:`, err);
-      });
+      // Enforce the logic synchronously so any shifted CIDRs are computed and saved
+      await NetworkService.applyPolicy(projectId, networkConfig);
 
-      res.json({ success: true });
+      // Fetch and return the updated config containing shifted CIDRs and IPs
+      const updatedConfig = await ProjectService.getNetworkConfig(projectId);
+      res.json(updatedConfig || { success: true });
     } catch (err: any) {
       res.status(500).json({ error: err.message });
     }

--- a/frontend/src/features/nodes/VpcNode/VpcModal.tsx
+++ b/frontend/src/features/nodes/VpcNode/VpcModal.tsx
@@ -44,7 +44,7 @@ export default function VpcModal({
   
   // VPC Config State Form
   const [name, setName] = useState(vpcConfig.name);
-  const [cidr] = useState(vpcConfig.cidr);
+  const cidr = vpcConfig.cidr;
   const [dnsEnabled, setDnsEnabled] = useState(vpcConfig.dnsEnabled);
   const [igwEnabled, setIgwEnabled] = useState(vpcConfig.igwEnabled);
   const [description, setDescription] = useState(vpcConfig.description);

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -206,7 +206,12 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       },
       body: JSON.stringify({ networkConfig: grownConfig })
     })
-    .then(res => res.json())
+    .then(res => {
+      if (!res.ok) {
+        throw new Error(`Failed to save network config (HTTP ${res.status})`);
+      }
+      return res.json();
+    })
     .then(data => {
       if (data && data.vpcConfig) {
         setNetworkConfig(data);

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -1349,11 +1349,16 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           return;
         }
 
+        // Derive the subnet CIDR and local route from the current VPC CIDR:
+        // it may have shifted from the default 10.0.0.0/16 when Docker's
+        // address pool overlapped the requested range.
+        const vpcCidr = networkConfig.vpcConfig.cidr;
+        const vpcPrefix = vpcCidr.split('.').slice(0, 2).join('.');
         const newSubnet: Subnet = {
           id: `subnet-${Math.random().toString(36).substr(2, 9)}`,
           name: `${isPublic ? 'Public' : 'Private'} Subnet-${networkConfig.subnets.length + 1}`,
           type: isPublic ? 'public' : 'private',
-          cidr: `10.0.${networkConfig.subnets.length + 1}.0/24`,
+          cidr: `${vpcPrefix}.${networkConfig.subnets.length + 1}.0/24`,
           vpcId: 'root-vpc',
           position: position,
           width: subnetWidth,
@@ -1361,7 +1366,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           columns: cols,
           rows: rows,
           routes: [
-            { destination: '10.0.0.0/16', target: 'local', description: 'Local VPC routing' },
+            { destination: vpcCidr, target: 'local', description: 'Local VPC routing' },
             ...(isPublic ? [{ destination: '0.0.0.0/0', target: 'igw', description: 'Internet access' }] : [])
           ]
         };

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -205,7 +205,15 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({ networkConfig: grownConfig })
-    }).catch(err => {
+    })
+    .then(res => res.json())
+    .then(data => {
+      if (data && data.vpcConfig) {
+        setNetworkConfig(data);
+        localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(data));
+      }
+    })
+    .catch(err => {
       console.error('Failed to sync network configuration to backend:', err);
       throw err;
     });
@@ -513,24 +521,13 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     ];
   };
 
-  // Load saved positions, network configurations and start polling
-  useEffect(() => {
-    fetchContainers();
-    const savedLayout = localStorage.getItem(`akal-lab-graph-layout-${projectId}`);
-    if (savedLayout) {
-      try {
-        positionsRef.current = JSON.parse(savedLayout);
-      } catch (err) {
-        console.error(err);
-      }
-    }
-
-    // Fetch network config from backend, fallback to localStorage if unavailable
+  const fetchNetworkConfig = useCallback(() => {
     fetch(`${API_BASE}/api/projects/${projectId}/network-config`)
       .then(res => res.json())
       .then(data => {
         if (data && data.vpcConfig) {
           setNetworkConfig(data);
+          localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(data));
         } else {
           const savedConfig = localStorage.getItem(`akal-lab-network-config-${projectId}`);
           if (savedConfig) {
@@ -565,10 +562,27 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           }
         }
       });
+  }, [projectId, defaultVpcConfig]);
 
-    const timer = setInterval(fetchContainers, 4000);
+  // Load saved positions, network configurations and start polling
+  useEffect(() => {
+    fetchContainers();
+    fetchNetworkConfig();
+    const savedLayout = localStorage.getItem(`akal-lab-graph-layout-${projectId}`);
+    if (savedLayout) {
+      try {
+        positionsRef.current = JSON.parse(savedLayout);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    const timer = setInterval(() => {
+      fetchContainers();
+      fetchNetworkConfig();
+    }, 4000);
     return () => clearInterval(timer);
-  }, [projectId, fetchContainers, defaultVpcConfig]);
+  }, [projectId, fetchContainers, fetchNetworkConfig]);
 
   // Sync container data into React Flow nodes when containers change
   useEffect(() => {
@@ -739,7 +753,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
             status: c.status,
             lastError: opErrors[c.id],
             port: c.port,
-            ip: networkConfig.nodeIpMap?.[c.id] || 'pending',
+            ip: c.ip || networkConfig.nodeIpMap?.[c.id] || 'pending',
             subnetType,
             config: nodeConfig,
             asgConfig: asgConfig ? { ...asgConfig, parentName } : undefined,
@@ -1595,7 +1609,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       {inspectingNat && (
         <NatGatewayModal
           nodeName={inspectingNat.name}
-          ipAddress={networkConfig.nodeIpMap?.[inspectingNat.id]}
+          ipAddress={containers.find(c => c.id === inspectingNat.id)?.ip || networkConfig.nodeIpMap?.[inspectingNat.id]}
           state={containers.find(c => c.id === inspectingNat.id)?.state || 'stopped'}
           onClose={() => setInspectingNat(null)}
         />
@@ -1605,7 +1619,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         <LoadBalancerModal
           containerId={inspectingLoadBalancer.id}
           nodeName={inspectingLoadBalancer.name}
-          ipAddress={networkConfig.nodeIpMap?.[inspectingLoadBalancer.id]}
+          ipAddress={containers.find(c => c.id === inspectingLoadBalancer.id)?.ip || networkConfig.nodeIpMap?.[inspectingLoadBalancer.id]}
           port={containers.find(c => c.id === inspectingLoadBalancer.id)?.port}
           state={containers.find(c => c.id === inspectingLoadBalancer.id)?.state || 'stopped'}
           config={{

--- a/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -49,19 +49,17 @@ export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
   }, []);
 
   const handleCreateProject = async (name: string) => {
-    try {
-      const res = await fetch(`${API_BASE}/api/projects`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name }),
-      });
-      if (res.ok) {
-        fetchProjects();
-      }
-    } catch (err) {
-      console.error(err);
-    } finally {
+    const res = await fetch(`${API_BASE}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (res.ok) {
+      fetchProjects();
       setShowCreateModal(false);
+    } else {
+      const errorData = await res.json();
+      throw new Error(errorData.error || 'Failed to create project');
     }
   };
 

--- a/frontend/src/shared/components/InputModal.test.tsx
+++ b/frontend/src/shared/components/InputModal.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import InputModal from './InputModal';
+
+describe('InputModal', () => {
+  it('renders title, label, placeholder, and buttons', () => {
+    const handleSubmit = vi.fn();
+    const handleCancel = vi.fn();
+
+    render(
+      <InputModal
+        title="Create Project"
+        label="Enter project name"
+        placeholder="My Project"
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+      />
+    );
+
+    expect(screen.getByText('Create Project')).toBeInTheDocument();
+    expect(screen.getByText('Enter project name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('My Project')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument();
+  });
+
+  it('updates input value on typing', () => {
+    render(
+      <InputModal
+        title="Create Project"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New Project Name' } });
+    expect(input.value).toBe('New Project Name');
+  });
+
+  it('calls onSubmit when submitting a valid value', async () => {
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InputModal
+        title="Create Project"
+        onSubmit={handleSubmit}
+        onCancel={vi.fn()}
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Torollo Project' } });
+
+    const submitBtn = screen.getByRole('button', { name: /create/i });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith('Torollo Project');
+    });
+  });
+
+  it('displays the inline error message when onSubmit fails, and clears it on typing', async () => {
+    const handleSubmit = vi.fn().mockRejectedValue(new Error('Project already exists'));
+
+    render(
+      <InputModal
+        title="Create Project"
+        onSubmit={handleSubmit}
+        onCancel={vi.fn()}
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Duplicate' } });
+
+    const submitBtn = screen.getByRole('button', { name: /create/i });
+    fireEvent.click(submitBtn);
+
+    // Should display the error message
+    await waitFor(() => {
+      expect(screen.getByText('Project already exists')).toBeInTheDocument();
+    });
+
+    // Error styling should be applied
+    expect(input).toHaveStyle('border-color: rgb(220, 38, 38)');
+
+    // Type in the input to resolve the error
+    fireEvent.change(input, { target: { value: 'Duplicate name but changing' } });
+
+    // The error message should disappear
+    expect(screen.queryByText('Project already exists')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/components/InputModal.tsx
+++ b/frontend/src/shared/components/InputModal.tsx
@@ -27,6 +27,7 @@ export default function InputModal({
 }: InputModalProps) {
   const [value, setValue] = useState(defaultValue);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -41,14 +42,18 @@ export default function InputModal({
       val = val.replace(restrictPattern, '');
     }
     setValue(val);
+    setError(''); // Clear error on typing
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (value.trim()) {
       setIsSubmitting(true);
+      setError('');
       try {
         await onSubmit(value.trim());
+      } catch (err: any) {
+        setError(err.message || 'An error occurred');
       } finally {
         setIsSubmitting(false);
       }
@@ -67,10 +72,18 @@ export default function InputModal({
           maxLength={maxLength}
           onChange={handleChange}
           placeholder={placeholder}
-          style={styles.input}
+          style={{
+            ...styles.input,
+            border: error ? '1px solid #DC2626' : '1px solid rgba(0, 0, 0, 0.12)'
+          }}
           id="modal-input"
           disabled={isSubmitting}
         />
+        {error && (
+          <div style={styles.errorMsg}>
+            {error}
+          </div>
+        )}
         <div style={styles.actions}>
           <button type="button" onClick={onCancel} style={styles.cancelBtn} disabled={isSubmitting}>
             Cancel
@@ -152,5 +165,11 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#FFF',
     cursor: 'pointer',
     transition: 'opacity 0.15s, transform 0.1s',
+  },
+  errorMsg: {
+    color: '#DC2626',
+    fontSize: '12px',
+    marginTop: '6px',
+    fontWeight: 500,
   },
 };


### PR DESCRIPTION
## Summary of Changes

This Pull Request addresses multiple issues concerning network configurations, CIDR persistence, project name uniqueness validation, and UI visual improvements:
1. **Dynamic CIDR Persistence:** Updates `projects.json` dynamically when a collision causes Docker subnets to shift CIDR ranges (e.g. to `10.112.0.0/16`). Updates subnet routes targeting `local` to match.
2. **Synchronous Sync & UI Polling:** Makes the backend network application synchronous, allowing the frontend to immediately retrieve and render the shifted range. Additionally, sets the frontend to poll `network-config` alongside container status every 4 seconds.
3. **Modal Verification & Validation:** Prevents duplicate project name creation (case-insensitive) on the backend (returning `409 Conflict`) and replaces browser `alert()` pop-ups with custom red inline error notifications inside `InputModal`.
4. **No 172.x IP Flash:** Prevents temporary Docker bridge network IPs (`172.x.x.x`) from flashing for 1 second in the UI by filtering them out on the backend, allowing immediate fallback to the assigned `10.x.x.x` subnet IP.
5. **Orphaned Network Cleanup:** Automatically detects and cleans up any legacy `akal-subnet-` networks from deleted or wiped projects on backend startup.

## Types of Changes

- [x] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

Tested locally by:
1. Simulating project creations with duplicate names to verify inline error validation inside the modal.
2. Dragging new containers onto the canvas and verifying that the IP starts with the correct subnet range immediately (no `172.` flash).
3. Verifying that starting containers triggers a backend CIDR shift when a collision is present, and that the updated CIDR is correctly persisted to `projects.json` and immediately synced to the Canvas UI and the VPC detail modals.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing