### PR TITLE
v1 roadmap format

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "ajv": "^8.20.0",
         "cors": "^2.8.6",
         "dockerode": "^5.0.0",
         "dotenv": "^17.4.2",
@@ -3068,16 +3069,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -4393,6 +4393,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4405,6 +4422,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -4585,7 +4609,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4608,6 +4631,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6138,10 +6177,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -7062,6 +7100,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,13 +10,15 @@
     "lint": "eslint .",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "roadmap:validate": "ts-node src/modules/learning/format/validateRoadmapCli.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "ajv": "^8.20.0",
     "cors": "^2.8.6",
     "dockerode": "^5.0.0",
     "dotenv": "^17.4.2",

--- a/backend/src/modules/learning/format/roadmap.schema.json
+++ b/backend/src/modules/learning/format/roadmap.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Derssa/Torollo/main/backend/src/modules/learning/format/roadmap.schema.json",
+  "title": "Torollo Roadmap",
+  "description": "A guided, auto-corrected learning roadmap. Purely declarative data: validators are { type, params } objects interpreted by the Torollo engine — a roadmap never contains executable code. See docs/roadmap-format.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "id", "title", "description", "language", "steps"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional reference to this schema's URL, for editor autocompletion."
+    },
+    "schemaVersion": {
+      "const": 1,
+      "description": "Format version. This schema describes version 1. Readers must reject files with an unsupported version."
+    },
+    "id": {
+      "$ref": "#/$defs/slug",
+      "description": "Stable roadmap identifier. Progression is keyed on it — never change it once published."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable roadmap title, in the roadmap's language."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short summary shown in the catalog and player."
+    },
+    "language": {
+      "type": "string",
+      "pattern": "^[a-z]{2,3}(-[A-Z]{2})?$",
+      "description": "Language of all texts in this file (e.g. \"en\", \"fr\", \"pt-BR\"). One language per file; a translation is a separate file with the same id."
+    },
+    "estimatedMinutes": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Rough total completion time, in minutes."
+    },
+    "difficulty": {
+      "enum": ["beginner", "intermediate", "advanced"]
+    },
+    "prerequisites": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Free-form human prerequisites (e.g. \"Docker installed\"). Not machine-resolved references."
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/step" }
+    }
+  },
+  "$defs": {
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 64
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "instruction", "validators"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/slug",
+          "description": "Stable step identifier, unique within the roadmap and independent of the step's position. Progression is keyed on it."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "instruction": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What the learner must do. Markdown is allowed."
+        },
+        "hints": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Ordered progressive hints, revealed one at a time (hint 1 first)."
+        },
+        "solution": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Full solution, revealed only after all hints. Always explicit — never encoded as the last hint."
+        },
+        "validators": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/validator" }
+        }
+      }
+    },
+    "validator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "params"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Validator type name, dispatched by the engine (e.g. \"container_running\"). Unknown types are reported by the engine, not by this schema."
+        },
+        "params": {
+          "type": "object",
+          "description": "Inert JSON data interpreted by the validator implementation shipped with Torollo. Per-type shape is documented in docs/roadmap-format.md."
+        }
+      }
+    }
+  }
+}

--- a/backend/src/modules/learning/format/roadmapTypes.ts
+++ b/backend/src/modules/learning/format/roadmapTypes.ts
@@ -1,0 +1,46 @@
+/**
+ * TypeScript types for the Torollo roadmap format, version 1.
+ *
+ * Source of truth for the format itself is the JSON Schema next to this file
+ * (roadmap.schema.json); these types mirror it for consumers in this package.
+ * The frontend keeps a documented copy in frontend/src/shared/types/roadmap.ts.
+ *
+ * Format documentation: docs/roadmap-format.md
+ */
+
+export const ROADMAP_SCHEMA_VERSION = 1 as const;
+
+/** A purely declarative check: `params` is inert JSON interpreted by the engine. */
+export interface RoadmapValidator {
+  type: string;
+  params: Record<string, unknown>;
+}
+
+export interface RoadmapStep {
+  /** Stable identifier, unique within the roadmap, independent of position. */
+  id: string;
+  title: string;
+  /** What the learner must do. Markdown allowed. */
+  instruction: string;
+  /** Ordered progressive hints (hint 1 first). */
+  hints?: string[];
+  /** Full solution, revealed after all hints. */
+  solution?: string;
+  validators: RoadmapValidator[];
+}
+
+export type RoadmapDifficulty = 'beginner' | 'intermediate' | 'advanced';
+
+export interface Roadmap {
+  schemaVersion: typeof ROADMAP_SCHEMA_VERSION;
+  /** Stable identifier — progression is keyed on it. */
+  id: string;
+  title: string;
+  description: string;
+  /** Language of all texts in the file (e.g. "en", "fr"). One language per file. */
+  language: string;
+  estimatedMinutes?: number;
+  difficulty?: RoadmapDifficulty;
+  prerequisites?: string[];
+  steps: RoadmapStep[];
+}

--- a/backend/src/modules/learning/format/validateRoadmap.test.ts
+++ b/backend/src/modules/learning/format/validateRoadmap.test.ts
@@ -1,0 +1,170 @@
+import fs from 'fs';
+import path from 'path';
+import { validateRoadmap } from './validateRoadmap';
+import { Roadmap } from './roadmapTypes';
+
+const EXAMPLE_PATH = path.resolve(
+  __dirname,
+  '../../../../../roadmaps/example-first-architecture.json'
+);
+
+/** Minimal valid roadmap used as a base for the invalid-input tests. */
+function minimalRoadmap(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    id: 'test-roadmap',
+    title: 'Test roadmap',
+    description: 'A minimal roadmap for tests.',
+    language: 'en',
+    steps: [
+      {
+        id: 'first-step',
+        title: 'First step',
+        instruction: 'Do the thing.',
+        validators: [{ type: 'container_running', params: { node: 'web' } }],
+      },
+    ],
+  };
+}
+
+function expectInvalid(data: unknown): string[] {
+  const result = validateRoadmap(data);
+  expect(result.valid).toBe(false);
+  if (result.valid) throw new Error('unreachable');
+  expect(result.errors.length).toBeGreaterThan(0);
+  return result.errors;
+}
+
+describe('validateRoadmap', () => {
+  it('accepts a minimal valid roadmap', () => {
+    const result = validateRoadmap(minimalRoadmap());
+    expect(result).toEqual({ valid: true, roadmap: minimalRoadmap() });
+  });
+
+  describe('repository example roadmap', () => {
+    const example = JSON.parse(fs.readFileSync(EXAMPLE_PATH, 'utf-8'));
+
+    it('validates', () => {
+      const result = validateRoadmap(example);
+      expect(result).toMatchObject({ valid: true });
+    });
+
+    it('covers the V-1 acceptance criteria structurally', () => {
+      const roadmap = example as Roadmap;
+      expect(roadmap.steps.length).toBeGreaterThanOrEqual(2);
+      expect(roadmap.steps.some((s) => (s.hints ?? []).length >= 2)).toBe(true);
+      expect(
+        roadmap.steps.some((s) => new Set(s.validators.map((v) => v.type)).size >= 2)
+      ).toBe(true);
+    });
+  });
+
+  describe('schemaVersion', () => {
+    it('rejects a missing schemaVersion and names the field', () => {
+      const data = minimalRoadmap();
+      delete data.schemaVersion;
+      const errors = expectInvalid(data);
+      expect(errors.join('\n')).toContain('missing required field "schemaVersion"');
+    });
+
+    it('rejects an unsupported schemaVersion with an explicit message', () => {
+      const errors = expectInvalid({ ...minimalRoadmap(), schemaVersion: 2 });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('/schemaVersion: unsupported schemaVersion 2');
+      expect(errors[0]).toContain('reads schemaVersion 1');
+    });
+  });
+
+  describe('error messages point at the faulty field', () => {
+    it('names a missing required field with its path', () => {
+      const data = minimalRoadmap();
+      delete (data.steps as Record<string, unknown>[])[0].id;
+      const errors = expectInvalid(data);
+      expect(errors.join('\n')).toContain('/steps/0: missing required field "id"');
+    });
+
+    it('names an unknown field (typo detection)', () => {
+      const data = minimalRoadmap();
+      (data.steps as Record<string, unknown>[])[0].titel = 'typo';
+      const errors = expectInvalid(data);
+      expect(errors.join('\n')).toContain('/steps/0: unknown field "titel"');
+    });
+
+    it('points inside a validator missing its type', () => {
+      const data = minimalRoadmap();
+      (data.steps as Record<string, unknown>[])[0].validators = [{ params: {} }];
+      const errors = expectInvalid(data);
+      expect(errors.join('\n')).toContain(
+        '/steps/0/validators/0: missing required field "type"'
+      );
+    });
+
+    it('points at non-object validator params', () => {
+      const data = minimalRoadmap();
+      (data.steps as Record<string, unknown>[])[0].validators = [
+        { type: 'container_running', params: 'web' },
+      ];
+      const errors = expectInvalid(data);
+      expect(errors.join('\n')).toContain('/steps/0/validators/0/params');
+    });
+  });
+
+  describe('step ids', () => {
+    it('rejects duplicate step ids, naming the duplicate and both positions', () => {
+      const data = minimalRoadmap();
+      const step = (data.steps as Record<string, unknown>[])[0];
+      data.steps = [step, { ...step }];
+      const errors = expectInvalid(data);
+      expect(errors).toEqual([
+        '/steps/1/id: duplicate step id "first-step" (already used at /steps/0/id)',
+      ]);
+    });
+
+    it('rejects a step id that is not a slug', () => {
+      const data = minimalRoadmap();
+      (data.steps as Record<string, unknown>[])[0].id = 'Not A Slug!';
+      const errors = expectInvalid(data);
+      expect(errors.join('\n')).toContain('/steps/0/id');
+    });
+  });
+
+  describe('malformed inputs never throw', () => {
+    it.each([
+      ['null', null],
+      ['an array', []],
+      ['a string', 'roadmap'],
+      ['a number', 42],
+    ])('rejects %s as the root value', (_label, data) => {
+      const errors = expectInvalid(data);
+      expect(errors).toEqual(['(root): a roadmap must be a JSON object']);
+    });
+
+    it('rejects an empty steps array', () => {
+      const errors = expectInvalid({ ...minimalRoadmap(), steps: [] });
+      expect(errors.join('\n')).toContain('/steps');
+    });
+
+    it('rejects a step without validators', () => {
+      const data = minimalRoadmap();
+      (data.steps as Record<string, unknown>[])[0].validators = [];
+      const errors = expectInvalid(data);
+      expect(errors.join('\n')).toContain('/steps/0/validators');
+    });
+  });
+
+  it('accepts a roadmap using all 8 v1 validator types with their documented params', () => {
+    const allValidators = [
+      { type: 'container_running', params: { node: 'web' } },
+      { type: 'table_exists', params: { node: 'db', table: 'users' } },
+      { type: 'redis_key_exists', params: { node: 'cache', key: 'session:*' } },
+      { type: 'mongo_collection_exists', params: { node: 'docs-db', collection: 'orders' } },
+      { type: 'edge_exists', params: { source: 'web', target: 'db', port: 5432 } },
+      { type: 'lb_upstreams', params: { node: 'lb', min: 2 } },
+      { type: 'port_denied', params: { source: 'web', target: 'db', port: 80 } },
+      { type: 'asg_replicas', params: { node: 'workers', count: 3 } },
+    ];
+    const data = minimalRoadmap();
+    (data.steps as Record<string, unknown>[])[0].validators = allValidators;
+    expect(validateRoadmap(data)).toMatchObject({ valid: true });
+  });
+});

--- a/backend/src/modules/learning/format/validateRoadmap.ts
+++ b/backend/src/modules/learning/format/validateRoadmap.ts
@@ -1,0 +1,70 @@
+import Ajv2020, { ErrorObject } from 'ajv/dist/2020';
+import roadmapSchema from './roadmap.schema.json';
+import { Roadmap, ROADMAP_SCHEMA_VERSION } from './roadmapTypes';
+
+export type RoadmapValidationResult =
+  | { valid: true; roadmap: Roadmap }
+  | { valid: false; errors: string[] };
+
+const ajv = new Ajv2020({ allErrors: true });
+const validateAgainstSchema = ajv.compile(roadmapSchema);
+
+/** Formats an Ajv error so it always points at the faulty field. */
+function formatError(error: ErrorObject): string {
+  const path = error.instancePath || '(root)';
+  if (error.keyword === 'required') {
+    return `${path || '(root)'}: missing required field "${error.params.missingProperty}"`;
+  }
+  if (error.keyword === 'additionalProperties') {
+    return `${path}: unknown field "${error.params.additionalProperty}" — check for typos`;
+  }
+  return `${path}: ${error.message}`;
+}
+
+/**
+ * Validates arbitrary parsed JSON against the roadmap format (schemaVersion 1).
+ *
+ * Pure function, no I/O: callers read the file (CLI, roadmap loader) and pass
+ * the parsed value. On failure, every error message points at the faulty field.
+ */
+export function validateRoadmap(data: unknown): RoadmapValidationResult {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return { valid: false, errors: ['(root): a roadmap must be a JSON object'] };
+  }
+
+  const { schemaVersion } = data as Record<string, unknown>;
+  if (schemaVersion !== undefined && schemaVersion !== ROADMAP_SCHEMA_VERSION) {
+    return {
+      valid: false,
+      errors: [
+        `/schemaVersion: unsupported schemaVersion ${JSON.stringify(schemaVersion)} — ` +
+          `this version of Torollo reads schemaVersion ${ROADMAP_SCHEMA_VERSION}`,
+      ],
+    };
+  }
+
+  if (!validateAgainstSchema(data)) {
+    return { valid: false, errors: (validateAgainstSchema.errors ?? []).map(formatError) };
+  }
+
+  const roadmap = data as unknown as Roadmap;
+
+  // Uniqueness of step ids is not expressible in JSON Schema.
+  const errors: string[] = [];
+  const seenStepIds = new Map<string, number>();
+  roadmap.steps.forEach((step, index) => {
+    const firstIndex = seenStepIds.get(step.id);
+    if (firstIndex !== undefined) {
+      errors.push(
+        `/steps/${index}/id: duplicate step id "${step.id}" (already used at /steps/${firstIndex}/id)`
+      );
+    } else {
+      seenStepIds.set(step.id, index);
+    }
+  });
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, roadmap };
+}

--- a/backend/src/modules/learning/format/validateRoadmapCli.ts
+++ b/backend/src/modules/learning/format/validateRoadmapCli.ts
@@ -1,0 +1,42 @@
+/**
+ * CLI to check a roadmap file against the format schema.
+ *
+ * Usage: npm run roadmap:validate -- <path/to/roadmap.json>
+ */
+import fs from 'fs';
+import { validateRoadmap } from './validateRoadmap';
+
+const filePath = process.argv[2];
+if (!filePath) {
+  console.error('Usage: npm run roadmap:validate -- <path/to/roadmap.json>');
+  process.exit(1);
+}
+
+let raw: string;
+try {
+  raw = fs.readFileSync(filePath, 'utf-8');
+} catch (error) {
+  console.error(`Cannot read ${filePath}: ${(error as Error).message}`);
+  process.exit(1);
+}
+
+let data: unknown;
+try {
+  data = JSON.parse(raw);
+} catch (error) {
+  console.error(`${filePath} is not valid JSON: ${(error as Error).message}`);
+  process.exit(1);
+}
+
+const result = validateRoadmap(data);
+if (result.valid) {
+  const { id, steps } = result.roadmap;
+  console.log(`OK ${filePath} (roadmap "${id}", ${steps.length} step${steps.length > 1 ? 's' : ''})`);
+  process.exit(0);
+}
+
+console.error(`${filePath} is not a valid roadmap:`);
+for (const message of result.errors) {
+  console.error(`  - ${message}`);
+}
+process.exit(1);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -11,7 +11,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "types": ["jest", "node"],
-    "isolatedModules": true
+    "isolatedModules": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"]
 }

--- a/docs/roadmap-format.md
+++ b/docs/roadmap-format.md
@@ -1,0 +1,120 @@
+# The Torollo roadmap format (schemaVersion 1)
+
+A **roadmap** is a guided, auto-corrected learning path: an ordered list of steps, each with an instruction, optional progressive hints, and one or more **validators** that Torollo runs against your *real* Docker containers to check that the step is done.
+
+This document is the reference for authoring roadmap files. You should be able to write a working roadmap from this page alone, without reading any code.
+
+- JSON Schema: [`backend/src/modules/learning/format/roadmap.schema.json`](../backend/src/modules/learning/format/roadmap.schema.json)
+- Reference example: [`roadmaps/example-first-architecture.json`](../roadmaps/example-first-architecture.json)
+
+## Philosophy
+
+- **A roadmap is data, never code.** Validators are declarative `{ "type", "params" }` objects. The `params` are inert JSON interpreted by validator implementations shipped inside Torollo — nothing in a roadmap file is ever evaluated or executed. This is what makes community roadmaps safe to share and run.
+- **The format is versioned and public.** It is the interface between the open-source player/engine (MIT, this repo) and any content written for it — community roadmaps and premium packs alike are files at this format.
+- **Stable identifiers everywhere.** Roadmaps and steps carry slug ids. Your progression is keyed on them, so reordering or inserting steps in a later edit of a roadmap never corrupts anyone's progress. Never change a published id.
+
+## Quick start
+
+Create `my-roadmap.json`:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/Derssa/Torollo/main/backend/src/modules/learning/format/roadmap.schema.json",
+  "schemaVersion": 1,
+  "id": "my-first-roadmap",
+  "title": "My first roadmap",
+  "description": "One step: start a web server.",
+  "language": "en",
+  "steps": [
+    {
+      "id": "start-web",
+      "title": "Start a web server",
+      "instruction": "Create an **Ubuntu** node named `web` and start it.",
+      "hints": ["Drag it from the node library on the left."],
+      "validators": [
+        { "type": "container_running", "params": { "node": "web" } }
+      ]
+    }
+  ]
+}
+```
+
+Check it:
+
+```bash
+cd backend && npm run roadmap:validate -- ../my-roadmap.json
+```
+
+The validator either prints `OK` or a list of errors, each pointing at the faulty field (`/steps/0: missing required field "id"`). Unknown fields are rejected — that's deliberate, it catches typos like `titel`.
+
+## Field reference
+
+### Roadmap (root object)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `$schema` | string | no | URL of the JSON Schema, for editor autocompletion. |
+| `schemaVersion` | the integer `1` | **yes** | Format version. See [Versioning](#versioning--evolution-policy). |
+| `id` | slug, ≤ 64 chars | **yes** | Stable roadmap identifier (e.g. `"scaling-basics"`). Progression is keyed on it — never change it once published. |
+| `title` | non-empty string | **yes** | Shown in the catalog and player. |
+| `description` | non-empty string | **yes** | Short summary of what the learner will build. |
+| `language` | `en`, `fr`, `pt-BR`, … | **yes** | Language of every text in this file. See [Languages](#languages-i18n). |
+| `estimatedMinutes` | integer ≥ 1 | no | Rough total completion time. |
+| `difficulty` | `beginner` \| `intermediate` \| `advanced` | no | |
+| `prerequisites` | array of non-empty strings | no | Free human text ("Docker installed"). Not machine-resolved references to other roadmaps. |
+| `steps` | array of Step, ≥ 1 | **yes** | The ordered steps. |
+
+A *slug* is lowercase letters/digits separated by single hyphens: `^[a-z0-9]+(-[a-z0-9]+)*$`.
+
+### Step
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | slug, ≤ 64 chars | **yes** | Stable step identifier, **unique within the roadmap** and independent of the step's position. Progression is keyed on it. |
+| `title` | non-empty string | **yes** | Short step name shown in the step list. |
+| `instruction` | non-empty string | **yes** | What the learner must do. **Markdown allowed.** |
+| `hints` | array of non-empty strings | no | Progressive hints, revealed one at a time in array order (hint 1 first). Order them from a gentle nudge to nearly-the-answer. |
+| `solution` | non-empty string | no | The full solution, revealed only after all hints. Always use this field — never encode the solution as the last hint. |
+| `validators` | array of Validator, ≥ 1 | **yes** | Every step must be auto-checkable: a step is complete when **all** its validators pass. |
+
+### Validator
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string, `^[a-z][a-z0-9_]*$` | **yes** | One of the validator types below. The schema deliberately does not hard-code the list: new types can appear without a format version bump. A type unknown to your Torollo version is reported by the engine at run time. |
+| `params` | object | **yes** | Plain JSON data configuring the check. The shape depends on `type` (below) and is enforced by the engine, not by the schema. |
+
+## Validators & the targeting convention
+
+**Targeting convention (all validators):** nodes are designated by their **canvas node name** — the name your instruction tells the learner to use (`"node": "web"` matches the node the learner named `web`). Never target runtime identifiers: container and node ids are generated per-user at execution time and change when containers are recreated. Resolving a name to the learner's actual containers/rules is the engine's job.
+
+The 8 validator types of format v1:
+
+| `type` | Checks that… | `params` |
+|---|---|---|
+| `container_running` | the node's container exists and is running | `{ "node": string }` |
+| `table_exists` | a table exists in the node's PostgreSQL (schema `public`) | `{ "node": string, "table": string }` |
+| `redis_key_exists` | a key — or Redis glob pattern like `session:*` — exists in the node's Redis | `{ "node": string, "key": string }` |
+| `mongo_collection_exists` | a collection exists in the node's MongoDB (`database` defaults to the engine's default DB) | `{ "node": string, "collection": string, "database"?: string }` |
+| `edge_exists` | a connection edge exists from `source` to `target` (omit `port` to accept any port) | `{ "source": string, "target": string, "port"?: number }` |
+| `lb_upstreams` | the load balancer node has **at least** `min` upstream targets | `{ "node": string, "min": number }` |
+| `port_denied` | traffic from `source` to `target` on `port` is **blocked** | `{ "source": string, "target": string, "port": number }` |
+| `asg_replicas` | the auto-scaling group node runs **exactly** `count` instances | `{ "node": string, "count": number }` |
+
+Ports and counts are JSON numbers.
+
+## Languages (i18n)
+
+**One language per file.** Every text in a roadmap (title, instructions, hints, solutions) is written in the single language declared by the `language` field.
+
+A translation is a **separate file with the same `id` and a different `language`**. Because progression is keyed on roadmap id + step ids (which are language-neutral slugs), a learner who switches language keeps their progress. There are no per-field translation maps in v1.
+
+## Versioning & evolution policy
+
+- `schemaVersion` is an integer **major** version. This document describes version **1**.
+- **v1 is frozen.** Any field addition, removal, or change of meaning requires `schemaVersion: 2`. There are no minor or "silently additive" changes: the schema rejects unknown fields (typo safety for hand-written files), so an old player could not tolerate a new field anyway. What is published is committed.
+- **Readers must reject unsupported versions explicitly** ("unsupported schemaVersion 2 — this version of Torollo reads schemaVersion 1"), never half-read a file.
+- **Newer players keep reading older files:** a Torollo that understands v2 must still read every valid v1 roadmap.
+- **New validator `type` values are *not* format changes.** The palette can grow within v1; an engine that meets a type it doesn't implement reports it as unknown at run time.
+
+> Note: the `roadmaps/` directory is reference content in the repository; it is not yet shipped inside the published npm package. How roadmap content is distributed is decided with the roadmap loader (V-2/R-1), not by the format.

--- a/frontend/src/shared/types/roadmap.ts
+++ b/frontend/src/shared/types/roadmap.ts
@@ -1,0 +1,48 @@
+/**
+ * TypeScript types for the Torollo roadmap format, version 1.
+ *
+ * KEEP IN SYNC with backend/src/modules/learning/format/roadmapTypes.ts —
+ * the duplication is deliberate: backend and frontend are separate npm
+ * packages (same policy as the Project type in shared/types/index.ts).
+ * Source of truth for the format is the JSON Schema:
+ * backend/src/modules/learning/format/roadmap.schema.json
+ *
+ * Format documentation: docs/roadmap-format.md
+ */
+
+export const ROADMAP_SCHEMA_VERSION = 1 as const;
+
+/** A purely declarative check: `params` is inert JSON interpreted by the engine. */
+export interface RoadmapValidator {
+  type: string;
+  params: Record<string, unknown>;
+}
+
+export interface RoadmapStep {
+  /** Stable identifier, unique within the roadmap, independent of position. */
+  id: string;
+  title: string;
+  /** What the learner must do. Markdown allowed. */
+  instruction: string;
+  /** Ordered progressive hints (hint 1 first). */
+  hints?: string[];
+  /** Full solution, revealed after all hints. */
+  solution?: string;
+  validators: RoadmapValidator[];
+}
+
+export type RoadmapDifficulty = 'beginner' | 'intermediate' | 'advanced';
+
+export interface Roadmap {
+  schemaVersion: typeof ROADMAP_SCHEMA_VERSION;
+  /** Stable identifier — progression is keyed on it. */
+  id: string;
+  title: string;
+  description: string;
+  /** Language of all texts in the file (e.g. "en", "fr"). One language per file. */
+  language: string;
+  estimatedMinutes?: number;
+  difficulty?: RoadmapDifficulty;
+  prerequisites?: string[];
+  steps: RoadmapStep[];
+}

--- a/roadmaps/example-first-architecture.json
+++ b/roadmaps/example-first-architecture.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Derssa/Torollo/main/backend/src/modules/learning/format/roadmap.schema.json",
+  "schemaVersion": 1,
+  "id": "example-first-architecture",
+  "title": "Your first architecture: a web server and its database",
+  "description": "Build a minimal two-tier architecture on the canvas: a web server, a PostgreSQL database, an authorized connection between them, and a locked-down network path. Every step is checked against your real containers.",
+  "language": "en",
+  "estimatedMinutes": 30,
+  "difficulty": "beginner",
+  "prerequisites": [
+    "Docker installed and running",
+    "A Torollo project created and open on the canvas"
+  ],
+  "steps": [
+    {
+      "id": "create-web-server",
+      "title": "Create the web server",
+      "instruction": "From the node library, drag an **Ubuntu** node onto the canvas and name it `web`. Start it and wait until it is running.",
+      "hints": [
+        "Nodes are created by dragging them from the library panel on the left side of the canvas."
+      ],
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "web" }
+        }
+      ]
+    },
+    {
+      "id": "add-database",
+      "title": "Add a PostgreSQL database with a users table",
+      "instruction": "Add a **PostgreSQL** node named `db` and start it. Then open its explorer and create a table named `users` (any columns you like).",
+      "hints": [
+        "Double-click the PostgreSQL node to open its modal — the explorer tab lets you run SQL against the real container.",
+        "A table needs at least one column, for example: `CREATE TABLE users (id SERIAL PRIMARY KEY);`"
+      ],
+      "solution": "Create the node, start it, open its modal and run:\n\n```sql\nCREATE TABLE users (\n  id SERIAL PRIMARY KEY,\n  email TEXT NOT NULL\n);\n```",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "db" }
+        },
+        {
+          "type": "table_exists",
+          "params": { "node": "db", "table": "users" }
+        }
+      ]
+    },
+    {
+      "id": "connect-web-to-db",
+      "title": "Connect the web server to the database",
+      "instruction": "Allow `web` to reach `db` on port **5432** by adding an inbound ALLOW rule on `db`. A connection edge should appear on the canvas.",
+      "hints": [
+        "Security group rules are edited from the node's Security Groups panel: add an inbound rule on `db` with `web` as the source and 5432 as the port."
+      ],
+      "validators": [
+        {
+          "type": "edge_exists",
+          "params": { "source": "web", "target": "db", "port": 5432 }
+        }
+      ]
+    },
+    {
+      "id": "lock-down-database",
+      "title": "Lock down the database",
+      "instruction": "A database should only ever be reachable on its own port. Make sure `web` **cannot** reach `db` on port **80**.",
+      "hints": [
+        "Check the inbound rules on `db`: is there anything broader than port 5432, like an ALLOW on all ports or on 0.0.0.0/0?"
+      ],
+      "validators": [
+        {
+          "type": "port_denied",
+          "params": { "source": "web", "target": "db", "port": 80 }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of Changes

Introduces the **open roadmap file format** (versioned JSON Schema) — the foundation for guided, auto-corrected learning roadmaps in Torollo.

A roadmap is a **purely declarative, versioned JSON file**: `Roadmap → steps[] → { instruction, hints[], solution?, validators[] }`, where a validator is inert data `{ type, params }` — nothing in a roadmap file is ever executed. This format is the public contract that the upcoming validation engine and roadmap player will consume, and that community-written content will target.

**What this PR adds:**
- **JSON Schema (draft 2020-12)** at `backend/src/modules/learning/format/roadmap.schema.json` — `schemaVersion: 1` required (`const`), strict `additionalProperties: false` everywhere so hand-written files fail on typos, `$id` set to the raw GitHub URL for editor autocompletion. Emitted to `backend/dist` via `resolveJsonModule`, so the future roadmap loader gets it at runtime for free.
- **TypeScript types**: source of truth in `backend/src/modules/learning/format/roadmapTypes.ts`, documented KEEP-IN-SYNC copy in `frontend/src/shared/types/roadmap.ts` (same deliberate-duplication policy as the existing `Project` type).
- **Validation function** `validateRoadmap(data)` (pure, no I/O) — every error points at the faulty field: missing required fields are named, unknown fields get a "check for typos" hint, unsupported `schemaVersion` gets an explicit rejection, duplicate step ids report both positions.
- **CLI** for roadmap authors: `cd backend && npm run roadmap:validate -- <file>` (exit 0/1).
- **Reference example** `roadmaps/example-first-architecture.json`: 4 steps, one step with 2 hints + solution, one step with 2 validators of different types, stable slug ids decoupled from position.
- **Format documentation** `docs/roadmap-format.md`: philosophy, copy-pasteable quick start, field-by-field reference, the 8 v1 validator types with their params, the **name-based targeting convention** (nodes are referenced by canvas name, never by runtime ids), the **i18n decision** (one language per file; a translation is a separate file with the same `id`), and the **versioning policy** (v1 frozen at merge — any field change ⇒ `schemaVersion: 2`; new validator `type`s are NOT schema changes).

New runtime dependency: `ajv` ^8 (backend). No CI changes, no root package changes, no frontend build changes.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: 53 tests green (18 new — including one embedding all 8 validator types with their documented params, and one asserting the example file structurally keeps covering the format's reference requirements so it can't silently regress). Frontend: 107 tests green, no regression.

### Manual Verification

- `npm run roadmap:validate -- ../roadmaps/example-first-architecture.json` → `OK ... (roadmap "example-first-architecture", 4 steps)`.
- Deliberately broken files rejected with actionable messages:
  - `schemaVersion: 2` → `/schemaVersion: unsupported schemaVersion 2 — this version of Torollo reads schemaVersion 1`
  - typo field `titel` → `(root): unknown field "titel" — check for typos` + missing `title` named.
- Authored a minimal new roadmap from the Quick start section of `docs/roadmap-format.md` alone, in under 15 minutes.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing