### PR TITLE
refactor(frontend): split the CanvasPage god component

### DIFF
--- a/frontend/src/features/nodes/SecurityGroups/SecurityGroupsModal.tsx
+++ b/frontend/src/features/nodes/SecurityGroups/SecurityGroupsModal.tsx
@@ -1,15 +1,9 @@
 import { X, ShieldAlert, Plus, Trash, ChevronUp, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ContainerData } from '../../../shared/types';
+import type { SecurityGroupRule } from '../../../shared/types/network';
 
-export interface SecurityGroupRule {
-  id: string;
-  type: 'inbound' | 'outbound';
-  action: 'ALLOW' | 'DENY';
-  protocol: 'ALL' | 'TCP' | 'UDP' | 'ICMP';
-  port: string; // e.g. "80", "5432", "ALL"
-  source: string; // e.g. "0.0.0.0/0", "subnet-id", "node-id"
-}
+export type { SecurityGroupRule };
 
 interface SecurityGroupsModalProps {
   nodeId: string;

--- a/frontend/src/features/nodes/VpcNode/VpcModal.tsx
+++ b/frontend/src/features/nodes/VpcNode/VpcModal.tsx
@@ -2,15 +2,9 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Shield, Send, CheckCircle2, XCircle } from 'lucide-react';
 import type { ContainerData } from '../../../shared/types';
-import type { SecurityGroupRule } from '../SecurityGroups/SecurityGroupsModal';
+import type { SecurityGroupRule, VPCConfig } from '../../../shared/types/network';
 
-export interface VPCConfig {
-  name: string;
-  cidr: string;
-  dnsEnabled: boolean;
-  igwEnabled: boolean;
-  description: string;
-}
+export type { VPCConfig };
 
 interface VpcModalProps {
   vpcConfig: VPCConfig;

--- a/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
@@ -3,20 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, createEvent, waitFor, within, act } from '@testing-library/react';
 import CanvasPage from './CanvasPage';
 
-// KNOWN COVERAGE GAPS (accepted, see the frontend test safety net plan):
-// - onNodeDragStart/onNodeDrag/onNodeDragStop (~300 lines): drag-based nesting/
-//   reparenting/overlap logic is not exercised here. jsdom has no real layout
-//   engine, and RTL/fireEvent cannot simulate pointer-based drag sequences
-//   realistically enough to drive this logic meaningfully. Deep coverage of this
-//   logic is deferred to the CanvasPage split-up refactor, which should extract
-//   it into a testable pure function/hook first.
-// - onConnect (drawing a connection creates a default inbound ALLOW rule) and
-//   the edges-derived-from-security-rules rendering (incl. handleDeleteEdge):
-//   both require React Flow handles/edges to be laid out and hit-testable,
-//   which jsdom cannot provide (nodes are never measured — the ResizeObserver
-//   polyfill in setupTests.ts is an intentional no-op). The refactor should
-//   extract the rule<->edge mapping into pure functions so it can be
-//   unit-tested directly.
+// Drag geometry, security-rule creation and rule->edge derivation cannot be
+// driven through jsdom (no layout engine, no measurable React Flow handles).
+// They are unit-tested directly in utils/canvasGeometry.test.ts,
+// utils/securityRules.test.ts and utils/networkConfigOps.test.ts.
 
 function jsonResponse(ok: boolean, body: unknown) {
   return Promise.resolve({ ok, json: () => Promise.resolve(body) } as Response);

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -32,12 +32,11 @@ import VpcNode from '../../features/nodes/VpcNode/VpcNode';
 import SubnetNode from '../../features/nodes/SubnetNode/SubnetNode';
 import RoutingTableModal from '../../features/nodes/SubnetNode/RoutingTableModal';
 import SecurityGroupsModal from '../../features/nodes/SecurityGroups/SecurityGroupsModal';
-import type { SecurityGroupRule } from '../../features/nodes/SecurityGroups/SecurityGroupsModal';
 import VpcModal from '../../features/nodes/VpcNode/VpcModal';
-import type { VPCConfig } from '../../features/nodes/VpcNode/VpcModal';
 import ButtonEdge from './components/ButtonEdge';
 import { validateArchitecture } from '../../shared/utils/architectureValidator';
 import { API_BASE } from '../../shared/types';
+import type { Subnet, NetworkConfig, SecurityGroupRule } from '../../shared/types/network';
 
 // Recursively calculate absolute coordinates of a node
 const getAbsoluteCoordinates = (nodeId: string, currentNodes: Node[]): { x: number; y: number } => {
@@ -56,33 +55,6 @@ interface CanvasPageProps {
   projectName: string;
   onBackToProjects: () => void;
   onTerminalOpen: (id: string, name: string) => void;
-}
-
-interface Subnet {
-  id: string;
-  name: string;
-  type: 'public' | 'private';
-  cidr?: string;
-  vpcId: string | null;
-  position: { x: number; y: number };
-  width: number;
-  height: number;
-  columns?: number;
-  rows?: number;
-  routes: Array<{ destination: string; target: string; description: string }>;
-}
-
-interface NetworkConfig {
-  vpcConfig: VPCConfig;
-  subnets: Subnet[];
-  nodeSubnetMap: Record<string, string>; // nodeId -> subnetId or vpcId
-  nodeSecurityGroups: Record<string, SecurityGroupRule[]>; // nodeId -> SecurityGroupRule[]
-  nodeIpMap: Record<string, string>; // nodeId -> ipAddress
-  loadBalancerAlgorithms?: Record<string, 'round_robin' | 'least_conn'>;
-  loadBalancerTargets?: Record<string, string[]>;
-  loadBalancerTargetPorts?: Record<string, number>;
-  loadBalancerRoutingRules?: Record<string, Array<{ path: string; targetId: string }>>;
-  asgs?: Record<string, { desiredCapacity: number; minCapacity: number; maxCapacity: number; parentId: string; subnetIds: string[] }>;
 }
 
 function autoGrowContainers(

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -36,14 +36,8 @@ import VpcModal from '../../features/nodes/VpcNode/VpcModal';
 import ButtonEdge from './components/ButtonEdge';
 import { API_BASE } from '../../shared/types';
 import { useNetworkConfig } from './hooks/useNetworkConfig';
-import {
-  getAbsoluteCoordinates,
-  findSubnetAtPoint,
-  positionToCell,
-  clampToCell,
-  resolveSubnetChildPosition,
-  subnetSize,
-} from './utils/canvasGeometry';
+import { useCanvasDragDrop } from './hooks/useCanvasDragDrop';
+import { positionToCell, resolveSubnetChildPosition, subnetSize } from './utils/canvasGeometry';
 import {
   addConnectionRule,
   parseEdgeId,
@@ -51,12 +45,7 @@ import {
   removeRulesForConnections,
   buildFirewallEdges,
 } from './utils/securityRules';
-import {
-  autoGrowContainers,
-  assignNodeToSubnet,
-  removeNodeFromConfig,
-  createSubnet,
-} from './utils/networkConfigOps';
+import { assignNodeToSubnet, removeNodeFromConfig } from './utils/networkConfigOps';
 
 interface CanvasPageProps {
   projectId: string;
@@ -105,8 +94,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   const dropPositionsRef = useRef<Record<string, { x: number; y: number }>>({});
   const dropSubnetsRef = useRef<Record<string, string>>({});
   const pendingSubnetIdRef = useRef<string | null>(null);
-  const dragStartPositionsRef = useRef<Record<string, { x: number; y: number; parentId?: string }>>({});
-  const draggingNodeIdRef = useRef<string | null>(null);
 
   // React Flow managed nodes state
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
@@ -116,6 +103,28 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
   const { networkConfig, saveNetworkConfig, fetchNetworkConfig, triggerArchitectureAudit } =
     useNetworkConfig({ projectId, containers, showNotification });
+
+  // A service was dropped inside a subnet: stash the drop context and open the create modal
+  const onRequestCreateNode = useCallback((drop: { position: { x: number; y: number }; type: string; subnetId: string }) => {
+    setDropState({ position: drop.position, type: drop.type });
+    pendingSubnetIdRef.current = drop.subnetId;
+    setShowCreateModal(true);
+  }, []);
+
+  const { onNodeDragStart, onNodeDrag, onNodeDragStop, onNodesDelete, onDragOver, onDrop, draggingNodeIdRef } =
+    useCanvasDragDrop({
+      reactFlowInstance,
+      networkConfig,
+      containers,
+      positionsRef,
+      setNodes,
+      projectId,
+      saveNetworkConfig,
+      triggerArchitectureAudit,
+      showNotification,
+      fetchContainers,
+      onRequestCreateNode,
+    });
 
   const [showVpcSettings, setShowVpcSettings] = useState(false);
   const [showTrafficSimulator, setShowTrafficSimulator] = useState(false);
@@ -448,265 +457,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
     // Save current positions (including auto-placed new nodes) to localStorage
     localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
-  }, [projectId, containers, opErrors, startContainer, stopContainer, onTerminalOpen, setNodes, networkConfig, saveNetworkConfig, handleDeleteSubnet, handleSubnetResize]);
+  }, [projectId, containers, opErrors, startContainer, stopContainer, onTerminalOpen, setNodes, networkConfig, saveNetworkConfig, handleDeleteSubnet, handleSubnetResize, draggingNodeIdRef, showNotification]);
 
 
-
-  // Track start position on drag start to allow rollback/reversion if drop is invalid
-  const onNodeDragStart = useCallback((_event: any, node: Node) => {
-    draggingNodeIdRef.current = node.id;
-    dragStartPositionsRef.current[node.id] = {
-      x: node.position.x,
-      y: node.position.y,
-      parentId: node.parentId
-    };
-  }, []);
-
-  const onNodeDrag = useCallback((_event: any, draggedNode: Node) => {
-    if (!reactFlowInstance) return;
-
-    const currentNodes = reactFlowInstance.getNodes();
-
-    // Calculate absolute coordinates of dragged node center
-    let absX = draggedNode.position.x;
-    let absY = draggedNode.position.y;
-    if (draggedNode.parentId) {
-      const parentPos = getAbsoluteCoordinates(draggedNode.parentId, currentNodes);
-      absX += parentPos.x;
-      absY += parentPos.y;
-    }
-
-    const nodeWidth = draggedNode.width || (draggedNode.type === 'subnet' ? 260 : 220);
-    const nodeHeight = draggedNode.height || (draggedNode.type === 'subnet' ? 180 : 140);
-    const centerX = absX + nodeWidth / 2;
-    const centerY = absY + nodeHeight / 2;
-
-    // Check intersection with subnets: hovering one is valid for a service
-    // node, invalid for a subnet (no nesting).
-    const center = { x: centerX, y: centerY };
-    const hoveredSubnet = draggedNode.type !== 'subnet'
-      ? findSubnetAtPoint(center, networkConfig.subnets)
-      : findSubnetAtPoint(center, networkConfig.subnets, draggedNode.id);
-    const hoveredId = hoveredSubnet?.id ?? null;
-    const isValid = !!hoveredSubnet && draggedNode.type !== 'subnet';
-
-    // Update real-time position in coordinates map for auto-growing calculations
-    const tempNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
-
-    // If we are hovering a valid container, assume it's parented temporarily for sizing check
-    if (hoveredId && isValid) {
-      tempNodeSubnetMap[draggedNode.id] = hoveredId;
-    } else if (draggedNode.type !== 'subnet') {
-      // Dragging service node outside of any container
-      delete tempNodeSubnetMap[draggedNode.id];
-    }
-
-
-
-
-
-    const tempConfig = {
-      ...networkConfig,
-      nodeSubnetMap: tempNodeSubnetMap
-    };
-
-    const grownConfig = autoGrowContainers(tempConfig);
-
-    setNodes(prev => prev.map(n => {
-      // Apply grew sizes to subnets
-      if (n.type === 'subnet') {
-        const subnet = grownConfig.subnets.find(s => s.id === n.id);
-        const isHoverTarget = n.id === hoveredId;
-        return {
-          ...n,
-          style: { ...n.style, width: subnet?.width, height: subnet?.height },
-          data: {
-            ...n.data,
-            hoverStatus: isHoverTarget ? (isValid ? 'valid' : 'invalid') : null
-          }
-        };
-      }
-      return n;
-    }));
-
-  }, [reactFlowInstance, networkConfig, containers, setNodes]);
-
-  // Save position to ref and localStorage when drag ends (auto-save with overlapping logic)
-  const onNodeDragStop = useCallback((_event: any, draggedNode: Node) => {
-    draggingNodeIdRef.current = null;
-    if (!reactFlowInstance) return;
-
-    const currentNodes = reactFlowInstance.getNodes();
-
-    // Reset all hoverStatus
-    setNodes(prev => prev.map(n => {
-      if (n.data && n.data.hoverStatus) {
-        return { ...n, data: { ...n.data, hoverStatus: null } };
-      }
-      return n;
-    }));
-
-    // Calculate final absolute coordinates of dragged node
-    let absX = draggedNode.position.x;
-    let absY = draggedNode.position.y;
-    if (draggedNode.parentId) {
-      const parentPos = getAbsoluteCoordinates(draggedNode.parentId, currentNodes);
-      absX += parentPos.x;
-      absY += parentPos.y;
-    }
-
-    const revertNode = (message: string) => {
-      showNotification({ type: 'error', message });
-      const original = dragStartPositionsRef.current[draggedNode.id];
-      if (original) {
-        setNodes(prev => prev.map(n => {
-          if (n.id === draggedNode.id) {
-            return {
-              ...n,
-              position: { x: original.x, y: original.y },
-              parentId: original.parentId
-            };
-          }
-          return n;
-        }));
-      }
-    };
-
-    if (draggedNode.type === 'subnet') {
-      const subnetWidth = 260;
-      const subnetHeight = 180;
-      const subnetCenter = { x: absX + subnetWidth / 2, y: absY + subnetHeight / 2 };
-
-      // Check if dropped inside another subnet
-      const insideAnotherSubnet = !!findSubnetAtPoint(subnetCenter, networkConfig.subnets, draggedNode.id);
-
-      if (insideAnotherSubnet) {
-        revertNode('Invalid placement: Subnets cannot be nested inside other subnets.');
-        return;
-      }
-
-      const updatedSubnets = networkConfig.subnets.map(s => {
-        if (s.id === draggedNode.id) {
-          return {
-            ...s,
-            position: { x: absX, y: absY }
-          };
-        }
-        return s;
-      });
-
-      const newConfig = { ...networkConfig, subnets: updatedSubnets };
-      saveNetworkConfig(newConfig);
-      triggerArchitectureAudit(newConfig);
-    }
-    else {
-      // Container/Service node
-      const nodeCenter = { x: absX + 110, y: absY + 70 };
-      const targetSubnet = findSubnetAtPoint(nodeCenter, networkConfig.subnets);
-      const targetSubnetId = targetSubnet?.id ?? null;
-
-      const original = dragStartPositionsRef.current[draggedNode.id];
-      const oldParentId = original?.parentId;
-      const newParentId = targetSubnetId || undefined;
-
-      if (oldParentId !== newParentId) {
-        const oldSubnet = networkConfig.subnets.find(s => s.id === oldParentId);
-        const newSubnet = networkConfig.subnets.find(s => s.id === newParentId);
-
-        if (oldParentId && oldParentId.startsWith('subnet-')) {
-          showNotification({ type: 'warning', message: `Node "${draggedNode.data.name}" removed from Subnet "${oldSubnet?.name || 'Subnet'}"` });
-        }
-
-        if (newParentId && newParentId.startsWith('subnet-')) {
-          showNotification({ type: 'success', message: `Node "${draggedNode.data.name}" added to Subnet "${newSubnet?.name || 'Subnet'}"` });
-        }
-      }
-
-      if (!targetSubnet) {
-        // Revert container node drag to its original subnet position
-        showNotification({ type: 'warning', message: 'Nodes must reside within a subnet.' });
-        const original = dragStartPositionsRef.current[draggedNode.id];
-        if (original) {
-          setNodes(prev => prev.map(n => {
-            if (n.id === draggedNode.id) {
-              return {
-                ...n,
-                position: { x: original.x, y: original.y },
-                parentId: original.parentId
-              };
-            }
-            return n;
-          }));
-        }
-        return;
-      }
-
-      positionsRef.current[draggedNode.id] = clampToCell(
-        { x: absX - targetSubnet.position.x, y: absY - targetSubnet.position.y },
-        targetSubnet.columns || 2,
-        targetSubnet.rows || 1
-      );
-      localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
-
-      const newConfig = assignNodeToSubnet(networkConfig, draggedNode.id, targetSubnet.id);
-      saveNetworkConfig(newConfig);
-      triggerArchitectureAudit(newConfig);
-    }
-  }, [reactFlowInstance, networkConfig, projectId, saveNetworkConfig, setNodes, triggerArchitectureAudit, showNotification]);
-
-  const onNodesDelete = useCallback((deleted: Node[]) => {
-    const blockedNode = deleted.find(node => {
-      const usingAsgs = Object.keys(networkConfig?.asgs || {}).filter(asgId => networkConfig?.asgs?.[asgId]?.parentId === node.id);
-      return usingAsgs.some(asgId => {
-        const container = containers.find(c => c.id === asgId);
-        return container && container.state === 'running';
-      });
-    });
-
-    if (blockedNode) {
-      showNotification({
-        type: 'error',
-        message: `Cannot delete node "${blockedNode.data?.name || 'Node'}": it is used as a template by an active Auto Scaling Group. Please stop the ASG first.`
-      });
-      fetchContainers();
-      return;
-    }
-
-    let updatedSubnets = [...networkConfig.subnets];
-    const updatedNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
-    const updatedSecurityGroups = { ...networkConfig.nodeSecurityGroups };
-    const updatedNodeIpMap = { ...networkConfig.nodeIpMap || {} };
-    let configChanged = false;
-
-    deleted.forEach(node => {
-      if (node.type === 'subnet') {
-        updatedSubnets = updatedSubnets.filter(s => s.id !== node.id);
-        Object.keys(updatedNodeSubnetMap).forEach(nodeId => {
-          if (updatedNodeSubnetMap[nodeId] === node.id) {
-            delete updatedNodeSubnetMap[nodeId];
-            delete updatedNodeIpMap[nodeId];
-          }
-        });
-        configChanged = true;
-      }
-      // If it's a node being deleted directly
-      if (updatedNodeSubnetMap[node.id]) {
-        delete updatedNodeSubnetMap[node.id];
-        delete updatedNodeIpMap[node.id];
-        configChanged = true;
-      }
-    });
-
-    if (configChanged || deleted.length > 0) {
-      saveNetworkConfig({
-        ...networkConfig,
-        subnets: updatedSubnets,
-        nodeSubnetMap: updatedNodeSubnetMap,
-        nodeSecurityGroups: updatedSecurityGroups,
-        nodeIpMap: updatedNodeIpMap
-      });
-    }
-  }, [networkConfig, saveNetworkConfig, containers, fetchContainers, showNotification]);
 
   const saveGraphLocally = () => {
     const currentPositions: Record<string, { x: number; y: number }> = {};
@@ -824,72 +577,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       setDeleteTarget(null);
     }
   };
-
-  // React Flow Drag-and-Drop handlers
-  const onDragOver = useCallback((event: React.DragEvent) => {
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-  }, []);
-
-  const onDrop = useCallback(
-    (event: React.DragEvent) => {
-      event.preventDefault();
-
-      if (!reactFlowInstance) return;
-
-      const type = event.dataTransfer.getData('application/reactflow');
-      if (!type) return;
-
-      const position = reactFlowInstance.screenToFlowPosition({
-        x: event.clientX,
-        y: event.clientY,
-      });
-
-      if (type === 'subnet-public' || type === 'subnet-private') {
-        const newSubnet = createSubnet(
-          type === 'subnet-public' ? 'public' : 'private',
-          position,
-          networkConfig.vpcConfig.cidr,
-          networkConfig.subnets.length
-        );
-
-        // Check if dropped inside another subnet
-        const subnetCenter = { x: position.x + newSubnet.width / 2, y: position.y + newSubnet.height / 2 };
-        if (findSubnetAtPoint(subnetCenter, networkConfig.subnets)) {
-          showNotification({ type: 'error', message: 'Invalid placement: Subnets cannot be nested inside other subnets.' });
-          return;
-        }
-
-        const newConfig = {
-          ...networkConfig,
-          subnets: [...networkConfig.subnets, newSubnet]
-        };
-        saveNetworkConfig(newConfig);
-        triggerArchitectureAudit(newConfig);
-      } else {
-        const nodeCenter = { x: position.x + 110, y: position.y + 70 };
-        const targetSubnet = findSubnetAtPoint(nodeCenter, networkConfig.subnets);
-
-        if (!targetSubnet) {
-          showNotification({ type: 'error', message: 'Nodes must reside within a subnet.' });
-          return;
-        }
-
-        const finalDropPos = clampToCell(
-          { x: position.x - targetSubnet.position.x, y: position.y - targetSubnet.position.y },
-          targetSubnet.columns || 2,
-          targetSubnet.rows || 1
-        );
-
-        setDropState({ position: finalDropPos, type });
-        pendingSubnetIdRef.current = targetSubnet.id;
-        setShowCreateModal(true);
-      }
-    },
-    [reactFlowInstance, networkConfig, saveNetworkConfig, showNotification, triggerArchitectureAudit]
-  );
-
-
 
   return (
     <div style={styles.wrapper}>

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -5,34 +5,22 @@ import '@xyflow/react/dist/style.css';
 
 import UbuntuNode from '../../features/nodes/UbuntuNode/UbuntuNode';
 import NatNode from '../../features/nodes/NatNode/NatNode';
-import NatGatewayModal from '../../features/nodes/NatNode/NatGatewayModal';
 import PostgresNode from '../../features/nodes/PostgresNode/PostgresNode';
-import PostgresModal from '../../features/nodes/PostgresNode/PostgresModal';
 import NoSqlNode from '../../features/nodes/NoSqlNode/NoSqlNode';
-import NoSqlModal from '../../features/nodes/NoSqlNode/NoSqlModal';
 import RedisNode from '../../features/nodes/RedisNode/RedisNode';
-import RedisModal from '../../features/nodes/RedisNode/RedisModal';
-
 import LoadBalancerNode from '../../features/nodes/LoadBalancerNode/LoadBalancerNode';
-import LoadBalancerModal from '../../features/nodes/LoadBalancerNode/LoadBalancerModal';
 import AsgNode from '../../features/nodes/AsgNode/AsgNode';
-import AsgModal from '../../features/nodes/AsgNode/AsgModal';
+import VpcNode from '../../features/nodes/VpcNode/VpcNode';
+import SubnetNode from '../../features/nodes/SubnetNode/SubnetNode';
 import NodeLibrary from './components/NodeLibrary';
 import { useContainers } from '../../shared/hooks/useContainers';
 import { useToast } from '../../shared/hooks/useToast';
 import { ToastNotification } from '../../shared/components/Toast';
 import { DockerUnavailableBanner } from '../../shared/components/DockerUnavailableBanner';
-import InputModal from '../../shared/components/InputModal';
-import ConfirmModal from '../../shared/components/ConfirmModal';
 import CanvasTopbar from './components/CanvasTopbar';
 import CanvasFooter from './components/CanvasFooter';
-
-// Phase 3 Imports
-import VpcNode from '../../features/nodes/VpcNode/VpcNode';
-import SubnetNode from '../../features/nodes/SubnetNode/SubnetNode';
-import RoutingTableModal from '../../features/nodes/SubnetNode/RoutingTableModal';
-import SecurityGroupsModal from '../../features/nodes/SecurityGroups/SecurityGroupsModal';
-import VpcModal from '../../features/nodes/VpcNode/VpcModal';
+import CanvasModals from './components/CanvasModals';
+import type { InspectorState } from './components/CanvasModals';
 import ButtonEdge from './components/ButtonEdge';
 import { API_BASE } from '../../shared/types';
 import { useNetworkConfig } from './hooks/useNetworkConfig';
@@ -52,15 +40,6 @@ interface CanvasPageProps {
   projectName: string;
   onBackToProjects: () => void;
   onTerminalOpen: (id: string, name: string) => void;
-}
-
-/** Which inspector modal is open. They are mutually exclusive, hence one state. */
-interface InspectorState {
-  kind: 'postgres' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'asg' | 'subnet-routes' | 'security-group';
-  id: string;
-  name: string;
-  /** Only set for kind 'security-group' (the modal displays the node type). */
-  nodeType?: string;
 }
 
 /** Inspector opened by each node type's magnifier action ('sql' shares the Postgres modal). */
@@ -638,260 +617,33 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
       <CanvasFooter containers={containers} />
 
-      {/* Modals */}
-      {showCreateModal && (
-        <InputModal
-          title={
-            (dropState?.type === 'postgres' || dropState?.type === 'sql')
-              ? "Create SQL Database Node"
-              : dropState?.type === 'nosql'
-                ? "Create NoSQL Database Node"
-                : dropState?.type === 'redis'
-                  ? "Create Cache Store Node"
-                : dropState?.type === 'nat'
-                  ? "Create NAT Gateway Node"
-                  : dropState?.type === 'loadbalancer'
-                    ? "Create Load Balancer Node"
-                    : dropState?.type === 'autoscalinggroup'
-                      ? "Create Auto Scaling Group Node"
-                      : "Create Ubuntu Node"
-          }
-          label="Give your new container a descriptive name."
-          placeholder={
-            (dropState?.type === 'postgres' || dropState?.type === 'sql')
-              ? "e.g. sql-1"
-              : dropState?.type === 'nosql'
-                ? "e.g. nosql-1"
-                : dropState?.type === 'redis'
-                  ? "e.g. redis-1"
-                : dropState?.type === 'nat'
-                  ? "e.g. nat-1"
-                  : dropState?.type === 'loadbalancer'
-                    ? "e.g. alb-1"
-                    : dropState?.type === 'autoscalinggroup'
-                      ? "e.g. asg-1"
-                      : "e.g. server-1"
-          }
-          maxLength={20}
-          restrictPattern={/[^a-zA-Z0-9-]/g}
-          defaultValue={
-            (() => {
-              const type = dropState?.type || 'ubuntu';
-              const prefix =
-                (type === 'postgres' || type === 'sql')
-                  ? 'sql-'
-                  : type === 'nosql'
-                    ? 'nosql-'
-                    : type === 'redis'
-                      ? 'redis-'
-                    : type === 'nat'
-                      ? 'nat-'
-                      : type === 'loadbalancer'
-                        ? 'alb-'
-                        : type === 'autoscalinggroup'
-                          ? 'asg-'
-                          : 'srv-';
-              let suffix = 1;
-              while (containers.some(c => c.name === `${prefix}${suffix}`)) {
-                suffix++;
-              }
-              return `${prefix}${suffix}`;
-            })()
-          }
-          submitText="Create Node"
-          onSubmit={handleCreateNode}
-          onCancel={handleCancelCreate}
-        />
-      )}
-
-      {deleteTarget && (
-        <ConfirmModal
-          title="Delete Container"
-          message="This will permanently stop and remove this container. This action cannot be undone."
-          confirmText="Delete"
-          variant="danger"
-          onConfirm={handleDeleteConfirmed}
-          onCancel={() => setDeleteTarget(null)}
-        />
-      )}
-
-      {renamingNode && (
-        <InputModal
-          title="Rename Node"
-          label="Enter a new name for this node."
-          placeholder="e.g. api-gateway"
-          maxLength={20}
-          restrictPattern={/[^a-zA-Z0-9-]/g}
-          defaultValue={renamingNode.currentName}
-          submitText="Rename"
-          onSubmit={handleRenameNode}
-          onCancel={() => setRenamingNode(null)}
-        />
-      )}
-
-      {inspector?.kind === 'postgres' && (
-        <PostgresModal
-          containerId={inspector.id}
-          nodeName={inspector.name}
-          projectId={projectId}
-          onClose={closeInspector}
-        />
-      )}
-
-      {inspector?.kind === 'nosql' && (
-        <NoSqlModal
-          containerId={inspector.id}
-          nodeName={inspector.name}
-          projectId={projectId}
-          onClose={closeInspector}
-        />
-      )}
-
-      {inspector?.kind === 'redis' && (
-        <RedisModal
-          containerId={inspector.id}
-          nodeName={inspector.name}
-          projectId={projectId}
-          onClose={closeInspector}
-        />
-      )}
-
-      {inspector?.kind === 'nat' && (
-        <NatGatewayModal
-          nodeName={inspector.name}
-          ipAddress={containers.find(c => c.id === inspector.id)?.ip || networkConfig.nodeIpMap?.[inspector.id]}
-          state={containers.find(c => c.id === inspector.id)?.state || 'stopped'}
-          onClose={closeInspector}
-        />
-      )}
-
-      {inspector?.kind === 'loadbalancer' && (
-        <LoadBalancerModal
-          containerId={inspector.id}
-          nodeName={inspector.name}
-          ipAddress={containers.find(c => c.id === inspector.id)?.ip || networkConfig.nodeIpMap?.[inspector.id]}
-          port={containers.find(c => c.id === inspector.id)?.port}
-          state={containers.find(c => c.id === inspector.id)?.state || 'stopped'}
-          config={{
-            loadBalancerAlgorithm: networkConfig.loadBalancerAlgorithms?.[inspector.id],
-            loadBalancerTargets: networkConfig.loadBalancerTargets?.[inspector.id],
-            loadBalancerTargetPort: networkConfig.loadBalancerTargetPorts?.[inspector.id],
-            loadBalancerRoutingRules: networkConfig.loadBalancerRoutingRules?.[inspector.id]
-          }}
-          allNodes={containers}
-          onClose={closeInspector}
-          onSaveConfig={async (algorithm, targets, targetPort, routingRules) => {
-            const newConfig = {
-              ...networkConfig,
-              loadBalancerAlgorithms: { ...(networkConfig.loadBalancerAlgorithms || {}), [inspector.id]: algorithm },
-              loadBalancerTargets: { ...(networkConfig.loadBalancerTargets || {}), [inspector.id]: targets },
-              loadBalancerTargetPorts: { ...(networkConfig.loadBalancerTargetPorts || {}), [inspector.id]: targetPort },
-              loadBalancerRoutingRules: { ...(networkConfig.loadBalancerRoutingRules || {}), [inspector.id]: routingRules }
-            };
-            await saveNetworkConfig(newConfig);
-            showToast("Load Balancer configuration applied");
-            triggerArchitectureAudit(newConfig);
-          }}
-        />
-      )}
-
-      {inspector?.kind === 'asg' && (
-        <AsgModal
-          asgId={inspector.id}
-          nodeName={inspector.name}
-          projectId={projectId}
-          config={networkConfig}
-          containers={containers}
-          onClose={closeInspector}
-          onSaveConfig={async (asgConfig) => {
-            const newConfig = {
-              ...networkConfig,
-              asgs: { ...(networkConfig.asgs || {}), [inspector.id]: asgConfig }
-            };
-            await saveNetworkConfig(newConfig);
-            showToast("Auto Scaling Group configuration saved");
-            triggerArchitectureAudit(newConfig);
-          }}
-          onRefreshContainers={fetchContainers}
-        />
-      )}
-
-      {inspector?.kind === 'subnet-routes' && (
-        <RoutingTableModal
-          subnetId={inspector.id}
-          subnetName={inspector.name}
-          routes={networkConfig.subnets.find(s => s.id === inspector.id)?.routes || []}
-          natGateways={containers.filter(c => c.type === 'nat').map(c => c.name)}
-          onClose={closeInspector}
-          onSave={async (updatedRoutes) => {
-            const updatedSubnets = networkConfig.subnets.map(s => {
-              if (s.id === inspector.id) {
-                return { ...s, routes: updatedRoutes };
-              }
-              return s;
-            });
-            await saveNetworkConfig({ ...networkConfig, subnets: updatedSubnets });
-          }}
-        />
-      )}
-
-      {inspector?.kind === 'security-group' && (
-        <SecurityGroupsModal
-          nodeId={inspector.id}
-          nodeName={inspector.name}
-          nodeType={inspector.nodeType || 'ubuntu'}
-          allNodes={containers}
-          allSubnets={networkConfig.subnets.map(s => ({ id: s.id, name: s.name }))}
-          rules={networkConfig.nodeSecurityGroups[inspector.id] || []}
-          onClose={closeInspector}
-          onSaveRules={(rules) => {
-            const newConfig = {
-              ...networkConfig,
-              nodeSecurityGroups: { ...networkConfig.nodeSecurityGroups, [inspector.id]: rules }
-            };
-            saveNetworkConfig(newConfig);
-            triggerArchitectureAudit(newConfig);
-          }}
-        />
-      )}
-
-      {showVpcSettings && (
-        <VpcModal
-          vpcConfig={networkConfig.vpcConfig}
-          subnets={networkConfig.subnets}
-          nodes={containers}
-          nodeSecurityGroups={networkConfig.nodeSecurityGroups}
-          nodeSubnetMap={networkConfig.nodeSubnetMap}
-          onClose={() => setShowVpcSettings(false)}
-          onSaveVpcConfig={(config) => {
-            const newConfig = { ...networkConfig, vpcConfig: config };
-            saveNetworkConfig(newConfig);
-            setShowVpcSettings(false);
-            showToast("VPC configuration saved");
-            triggerArchitectureAudit(newConfig);
-          }}
-          initialTab="info"
-        />
-      )}
-
-      {showTrafficSimulator && (
-        <VpcModal
-          vpcConfig={networkConfig.vpcConfig}
-          subnets={networkConfig.subnets}
-          nodes={containers}
-          nodeSecurityGroups={networkConfig.nodeSecurityGroups}
-          nodeSubnetMap={networkConfig.nodeSubnetMap}
-          onClose={() => setShowTrafficSimulator(false)}
-          onSaveVpcConfig={(config) => {
-            const newConfig = { ...networkConfig, vpcConfig: config };
-            saveNetworkConfig(newConfig);
-            setShowTrafficSimulator(false);
-            showToast("VPC configuration saved");
-            triggerArchitectureAudit(newConfig);
-          }}
-          initialTab="simulator"
-        />
-      )}
+      <CanvasModals
+        projectId={projectId}
+        containers={containers}
+        networkConfig={networkConfig}
+        saveNetworkConfig={saveNetworkConfig}
+        triggerArchitectureAudit={triggerArchitectureAudit}
+        showToast={showToast}
+        fetchContainers={fetchContainers}
+        createNode={showCreateModal ? {
+          type: dropState?.type || 'ubuntu',
+          onSubmit: handleCreateNode,
+          onCancel: handleCancelCreate,
+        } : null}
+        deleteNode={deleteTarget ? {
+          onConfirm: handleDeleteConfirmed,
+          onCancel: () => setDeleteTarget(null),
+        } : null}
+        renameNode={renamingNode ? {
+          currentName: renamingNode.currentName,
+          onSubmit: handleRenameNode,
+          onCancel: () => setRenamingNode(null),
+        } : null}
+        inspector={inspector}
+        onCloseInspector={closeInspector}
+        vpcSettings={showVpcSettings ? { onClose: () => setShowVpcSettings(false) } : null}
+        trafficSimulator={showTrafficSimulator ? { onClose: () => setShowTrafficSimulator(false) } : null}
+      />
 
       {dockerUnavailable && <DockerUnavailableBanner />}
 

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -34,9 +34,8 @@ import RoutingTableModal from '../../features/nodes/SubnetNode/RoutingTableModal
 import SecurityGroupsModal from '../../features/nodes/SecurityGroups/SecurityGroupsModal';
 import VpcModal from '../../features/nodes/VpcNode/VpcModal';
 import ButtonEdge from './components/ButtonEdge';
-import { validateArchitecture } from '../../shared/utils/architectureValidator';
 import { API_BASE } from '../../shared/types';
-import type { NetworkConfig } from '../../shared/types/network';
+import { useNetworkConfig } from './hooks/useNetworkConfig';
 import {
   getAbsoluteCoordinates,
   findSubnetAtPoint,
@@ -107,8 +106,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   const dropSubnetsRef = useRef<Record<string, string>>({});
   const pendingSubnetIdRef = useRef<string | null>(null);
   const dragStartPositionsRef = useRef<Record<string, { x: number; y: number; parentId?: string }>>({});
-  const prevDbCountRef = useRef(0);
-  const hasShownCacheWarningRef = useRef(false);
   const draggingNodeIdRef = useRef<string | null>(null);
 
   // React Flow managed nodes state
@@ -117,22 +114,8 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   // Ref to track saved positions (avoids re-render loops)
   const positionsRef = useRef<Record<string, { x: number; y: number }>>({});
 
-  const defaultVpcConfig = useMemo(() => ({
-    name: 'Main Network',
-    cidr: '10.0.0.0/16',
-    dnsEnabled: true,
-    igwEnabled: true,
-    description: 'Project-wide Virtual Private Cloud'
-  }), []);
-
-  // Network Simulation state
-  const [networkConfig, setNetworkConfig] = useState<NetworkConfig>({
-    vpcConfig: defaultVpcConfig,
-    subnets: [],
-    nodeSubnetMap: {},
-    nodeSecurityGroups: {},
-    nodeIpMap: {}
-  });
+  const { networkConfig, saveNetworkConfig, fetchNetworkConfig, triggerArchitectureAudit } =
+    useNetworkConfig({ projectId, containers, showNotification });
 
   const [showVpcSettings, setShowVpcSettings] = useState(false);
   const [showTrafficSimulator, setShowTrafficSimulator] = useState(false);
@@ -153,74 +136,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   const edgeTypes = useMemo(() => ({
     buttonEdge: ButtonEdge
   }), []);
-
-  // Save/load network config helper
-  const saveNetworkConfig = useCallback((newConfig: NetworkConfig) => {
-    const grownConfig = autoGrowContainers(newConfig);
-    setNetworkConfig(grownConfig);
-    localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(grownConfig));
-
-    // Sync to backend to trigger runtime enforcement
-    return fetch(`${API_BASE}/api/projects/${projectId}/network-config`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ networkConfig: grownConfig })
-    })
-    .then(res => {
-      if (!res.ok) {
-        throw new Error(`Failed to save network config (HTTP ${res.status})`);
-      }
-      return res.json();
-    })
-    .then(data => {
-      if (data && data.vpcConfig) {
-        setNetworkConfig(data);
-        localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(data));
-      }
-    })
-    .catch(err => {
-      console.error('Failed to sync network configuration to backend:', err);
-      throw err;
-    });
-  }, [projectId]);
-
-  const triggerArchitectureAudit = useCallback((configToValidate: NetworkConfig) => {
-    const result = validateArchitecture(configToValidate, containers);
-
-    // Detect DB nodes count
-    const currentDbCount = containers.filter(c => ['postgres', 'sql', 'nosql'].includes(c.type || '')).length;
-    if (currentDbCount > prevDbCountRef.current) {
-      hasShownCacheWarningRef.current = false;
-    }
-    prevDbCountRef.current = currentDbCount;
-
-    let warnings = result.warnings;
-    const hasCacheWarning = warnings.some(w => w.includes('No caching tier'));
-
-    if (hasCacheWarning) {
-      if (hasShownCacheWarningRef.current) {
-        // Filter it out so it doesn't toast again
-        warnings = warnings.filter(w => !w.includes('No caching tier'));
-      } else {
-        // Mark as shown so subsequent non-add actions don't trigger it
-        hasShownCacheWarningRef.current = true;
-      }
-    } else {
-      if (currentDbCount === 0) {
-        hasShownCacheWarningRef.current = false;
-      }
-    }
-
-    if (result.errors.length > 0) {
-      showNotification({ type: 'error', message: result.errors[0] });
-    } else if (warnings.length > 0) {
-      showNotification({ type: 'warning', message: warnings[0] });
-    } else if (result.successes.length > 0) {
-      showNotification({ type: 'success', message: result.successes[0] });
-    }
-  }, [containers, showNotification]);
 
   const handleDeleteSubnet = useCallback((subnetId: string) => {
     const hasNodes = Object.values(networkConfig.nodeSubnetMap).some(sid => sid === subnetId);
@@ -342,49 +257,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     showToast("Firewall rule removed");
     triggerArchitectureAudit(newConfig);
   }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
-
-  const fetchNetworkConfig = useCallback(() => {
-    fetch(`${API_BASE}/api/projects/${projectId}/network-config`)
-      .then(res => res.json())
-      .then(data => {
-        if (data && data.vpcConfig) {
-          setNetworkConfig(data);
-          localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(data));
-        } else {
-          const savedConfig = localStorage.getItem(`akal-lab-network-config-${projectId}`);
-          if (savedConfig) {
-            const parsed = JSON.parse(savedConfig);
-            if (!parsed.vpcConfig) {
-              parsed.vpcConfig = defaultVpcConfig;
-            }
-            setNetworkConfig(parsed);
-          } else {
-            setNetworkConfig({
-              vpcConfig: defaultVpcConfig,
-              subnets: [],
-              nodeSubnetMap: {},
-              nodeSecurityGroups: {},
-              nodeIpMap: {}
-            });
-          }
-        }
-      })
-      .catch(err => {
-        console.error('Failed to fetch network config from backend, using localStorage:', err);
-        const savedConfig = localStorage.getItem(`akal-lab-network-config-${projectId}`);
-        if (savedConfig) {
-          try {
-            const parsed = JSON.parse(savedConfig);
-            if (!parsed.vpcConfig) {
-              parsed.vpcConfig = defaultVpcConfig;
-            }
-            setNetworkConfig(parsed);
-          } catch (e) {
-            console.error(e);
-          }
-        }
-      });
-  }, [projectId, defaultVpcConfig]);
 
   // Load saved positions, network configurations and start polling
   useEffect(() => {

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -36,7 +36,7 @@ import VpcModal from '../../features/nodes/VpcNode/VpcModal';
 import ButtonEdge from './components/ButtonEdge';
 import { validateArchitecture } from '../../shared/utils/architectureValidator';
 import { API_BASE } from '../../shared/types';
-import type { Subnet, NetworkConfig, SecurityGroupRule } from '../../shared/types/network';
+import type { Subnet, NetworkConfig } from '../../shared/types/network';
 import {
   getAbsoluteCoordinates,
   findSubnetAtPoint,
@@ -45,6 +45,14 @@ import {
   resolveSubnetChildPosition,
   subnetSize,
 } from './utils/canvasGeometry';
+import {
+  createDefaultRules,
+  addConnectionRule,
+  parseEdgeId,
+  removeEdgeRule,
+  removeRulesForConnections,
+  buildFirewallEdges,
+} from './utils/securityRules';
 
 interface CanvasPageProps {
   projectId: string;
@@ -297,82 +305,22 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   }, [networkConfig, containers, saveNetworkConfig, triggerArchitectureAudit, showNotification]);
 
   const handleDeleteEdge = useCallback((edgeId: string) => {
-    const match = edgeId.match(/^edge-([^-]+)-([^-]+)-(.+)$/);
-    if (!match) return;
-    const [, sourceId, targetId, port] = match;
+    const parsed = parseEdgeId(edgeId);
+    if (!parsed) return;
 
-    const updatedSecurityGroups = { ...networkConfig.nodeSecurityGroups };
-    if (updatedSecurityGroups[targetId]) {
-      updatedSecurityGroups[targetId] = updatedSecurityGroups[targetId].filter(rule => {
-        return !(rule.type === 'inbound' && rule.action === 'ALLOW' && rule.port === port && (rule.source === sourceId || rule.source === '0.0.0.0/0'));
-      });
-      const newConfig = { ...networkConfig, nodeSecurityGroups: updatedSecurityGroups };
-      saveNetworkConfig(newConfig);
-      showToast("Firewall connection removed");
-      triggerArchitectureAudit(newConfig);
-    }
+    const newConfig = removeEdgeRule(networkConfig, parsed.sourceId, parsed.targetId, parsed.port);
+    if (!newConfig) return;
+
+    saveNetworkConfig(newConfig);
+    showToast("Firewall connection removed");
+    triggerArchitectureAudit(newConfig);
   }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
 
-  // Dynamic Edges builder representing firewall rules
-  const edges = useMemo(() => {
-    const edgesList: Edge[] = [];
-
-    containers.forEach(destNode => {
-      if (destNode.type === 'nat') return;
-      const destRules = networkConfig.nodeSecurityGroups[destNode.id] || [];
-      const destSubnetId = networkConfig.nodeSubnetMap[destNode.id];
-      if (!destSubnetId) return;
-      const destSubnet = networkConfig.subnets.find(s => s.id === destSubnetId);
-      const destVpcId = destSubnet?.vpcId;
-      if (!destVpcId) return;
-
-      const inboundAllowRules = destRules.filter(r => r.type === 'inbound' && r.action === 'ALLOW');
-
-      inboundAllowRules.forEach(rule => {
-        containers.forEach(srcNode => {
-          if (srcNode.id === destNode.id) return;
-          if (srcNode.type === 'nat') return;
-
-          const srcSubnetId = networkConfig.nodeSubnetMap[srcNode.id];
-          if (!srcSubnetId) return;
-          const srcSubnet = networkConfig.subnets.find(s => s.id === srcSubnetId);
-          const srcVpcId = srcSubnet?.vpcId;
-
-          // Must be in the same VPC
-          if (srcVpcId !== destVpcId) return;
-
-          // Check if source matches rule
-          let isMatch = false;
-          if (rule.source === '0.0.0.0/0') {
-            isMatch = true;
-          } else if (rule.source === srcSubnetId) {
-            isMatch = true;
-          } else if (rule.source === srcNode.id) {
-            isMatch = true;
-          }
-
-          if (isMatch) {
-            const edgeId = `edge-${srcNode.id}-${destNode.id}-${rule.port}`;
-            if (!edgesList.some(e => e.id === edgeId)) {
-              edgesList.push({
-                id: edgeId,
-                source: srcNode.id,
-                target: destNode.id,
-                type: 'buttonEdge',
-                data: { onDelete: handleDeleteEdge },
-                animated: true,
-                label: `Port ${rule.port}`,
-                style: { stroke: '#10B981', strokeWidth: 2 },
-                labelStyle: { fill: '#374151', fontSize: 9, fontWeight: 700 }
-              });
-            }
-          }
-        });
-      });
-    });
-
-    return edgesList;
-  }, [containers, networkConfig, handleDeleteEdge]);
+  // Dynamic edges representing firewall rules
+  const edges = useMemo(
+    () => buildFirewallEdges(containers, networkConfig, handleDeleteEdge),
+    [containers, networkConfig, handleDeleteEdge]
+  );
 
   // Handle manual connection line draws (automatically updates security group)
   const onConnect = useCallback((connection: Connection) => {
@@ -381,60 +329,27 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     const targetNode = containers.find(n => n.id === target);
     const sourceNode = containers.find(n => n.id === source);
     if (!targetNode) return;
-    const targetType = targetNode.type || 'ubuntu';
-    
-    const isDb = ['postgres', 'sql', 'nosql', 'mysql', 'redis'].includes(targetType);
-    const defaultProtocol = isDb ? 'TCP' : 'ALL';
-    const defaultPort = (targetType === 'postgres' || targetType === 'sql') ? '5432' : (targetType === 'nosql') ? '27017' : (targetType === 'mysql') ? '3306' : (targetType === 'redis') ? '6379' : 'ALL';
 
-    const currentRules = networkConfig.nodeSecurityGroups[target] || [];
-    const alreadyExists = currentRules.some(r => r.type === 'inbound' && r.action === 'ALLOW' && r.port === defaultPort && r.source === source);
-    if (alreadyExists) return;
+    const result = addConnectionRule(networkConfig, source, target, targetNode.type || 'ubuntu');
+    if (!result) return;
 
-    const newRule: SecurityGroupRule = {
-      id: `rule-${Math.random().toString(36).substr(2, 9)}`,
-      type: 'inbound',
-      action: 'ALLOW',
-      protocol: defaultProtocol,
-      port: defaultPort,
-      source: source
-    };
-
-    const updatedSecurityGroups = {
-      ...networkConfig.nodeSecurityGroups,
-      [target]: [newRule, ...currentRules]
-    };
-    const newConfig = { ...networkConfig, nodeSecurityGroups: updatedSecurityGroups };
-    saveNetworkConfig(newConfig);
+    saveNetworkConfig(result.config);
     const sourceName = sourceNode?.name || source;
-    showToast(`Security Group: Allowed ${defaultPort === 'ALL' ? 'all traffic' : `Port ${defaultPort}`} inbound from ${sourceName}`);
-    triggerArchitectureAudit(newConfig);
+    showToast(`Security Group: Allowed ${result.port === 'ALL' ? 'all traffic' : `Port ${result.port}`} inbound from ${sourceName}`);
+    triggerArchitectureAudit(result.config);
   }, [containers, networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
 
   // Handle connection line deletion (removes matching firewall rule)
   const onEdgesDelete = useCallback((deletedEdges: Edge[]) => {
-    const updatedSecurityGroups = { ...networkConfig.nodeSecurityGroups };
-    let changed = false;
+    const newConfig = removeRulesForConnections(
+      networkConfig,
+      deletedEdges.map(edge => ({ source: edge.source, target: edge.target }))
+    );
+    if (!newConfig) return;
 
-    deletedEdges.forEach(edge => {
-      const targetId = edge.target;
-      const sourceId = edge.source;
-
-      if (updatedSecurityGroups[targetId]) {
-        updatedSecurityGroups[targetId] = updatedSecurityGroups[targetId].filter(rule => {
-          const isMatch = rule.type === 'inbound' && rule.action === 'ALLOW' && (rule.source === sourceId || rule.source === '0.0.0.0/0');
-          if (isMatch) changed = true;
-          return !isMatch;
-        });
-      }
-    });
-
-    if (changed) {
-      const newConfig = { ...networkConfig, nodeSecurityGroups: updatedSecurityGroups };
-      saveNetworkConfig(newConfig);
-      showToast("Firewall rule removed");
-      triggerArchitectureAudit(newConfig);
-    }
+    saveNetworkConfig(newConfig);
+    showToast("Firewall rule removed");
+    triggerArchitectureAudit(newConfig);
   }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
 
   const allocateIpForNode = (nodeId: string, subnetId: string, currentConfig: NetworkConfig): string => {
@@ -463,28 +378,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     }
 
     return `${prefix}${suffix}`;
-  };
-
-  // Helper to generate default security group rules for network nodes (deny all inbound by default)
-  const initDefaultRules = () => {
-    return [
-      {
-        id: `rule-${Math.random().toString(36).substr(2, 9)}`,
-        type: 'inbound' as const,
-        action: 'DENY' as const,
-        protocol: 'ALL' as const,
-        port: 'ALL',
-        source: '0.0.0.0/0'
-      },
-      {
-        id: `rule-${Math.random().toString(36).substr(2, 9)}`,
-        type: 'outbound' as const,
-        action: 'ALLOW' as const,
-        protocol: 'ALL' as const,
-        port: 'ALL',
-        source: '0.0.0.0/0'
-      }
-    ];
   };
 
   const fetchNetworkConfig = useCallback(() => {
@@ -565,7 +458,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
         // Auto-configure default security rules on drop
         if (!updatedSecurityGroups[c.id] || updatedSecurityGroups[c.id].length === 0) {
-          updatedSecurityGroups[c.id] = initDefaultRules();
+          updatedSecurityGroups[c.id] = createDefaultRules();
         }
 
         const tempConfig = { ...networkConfig, nodeSubnetMap: updatedNodeSubnetMap, nodeIpMap: updatedNodeIpMap };
@@ -928,7 +821,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
         // Automatically setup default firewall connections when dragged into subnet
         if (!updatedSecurityGroups[draggedNode.id] || updatedSecurityGroups[draggedNode.id].length === 0) {
-          updatedSecurityGroups[draggedNode.id] = initDefaultRules();
+          updatedSecurityGroups[draggedNode.id] = createDefaultRules();
         }
 
         const tempConfig = {

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -54,6 +54,26 @@ interface CanvasPageProps {
   onTerminalOpen: (id: string, name: string) => void;
 }
 
+/** Which inspector modal is open. They are mutually exclusive, hence one state. */
+interface InspectorState {
+  kind: 'postgres' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'asg' | 'subnet-routes' | 'security-group';
+  id: string;
+  name: string;
+  /** Only set for kind 'security-group' (the modal displays the node type). */
+  nodeType?: string;
+}
+
+/** Inspector opened by each node type's magnifier action ('sql' shares the Postgres modal). */
+const INSPECTOR_KIND_BY_NODE_TYPE: Record<string, InspectorState['kind']> = {
+  postgres: 'postgres',
+  sql: 'postgres',
+  nosql: 'nosql',
+  redis: 'redis',
+  nat: 'nat',
+  loadbalancer: 'loadbalancer',
+  autoscalinggroup: 'asg',
+};
+
 export default function CanvasPage({ projectId, projectName, onBackToProjects, onTerminalOpen }: CanvasPageProps) {
   const { toast, showNotification, showToast, dismissToast } = useToast();
 
@@ -73,17 +93,8 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
   // Modal and inspector states
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
-  const [inspectingPostgres, setInspectingPostgres] = useState<{ id: string; name: string } | null>(null);
-  const [inspectingNosql, setInspectingNosql] = useState<{ id: string; name: string } | null>(null);
-  const [inspectingRedis, setInspectingRedis] = useState<{ id: string; name: string } | null>(null);
-
-  const [inspectingNat, setInspectingNat] = useState<{ id: string; name: string } | null>(null);
-  const [inspectingLoadBalancer, setInspectingLoadBalancer] = useState<{ id: string; name: string } | null>(null);
-  const [inspectingAsg, setInspectingAsg] = useState<{ id: string; name: string } | null>(null);
-
-  // Phase 3 Modal states
-  const [inspectingSubnet, setInspectingSubnet] = useState<{ id: string; name: string } | null>(null);
-  const [inspectingSecurityGroup, setInspectingSecurityGroup] = useState<{ id: string; name: string; type: string } | null>(null);
+  const [inspector, setInspector] = useState<InspectorState | null>(null);
+  const closeInspector = () => setInspector(null);
 
   // Rename modal state
   const [renamingNode, setRenamingNode] = useState<{ id: string; currentName: string } | null>(null);
@@ -325,7 +336,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
             columns: subnet.columns || 2,
             rows: subnet.rows || 1,
             onManageRoutes: (id: string, name: string) => {
-              setInspectingSubnet({ id, name });
+              setInspector({ kind: 'subnet-routes', id, name });
             },
             onDelete: handleDeleteSubnet,
             onResize: handleSubnetResize
@@ -428,22 +439,11 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
             },
             onTerminalOpen: (nodeType === 'loadbalancer' || nodeType === 'autoscalinggroup') ? () => {} : onTerminalOpen,
             onInspect: (id: string, name: string) => {
-              if (nodeType === 'postgres' || nodeType === 'sql') {
-                setInspectingPostgres({ id, name });
-              } else if (nodeType === 'nosql') {
-                setInspectingNosql({ id, name });
-              } else if (nodeType === 'redis') {
-                setInspectingRedis({ id, name });
-              } else if (nodeType === 'nat') {
-                setInspectingNat({ id, name });
-              } else if (nodeType === 'loadbalancer') {
-                setInspectingLoadBalancer({ id, name });
-              } else if (nodeType === 'autoscalinggroup') {
-                setInspectingAsg({ id, name });
-              }
+              const kind = INSPECTOR_KIND_BY_NODE_TYPE[nodeType];
+              if (kind) setInspector({ kind, id, name });
             },
             onSecurityGroupOpen: (id: string, name: string) => {
-              setInspectingSecurityGroup({ id, name, type: nodeType });
+              setInspector({ kind: 'security-group', id, name, nodeType });
             },
             onRename: (id: string, currentName: string) => {
               setRenamingNode({ id, currentName });
@@ -729,80 +729,64 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         />
       )}
 
-      {inspectingPostgres && (
+      {inspector?.kind === 'postgres' && (
         <PostgresModal
-          containerId={inspectingPostgres.id}
-          nodeName={inspectingPostgres.name}
+          containerId={inspector.id}
+          nodeName={inspector.name}
           projectId={projectId}
-          onClose={() => setInspectingPostgres(null)}
+          onClose={closeInspector}
         />
       )}
 
-      {inspectingNosql && (
+      {inspector?.kind === 'nosql' && (
         <NoSqlModal
-          containerId={inspectingNosql.id}
-          nodeName={inspectingNosql.name}
+          containerId={inspector.id}
+          nodeName={inspector.name}
           projectId={projectId}
-          onClose={() => setInspectingNosql(null)}
+          onClose={closeInspector}
         />
       )}
 
-      {inspectingRedis && (
+      {inspector?.kind === 'redis' && (
         <RedisModal
-          containerId={inspectingRedis.id}
-          nodeName={inspectingRedis.name}
+          containerId={inspector.id}
+          nodeName={inspector.name}
           projectId={projectId}
-          onClose={() => setInspectingRedis(null)}
+          onClose={closeInspector}
         />
       )}
 
-      {inspectingNat && (
+      {inspector?.kind === 'nat' && (
         <NatGatewayModal
-          nodeName={inspectingNat.name}
-          ipAddress={containers.find(c => c.id === inspectingNat.id)?.ip || networkConfig.nodeIpMap?.[inspectingNat.id]}
-          state={containers.find(c => c.id === inspectingNat.id)?.state || 'stopped'}
-          onClose={() => setInspectingNat(null)}
+          nodeName={inspector.name}
+          ipAddress={containers.find(c => c.id === inspector.id)?.ip || networkConfig.nodeIpMap?.[inspector.id]}
+          state={containers.find(c => c.id === inspector.id)?.state || 'stopped'}
+          onClose={closeInspector}
         />
       )}
 
-       {inspectingLoadBalancer && (
+      {inspector?.kind === 'loadbalancer' && (
         <LoadBalancerModal
-          containerId={inspectingLoadBalancer.id}
-          nodeName={inspectingLoadBalancer.name}
-          ipAddress={containers.find(c => c.id === inspectingLoadBalancer.id)?.ip || networkConfig.nodeIpMap?.[inspectingLoadBalancer.id]}
-          port={containers.find(c => c.id === inspectingLoadBalancer.id)?.port}
-          state={containers.find(c => c.id === inspectingLoadBalancer.id)?.state || 'stopped'}
+          containerId={inspector.id}
+          nodeName={inspector.name}
+          ipAddress={containers.find(c => c.id === inspector.id)?.ip || networkConfig.nodeIpMap?.[inspector.id]}
+          port={containers.find(c => c.id === inspector.id)?.port}
+          state={containers.find(c => c.id === inspector.id)?.state || 'stopped'}
           config={{
-            loadBalancerAlgorithm: networkConfig.loadBalancerAlgorithms?.[inspectingLoadBalancer.id],
-            loadBalancerTargets: networkConfig.loadBalancerTargets?.[inspectingLoadBalancer.id],
-            loadBalancerTargetPort: networkConfig.loadBalancerTargetPorts?.[inspectingLoadBalancer.id],
-            loadBalancerRoutingRules: networkConfig.loadBalancerRoutingRules?.[inspectingLoadBalancer.id]
+            loadBalancerAlgorithm: networkConfig.loadBalancerAlgorithms?.[inspector.id],
+            loadBalancerTargets: networkConfig.loadBalancerTargets?.[inspector.id],
+            loadBalancerTargetPort: networkConfig.loadBalancerTargetPorts?.[inspector.id],
+            loadBalancerRoutingRules: networkConfig.loadBalancerRoutingRules?.[inspector.id]
           }}
           allNodes={containers}
-          onClose={() => setInspectingLoadBalancer(null)}
+          onClose={closeInspector}
           onSaveConfig={async (algorithm, targets, targetPort, routingRules) => {
-            const updatedAlgorithms = {
-              ...(networkConfig.loadBalancerAlgorithms || {}),
-              [inspectingLoadBalancer.id]: algorithm
-            };
-            const updatedTargets = {
-              ...(networkConfig.loadBalancerTargets || {}),
-              [inspectingLoadBalancer.id]: targets
-            };
-            const updatedTargetPorts = {
-              ...(networkConfig.loadBalancerTargetPorts || {}),
-              [inspectingLoadBalancer.id]: targetPort
-            };
-            const updatedRoutingRules = {
-              ...(networkConfig.loadBalancerRoutingRules || {}),
-              [inspectingLoadBalancer.id]: routingRules
-            };
             const newConfig = {
               ...networkConfig,
-              loadBalancerAlgorithms: updatedAlgorithms,
-              loadBalancerTargets: updatedTargets,
-              loadBalancerTargetPorts: updatedTargetPorts,
-              loadBalancerRoutingRules: updatedRoutingRules
+              loadBalancerAlgorithms: { ...(networkConfig.loadBalancerAlgorithms || {}), [inspector.id]: algorithm },
+              loadBalancerTargets: { ...(networkConfig.loadBalancerTargets || {}), [inspector.id]: targets },
+              loadBalancerTargetPorts: { ...(networkConfig.loadBalancerTargetPorts || {}), [inspector.id]: targetPort },
+              loadBalancerRoutingRules: { ...(networkConfig.loadBalancerRoutingRules || {}), [inspector.id]: routingRules }
             };
             await saveNetworkConfig(newConfig);
             showToast("Load Balancer configuration applied");
@@ -811,22 +795,18 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         />
       )}
 
-      {inspectingAsg && (
+      {inspector?.kind === 'asg' && (
         <AsgModal
-          asgId={inspectingAsg.id}
-          nodeName={inspectingAsg.name}
+          asgId={inspector.id}
+          nodeName={inspector.name}
           projectId={projectId}
           config={networkConfig}
           containers={containers}
-          onClose={() => setInspectingAsg(null)}
+          onClose={closeInspector}
           onSaveConfig={async (asgConfig) => {
-            const updatedAsgs = {
-              ...(networkConfig.asgs || {}),
-              [inspectingAsg.id]: asgConfig
-            };
             const newConfig = {
               ...networkConfig,
-              asgs: updatedAsgs
+              asgs: { ...(networkConfig.asgs || {}), [inspector.id]: asgConfig }
             };
             await saveNetworkConfig(newConfig);
             showToast("Auto Scaling Group configuration saved");
@@ -836,17 +816,16 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         />
       )}
 
-      {/* Phase 3 Modals */}
-      {inspectingSubnet && (
+      {inspector?.kind === 'subnet-routes' && (
         <RoutingTableModal
-          subnetId={inspectingSubnet.id}
-          subnetName={inspectingSubnet.name}
-          routes={networkConfig.subnets.find(s => s.id === inspectingSubnet.id)?.routes || []}
+          subnetId={inspector.id}
+          subnetName={inspector.name}
+          routes={networkConfig.subnets.find(s => s.id === inspector.id)?.routes || []}
           natGateways={containers.filter(c => c.type === 'nat').map(c => c.name)}
-          onClose={() => setInspectingSubnet(null)}
+          onClose={closeInspector}
           onSave={async (updatedRoutes) => {
             const updatedSubnets = networkConfig.subnets.map(s => {
-              if (s.id === inspectingSubnet.id) {
+              if (s.id === inspector.id) {
                 return { ...s, routes: updatedRoutes };
               }
               return s;
@@ -856,21 +835,20 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         />
       )}
 
-      {inspectingSecurityGroup && (
+      {inspector?.kind === 'security-group' && (
         <SecurityGroupsModal
-          nodeId={inspectingSecurityGroup.id}
-          nodeName={inspectingSecurityGroup.name}
-          nodeType={inspectingSecurityGroup.type}
+          nodeId={inspector.id}
+          nodeName={inspector.name}
+          nodeType={inspector.nodeType || 'ubuntu'}
           allNodes={containers}
           allSubnets={networkConfig.subnets.map(s => ({ id: s.id, name: s.name }))}
-          rules={networkConfig.nodeSecurityGroups[inspectingSecurityGroup.id] || []}
-          onClose={() => setInspectingSecurityGroup(null)}
+          rules={networkConfig.nodeSecurityGroups[inspector.id] || []}
+          onClose={closeInspector}
           onSaveRules={(rules) => {
-            const updatedSecurityGroups = {
-              ...networkConfig.nodeSecurityGroups,
-              [inspectingSecurityGroup.id]: rules
+            const newConfig = {
+              ...networkConfig,
+              nodeSecurityGroups: { ...networkConfig.nodeSecurityGroups, [inspector.id]: rules }
             };
-            const newConfig = { ...networkConfig, nodeSecurityGroups: updatedSecurityGroups };
             saveNetworkConfig(newConfig);
             triggerArchitectureAudit(newConfig);
           }}

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -36,7 +36,7 @@ import VpcModal from '../../features/nodes/VpcNode/VpcModal';
 import ButtonEdge from './components/ButtonEdge';
 import { validateArchitecture } from '../../shared/utils/architectureValidator';
 import { API_BASE } from '../../shared/types';
-import type { Subnet, NetworkConfig } from '../../shared/types/network';
+import type { NetworkConfig } from '../../shared/types/network';
 import {
   getAbsoluteCoordinates,
   findSubnetAtPoint,
@@ -46,33 +46,24 @@ import {
   subnetSize,
 } from './utils/canvasGeometry';
 import {
-  createDefaultRules,
   addConnectionRule,
   parseEdgeId,
   removeEdgeRule,
   removeRulesForConnections,
   buildFirewallEdges,
 } from './utils/securityRules';
+import {
+  autoGrowContainers,
+  assignNodeToSubnet,
+  removeNodeFromConfig,
+  createSubnet,
+} from './utils/networkConfigOps';
 
 interface CanvasPageProps {
   projectId: string;
   projectName: string;
   onBackToProjects: () => void;
   onTerminalOpen: (id: string, name: string) => void;
-}
-
-function autoGrowContainers(
-  config: NetworkConfig
-): NetworkConfig {
-  const updatedSubnets = config.subnets.map(subnet => ({
-    ...subnet,
-    ...subnetSize(subnet.columns || 2, subnet.rows || 1)
-  }));
-
-  return {
-    ...config,
-    subnets: updatedSubnets
-  };
 }
 
 export default function CanvasPage({ projectId, projectName, onBackToProjects, onTerminalOpen }: CanvasPageProps) {
@@ -352,34 +343,6 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     triggerArchitectureAudit(newConfig);
   }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
 
-  const allocateIpForNode = (nodeId: string, subnetId: string, currentConfig: NetworkConfig): string => {
-    const subnet = currentConfig.subnets.find(s => s.id === subnetId);
-    if (!subnet) return '';
-    const cidr = subnet.cidr || '10.99.1.0/24';
-    const match = cidr.match(/^(\d+\.\d+\.\d+)\./);
-    if (!match) return '';
-    const prefix = match[1] + '.';
-
-    const existingIp = currentConfig.nodeIpMap?.[nodeId];
-    if (existingIp && existingIp.startsWith(prefix)) {
-      return existingIp;
-    }
-
-    const assignedIps = Object.entries(currentConfig.nodeIpMap || {})
-      .filter(([nid, ip]) => currentConfig.nodeSubnetMap[nid] === subnetId && ip.startsWith(prefix))
-      .map(([, ip]) => {
-        const parts = ip.split('.');
-        return parseInt(parts[3], 10);
-      });
-
-    let suffix = 2;
-    while (assignedIps.includes(suffix)) {
-      suffix++;
-    }
-
-    return `${prefix}${suffix}`;
-  };
-
   const fetchNetworkConfig = useCallback(() => {
     fetch(`${API_BASE}/api/projects/${projectId}/network-config`)
       .then(res => res.json())
@@ -445,39 +408,20 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
   // Sync container data into React Flow nodes when containers change
   useEffect(() => {
-    let configChanged = false;
-    const updatedNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
-    const updatedSecurityGroups = { ...networkConfig.nodeSecurityGroups };
-    const updatedNodeIpMap = { ...networkConfig.nodeIpMap || {} };
-
-    // Map dropped container positions or subnets if pending
+    // Assign freshly created containers to the subnet they were dropped in
+    let workingConfig = networkConfig;
     containers.forEach(c => {
-      if (dropSubnetsRef.current[c.name]) {
-        const subnetId = dropSubnetsRef.current[c.name];
-        updatedNodeSubnetMap[c.id] = subnetId;
-
-        // Auto-configure default security rules on drop
-        if (!updatedSecurityGroups[c.id] || updatedSecurityGroups[c.id].length === 0) {
-          updatedSecurityGroups[c.id] = createDefaultRules();
-        }
-
-        const tempConfig = { ...networkConfig, nodeSubnetMap: updatedNodeSubnetMap, nodeIpMap: updatedNodeIpMap };
-        const allocatedIp = allocateIpForNode(c.id, subnetId, tempConfig);
-        updatedNodeIpMap[c.id] = allocatedIp;
-
+      const subnetId = dropSubnetsRef.current[c.name];
+      if (subnetId) {
+        workingConfig = assignNodeToSubnet(workingConfig, c.id, subnetId);
         delete dropSubnetsRef.current[c.name];
-        configChanged = true;
       }
     });
 
-    if (configChanged) {
-      saveNetworkConfig({
-        ...networkConfig,
-        nodeSubnetMap: updatedNodeSubnetMap,
-        nodeSecurityGroups: updatedSecurityGroups,
-        nodeIpMap: updatedNodeIpMap
-      });
+    if (workingConfig !== networkConfig) {
+      saveNetworkConfig(workingConfig);
     }
+    const nodeSubnetMap = workingConfig.nodeSubnetMap;
 
     setNodes(prevNodes => {
       // 1. Map Subnet nodes
@@ -524,7 +468,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           delete dropPositionsRef.current[c.name];
         }
 
-        const parentId = updatedNodeSubnetMap[c.id] || undefined;
+        const parentId = nodeSubnetMap[c.id] || undefined;
         const isDragging = draggingNodeIdRef.current === c.id;
 
         let position = dropPos || savedPos || existing?.position || { x: defaultX, y: defaultY };
@@ -534,7 +478,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           const subnet = networkConfig.subnets.find(s => s.id === parentId);
 
           const occupiedCells = containers
-            .filter(node => !node.isAsgInstance && node.id !== c.id && updatedNodeSubnetMap[node.id] === parentId)
+            .filter(node => !node.isAsgInstance && node.id !== c.id && nodeSubnetMap[node.id] === parentId)
             .map(node => positionsRef.current[node.id])
             .filter((pos): pos is { x: number; y: number } => !!pos)
             .map(positionToCell);
@@ -806,32 +750,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         }
       }
 
-      const updatedNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
-      const updatedSecurityGroups = { ...networkConfig.nodeSecurityGroups };
-      const updatedNodeIpMap = { ...networkConfig.nodeIpMap || {} };
-
-      if (targetSubnet && targetSubnetId) {
-        updatedNodeSubnetMap[draggedNode.id] = targetSubnetId;
-
-        positionsRef.current[draggedNode.id] = clampToCell(
-          { x: absX - targetSubnet.position.x, y: absY - targetSubnet.position.y },
-          targetSubnet.columns || 2,
-          targetSubnet.rows || 1
-        );
-
-        // Automatically setup default firewall connections when dragged into subnet
-        if (!updatedSecurityGroups[draggedNode.id] || updatedSecurityGroups[draggedNode.id].length === 0) {
-          updatedSecurityGroups[draggedNode.id] = createDefaultRules();
-        }
-
-        const tempConfig = {
-          ...networkConfig,
-          nodeSubnetMap: updatedNodeSubnetMap,
-          nodeIpMap: updatedNodeIpMap
-        };
-        const allocatedIp = allocateIpForNode(draggedNode.id, targetSubnetId, tempConfig);
-        updatedNodeIpMap[draggedNode.id] = allocatedIp;
-      } else {
+      if (!targetSubnet) {
         // Revert container node drag to its original subnet position
         showNotification({ type: 'warning', message: 'Nodes must reside within a subnet.' });
         const original = dragStartPositionsRef.current[draggedNode.id];
@@ -850,13 +769,14 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         return;
       }
 
+      positionsRef.current[draggedNode.id] = clampToCell(
+        { x: absX - targetSubnet.position.x, y: absY - targetSubnet.position.y },
+        targetSubnet.columns || 2,
+        targetSubnet.rows || 1
+      );
       localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
-      const newConfig = {
-        ...networkConfig,
-        nodeSubnetMap: updatedNodeSubnetMap,
-        nodeSecurityGroups: updatedSecurityGroups,
-        nodeIpMap: updatedNodeIpMap
-      };
+
+      const newConfig = assignNodeToSubnet(networkConfig, draggedNode.id, targetSubnet.id);
       saveNetworkConfig(newConfig);
       triggerArchitectureAudit(newConfig);
     }
@@ -1026,27 +946,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         delete positionsRef.current[id];
         localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
 
-        const updatedNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
-        delete updatedNodeSubnetMap[id];
-        
-        const updatedSecurityGroups = { ...networkConfig.nodeSecurityGroups };
-        delete updatedSecurityGroups[id];
-        
-        // Cascade delete: remove any rules in other nodes that target this deleted node
-        Object.keys(updatedSecurityGroups).forEach(nodeId => {
-          updatedSecurityGroups[nodeId] = updatedSecurityGroups[nodeId].filter(
-            rule => rule.source !== id
-          );
-        });
-
-        const updatedNodeIpMap = { ...networkConfig.nodeIpMap || {} };
-        delete updatedNodeIpMap[id];
-        saveNetworkConfig({
-          ...networkConfig,
-          nodeSubnetMap: updatedNodeSubnetMap,
-          nodeSecurityGroups: updatedSecurityGroups,
-          nodeIpMap: updatedNodeIpMap
-        });
+        saveNetworkConfig(removeNodeFromConfig(networkConfig, id));
       }
     } finally {
       setDeleteTarget(null);
@@ -1074,41 +974,19 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       });
 
       if (type === 'subnet-public' || type === 'subnet-private') {
-        const isPublic = type === 'subnet-public';
-        const cols = 2;
-        const rows = 1;
-        const { width: subnetWidth, height: subnetHeight } = subnetSize(cols, rows);
-        const subnetCenter = { x: position.x + subnetWidth / 2, y: position.y + subnetHeight / 2 };
+        const newSubnet = createSubnet(
+          type === 'subnet-public' ? 'public' : 'private',
+          position,
+          networkConfig.vpcConfig.cidr,
+          networkConfig.subnets.length
+        );
 
         // Check if dropped inside another subnet
-        const insideAnotherSubnet = !!findSubnetAtPoint(subnetCenter, networkConfig.subnets);
-
-        if (insideAnotherSubnet) {
+        const subnetCenter = { x: position.x + newSubnet.width / 2, y: position.y + newSubnet.height / 2 };
+        if (findSubnetAtPoint(subnetCenter, networkConfig.subnets)) {
           showNotification({ type: 'error', message: 'Invalid placement: Subnets cannot be nested inside other subnets.' });
           return;
         }
-
-        // Derive the subnet CIDR and local route from the current VPC CIDR:
-        // it may have shifted from the default 10.0.0.0/16 when Docker's
-        // address pool overlapped the requested range.
-        const vpcCidr = networkConfig.vpcConfig.cidr;
-        const vpcPrefix = vpcCidr.split('.').slice(0, 2).join('.');
-        const newSubnet: Subnet = {
-          id: `subnet-${Math.random().toString(36).substr(2, 9)}`,
-          name: `${isPublic ? 'Public' : 'Private'} Subnet-${networkConfig.subnets.length + 1}`,
-          type: isPublic ? 'public' : 'private',
-          cidr: `${vpcPrefix}.${networkConfig.subnets.length + 1}.0/24`,
-          vpcId: 'root-vpc',
-          position: position,
-          width: subnetWidth,
-          height: subnetHeight,
-          columns: cols,
-          rows: rows,
-          routes: [
-            { destination: vpcCidr, target: 'local', description: 'Local VPC routing' },
-            ...(isPublic ? [{ destination: '0.0.0.0/0', target: 'igw', description: 'Internet access' }] : [])
-          ]
-        };
 
         const newConfig = {
           ...networkConfig,

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -37,18 +37,14 @@ import ButtonEdge from './components/ButtonEdge';
 import { validateArchitecture } from '../../shared/utils/architectureValidator';
 import { API_BASE } from '../../shared/types';
 import type { Subnet, NetworkConfig, SecurityGroupRule } from '../../shared/types/network';
-
-// Recursively calculate absolute coordinates of a node
-const getAbsoluteCoordinates = (nodeId: string, currentNodes: Node[]): { x: number; y: number } => {
-  const node = currentNodes.find(n => n.id === nodeId);
-  if (!node) return { x: 0, y: 0 };
-  if (!node.parentId) return node.position;
-  const parentPos = getAbsoluteCoordinates(node.parentId, currentNodes);
-  return {
-    x: parentPos.x + node.position.x,
-    y: parentPos.y + node.position.y
-  };
-};
+import {
+  getAbsoluteCoordinates,
+  findSubnetAtPoint,
+  positionToCell,
+  clampToCell,
+  resolveSubnetChildPosition,
+  subnetSize,
+} from './utils/canvasGeometry';
 
 interface CanvasPageProps {
   projectId: string;
@@ -60,15 +56,10 @@ interface CanvasPageProps {
 function autoGrowContainers(
   config: NetworkConfig
 ): NetworkConfig {
-  const updatedSubnets = config.subnets.map(subnet => {
-    const cols = subnet.columns || 2;
-    const rows = subnet.rows || 1;
-    return {
-      ...subnet,
-      width: cols * 340,
-      height: 70 + rows * 190
-    };
-  });
+  const updatedSubnets = config.subnets.map(subnet => ({
+    ...subnet,
+    ...subnetSize(subnet.columns || 2, subnet.rows || 1)
+  }));
 
   return {
     ...config,
@@ -274,8 +265,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       for (const node of subnetNodes) {
         const pos = positionsRef.current[node.id];
         if (pos) {
-          const col = Math.round((pos.x - 60) / 340);
-          const row = Math.round((pos.y - 60) / 190);
+          const { col, row } = positionToCell(pos);
           if (col >= targetCols || row >= targetRows) {
             showNotification({
               type: 'error',
@@ -295,8 +285,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           ...s,
           columns: cols,
           rows: rows,
-          width: cols * 340,
-          height: 70 + rows * 190
+          ...subnetSize(cols, rows)
         };
       }
       return s;
@@ -650,52 +639,19 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         // Auto-layout grid for subnet children (if not currently dragging)
         if (parentId && parentId.startsWith('subnet-') && !isDragging) {
           const subnet = networkConfig.subnets.find(s => s.id === parentId);
-          const cols = subnet?.columns || 2;
-          const rows = subnet?.rows || 1;
 
-          const pos = positionsRef.current[c.id];
-          let col = -1;
-          let row = -1;
-          if (pos) {
-            col = Math.round((pos.x - 60) / 340);
-            row = Math.round((pos.y - 60) / 190);
-          }
+          const occupiedCells = containers
+            .filter(node => !node.isAsgInstance && node.id !== c.id && updatedNodeSubnetMap[node.id] === parentId)
+            .map(node => positionsRef.current[node.id])
+            .filter((pos): pos is { x: number; y: number } => !!pos)
+            .map(positionToCell);
 
-          const isOccupied = (colIdx: number, rowIdx: number, excludeId: string) => {
-            return containers.filter(node => !node.isAsgInstance).some(node => {
-              if (node.id === excludeId) return false;
-              if (updatedNodeSubnetMap[node.id] !== parentId) return false;
-              const nodePos = positionsRef.current[node.id];
-              if (!nodePos) return false;
-              const nCol = Math.round((nodePos.x - 60) / 340);
-              const nRow = Math.round((nodePos.y - 60) / 190);
-              return nCol === colIdx && nRow === rowIdx;
-            });
-          };
-
-          if (col < 0 || col >= cols || row < 0 || row >= rows) {
-            let found = false;
-            for (let r = 0; r < rows; r++) {
-              for (let cp = 0; cp < cols; cp++) {
-                if (!isOccupied(cp, r, c.id)) {
-                  col = cp;
-                  row = r;
-                  found = true;
-                  break;
-                }
-              }
-              if (found) break;
-            }
-            if (!found) {
-              col = 0;
-              row = 0;
-            }
-          }
-
-          position = {
-            x: 60 + col * 340,
-            y: 60 + row * 190
-          };
+          position = resolveSubnetChildPosition({
+            savedPos: positionsRef.current[c.id],
+            columns: subnet?.columns || 2,
+            rows: subnet?.rows || 1,
+            occupiedCells
+          });
           positionsRef.current[c.id] = position;
         }
 
@@ -816,44 +772,14 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     const centerX = absX + nodeWidth / 2;
     const centerY = absY + nodeHeight / 2;
 
-    let hoveredId: string | null = null;
-    let isValid = false;
-
-    // Check intersection with subnets
-    if (draggedNode.type !== 'subnet') {
-      // Service node dragged
-      for (const subnet of networkConfig.subnets) {
-        const subnetAbsX = subnet.position.x;
-        const subnetAbsY = subnet.position.y;
-        if (
-          centerX >= subnetAbsX &&
-          centerX <= subnetAbsX + subnet.width &&
-          centerY >= subnetAbsY &&
-          centerY <= subnetAbsY + subnet.height
-        ) {
-          hoveredId = subnet.id;
-          isValid = true;
-          break;
-        }
-      }
-    } else if (draggedNode.type === 'subnet') {
-      // Subnet dragged: Check if dropped inside another subnet (invalid)
-      for (const subnet of networkConfig.subnets) {
-        if (subnet.id === draggedNode.id) continue;
-        const subnetAbsX = subnet.position.x;
-        const subnetAbsY = subnet.position.y;
-        if (
-          centerX >= subnetAbsX &&
-          centerX <= subnetAbsX + subnet.width &&
-          centerY >= subnetAbsY &&
-          centerY <= subnetAbsY + subnet.height
-        ) {
-          hoveredId = subnet.id;
-          isValid = false; // invalid!
-          break;
-        }
-      }
-    }
+    // Check intersection with subnets: hovering one is valid for a service
+    // node, invalid for a subnet (no nesting).
+    const center = { x: centerX, y: centerY };
+    const hoveredSubnet = draggedNode.type !== 'subnet'
+      ? findSubnetAtPoint(center, networkConfig.subnets)
+      : findSubnetAtPoint(center, networkConfig.subnets, draggedNode.id);
+    const hoveredId = hoveredSubnet?.id ?? null;
+    const isValid = !!hoveredSubnet && draggedNode.type !== 'subnet';
 
     // Update real-time position in coordinates map for auto-growing calculations
     const tempNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
@@ -940,25 +866,10 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     if (draggedNode.type === 'subnet') {
       const subnetWidth = 260;
       const subnetHeight = 180;
-      const subnetCenterX = absX + subnetWidth / 2;
-      const subnetCenterY = absY + subnetHeight / 2;
+      const subnetCenter = { x: absX + subnetWidth / 2, y: absY + subnetHeight / 2 };
 
       // Check if dropped inside another subnet
-      let insideAnotherSubnet = false;
-      for (const subnet of networkConfig.subnets) {
-        if (subnet.id === draggedNode.id) continue;
-        const subnetAbsX = subnet.position.x;
-        const subnetAbsY = subnet.position.y;
-        if (
-          subnetCenterX >= subnetAbsX &&
-          subnetCenterX <= subnetAbsX + subnet.width &&
-          subnetCenterY >= subnetAbsY &&
-          subnetCenterY <= subnetAbsY + subnet.height
-        ) {
-          insideAnotherSubnet = true;
-          break;
-        }
-      }
+      const insideAnotherSubnet = !!findSubnetAtPoint(subnetCenter, networkConfig.subnets, draggedNode.id);
 
       if (insideAnotherSubnet) {
         revertNode('Invalid placement: Subnets cannot be nested inside other subnets.');
@@ -981,27 +892,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     }
     else {
       // Container/Service node
-      const nodeCenterX = absX + 110;
-      const nodeCenterY = absY + 70;
-
-      let targetSubnetId: string | null = null;
-      let targetSubnetAbsPos = { x: 0, y: 0 };
-
-      for (const subnet of networkConfig.subnets) {
-        const subnetAbsX = subnet.position.x;
-        const subnetAbsY = subnet.position.y;
-
-        if (
-          nodeCenterX >= subnetAbsX &&
-          nodeCenterX <= subnetAbsX + subnet.width &&
-          nodeCenterY >= subnetAbsY &&
-          nodeCenterY <= subnetAbsY + subnet.height
-        ) {
-          targetSubnetId = subnet.id;
-          targetSubnetAbsPos = { x: subnetAbsX, y: subnetAbsY };
-          break;
-        }
-      }
+      const nodeCenter = { x: absX + 110, y: absY + 70 };
+      const targetSubnet = findSubnetAtPoint(nodeCenter, networkConfig.subnets);
+      const targetSubnetId = targetSubnet?.id ?? null;
 
       const original = dragStartPositionsRef.current[draggedNode.id];
       const oldParentId = original?.parentId;
@@ -1024,23 +917,14 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       const updatedSecurityGroups = { ...networkConfig.nodeSecurityGroups };
       const updatedNodeIpMap = { ...networkConfig.nodeIpMap || {} };
 
-      if (targetSubnetId) {
+      if (targetSubnet && targetSubnetId) {
         updatedNodeSubnetMap[draggedNode.id] = targetSubnetId;
 
-        const subnet = networkConfig.subnets.find(s => s.id === targetSubnetId);
-        const cols = subnet?.columns || 2;
-        const rows = subnet?.rows || 1;
-
-        const relX = absX - targetSubnetAbsPos.x;
-        const relY = absY - targetSubnetAbsPos.y;
-
-        const col = Math.max(0, Math.min(cols - 1, Math.round((relX - 60) / 340)));
-        const row = Math.max(0, Math.min(rows - 1, Math.round((relY - 60) / 190)));
-
-        positionsRef.current[draggedNode.id] = {
-          x: 60 + col * 340,
-          y: 60 + row * 190
-        };
+        positionsRef.current[draggedNode.id] = clampToCell(
+          { x: absX - targetSubnet.position.x, y: absY - targetSubnet.position.y },
+          targetSubnet.columns || 2,
+          targetSubnet.rows || 1
+        );
 
         // Automatically setup default firewall connections when dragged into subnet
         if (!updatedSecurityGroups[draggedNode.id] || updatedSecurityGroups[draggedNode.id].length === 0) {
@@ -1300,26 +1184,11 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         const isPublic = type === 'subnet-public';
         const cols = 2;
         const rows = 1;
-        const subnetWidth = cols * 340;
-        const subnetHeight = 70 + rows * 190;
-        const subnetCenterX = position.x + subnetWidth / 2;
-        const subnetCenterY = position.y + subnetHeight / 2;
+        const { width: subnetWidth, height: subnetHeight } = subnetSize(cols, rows);
+        const subnetCenter = { x: position.x + subnetWidth / 2, y: position.y + subnetHeight / 2 };
 
         // Check if dropped inside another subnet
-        let insideAnotherSubnet = false;
-        for (const subnet of networkConfig.subnets) {
-          const subnetAbsX = subnet.position.x;
-          const subnetAbsY = subnet.position.y;
-          if (
-            subnetCenterX >= subnetAbsX &&
-            subnetCenterX <= subnetAbsX + subnet.width &&
-            subnetCenterY >= subnetAbsY &&
-            subnetCenterY <= subnetAbsY + subnet.height
-          ) {
-            insideAnotherSubnet = true;
-            break;
-          }
-        }
+        const insideAnotherSubnet = !!findSubnetAtPoint(subnetCenter, networkConfig.subnets);
 
         if (insideAnotherSubnet) {
           showNotification({ type: 'error', message: 'Invalid placement: Subnets cannot be nested inside other subnets.' });
@@ -1355,53 +1224,22 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         saveNetworkConfig(newConfig);
         triggerArchitectureAudit(newConfig);
       } else {
-        const nodeCenterX = position.x + 110;
-        const nodeCenterY = position.y + 70;
+        const nodeCenter = { x: position.x + 110, y: position.y + 70 };
+        const targetSubnet = findSubnetAtPoint(nodeCenter, networkConfig.subnets);
 
-        let targetSubnetId: string | null = null;
-        let targetSubnetAbsPos = { x: 0, y: 0 };
-
-        for (const subnet of networkConfig.subnets) {
-          const subnetAbsX = subnet.position.x;
-          const subnetAbsY = subnet.position.y;
-
-          if (
-            nodeCenterX >= subnetAbsX &&
-            nodeCenterX <= subnetAbsX + subnet.width &&
-            nodeCenterY >= subnetAbsY &&
-            nodeCenterY <= subnetAbsY + subnet.height
-          ) {
-            targetSubnetId = subnet.id;
-            targetSubnetAbsPos = { x: subnetAbsX, y: subnetAbsY };
-            break;
-          }
-        }
-
-        if (!targetSubnetId) {
+        if (!targetSubnet) {
           showNotification({ type: 'error', message: 'Nodes must reside within a subnet.' });
           return;
         }
 
-        let finalDropPos = position;
-        if (targetSubnetId) {
-          const subnet = networkConfig.subnets.find(s => s.id === targetSubnetId);
-          const cols = subnet?.columns || 2;
-          const rows = subnet?.rows || 1;
-
-          const relX = position.x - targetSubnetAbsPos.x;
-          const relY = position.y - targetSubnetAbsPos.y;
-
-          const col = Math.max(0, Math.min(cols - 1, Math.round((relX - 60) / 340)));
-          const row = Math.max(0, Math.min(rows - 1, Math.round((relY - 60) / 190)));
-
-          finalDropPos = {
-            x: 60 + col * 340,
-            y: 60 + row * 190
-          };
-        }
+        const finalDropPos = clampToCell(
+          { x: position.x - targetSubnet.position.x, y: position.y - targetSubnet.position.y },
+          targetSubnet.columns || 2,
+          targetSubnet.rows || 1
+        );
 
         setDropState({ position: finalDropPos, type });
-        pendingSubnetIdRef.current = targetSubnetId;
+        pendingSubnetIdRef.current = targetSubnet.id;
         setShowCreateModal(true);
       }
     },

--- a/frontend/src/pages/CanvasPage/components/CanvasModals.tsx
+++ b/frontend/src/pages/CanvasPage/components/CanvasModals.tsx
@@ -1,0 +1,245 @@
+import PostgresModal from '../../../features/nodes/PostgresNode/PostgresModal';
+import NoSqlModal from '../../../features/nodes/NoSqlNode/NoSqlModal';
+import RedisModal from '../../../features/nodes/RedisNode/RedisModal';
+import NatGatewayModal from '../../../features/nodes/NatNode/NatGatewayModal';
+import LoadBalancerModal from '../../../features/nodes/LoadBalancerNode/LoadBalancerModal';
+import AsgModal from '../../../features/nodes/AsgNode/AsgModal';
+import RoutingTableModal from '../../../features/nodes/SubnetNode/RoutingTableModal';
+import SecurityGroupsModal from '../../../features/nodes/SecurityGroups/SecurityGroupsModal';
+import VpcModal from '../../../features/nodes/VpcNode/VpcModal';
+import ConfirmModal from '../../../shared/components/ConfirmModal';
+import InputModal from '../../../shared/components/InputModal';
+import CreateNodeModal from './CreateNodeModal';
+import type { ContainerData } from '../../../shared/types';
+import type { NetworkConfig } from '../../../shared/types/network';
+
+/** Which inspector modal is open. They are mutually exclusive, hence one state. */
+export interface InspectorState {
+  kind: 'postgres' | 'nosql' | 'redis' | 'nat' | 'loadbalancer' | 'asg' | 'subnet-routes' | 'security-group';
+  id: string;
+  name: string;
+  /** Only set for kind 'security-group' (the modal displays the node type). */
+  nodeType?: string;
+}
+
+interface CanvasModalsProps {
+  projectId: string;
+  containers: ContainerData[];
+  networkConfig: NetworkConfig;
+  saveNetworkConfig: (config: NetworkConfig) => Promise<unknown>;
+  triggerArchitectureAudit: (config: NetworkConfig) => void;
+  showToast: (message: string) => void;
+  fetchContainers: () => Promise<void>;
+  createNode: { type: string; onSubmit: (name: string) => void; onCancel: () => void } | null;
+  deleteNode: { onConfirm: () => void; onCancel: () => void } | null;
+  renameNode: { currentName: string; onSubmit: (name: string) => void; onCancel: () => void } | null;
+  inspector: InspectorState | null;
+  onCloseInspector: () => void;
+  vpcSettings: { onClose: () => void } | null;
+  trafficSimulator: { onClose: () => void } | null;
+}
+
+/** All CanvasPage modals: create/delete/rename dialogs, node inspectors and the VPC modal. */
+export default function CanvasModals({
+  projectId,
+  containers,
+  networkConfig,
+  saveNetworkConfig,
+  triggerArchitectureAudit,
+  showToast,
+  fetchContainers,
+  createNode,
+  deleteNode,
+  renameNode,
+  inspector,
+  onCloseInspector,
+  vpcSettings,
+  trafficSimulator,
+}: CanvasModalsProps) {
+  const renderVpcModal = (initialTab: 'info' | 'simulator', onClose: () => void) => (
+    <VpcModal
+      vpcConfig={networkConfig.vpcConfig}
+      subnets={networkConfig.subnets}
+      nodes={containers}
+      nodeSecurityGroups={networkConfig.nodeSecurityGroups}
+      nodeSubnetMap={networkConfig.nodeSubnetMap}
+      onClose={onClose}
+      onSaveVpcConfig={(config) => {
+        const newConfig = { ...networkConfig, vpcConfig: config };
+        saveNetworkConfig(newConfig);
+        onClose();
+        showToast("VPC configuration saved");
+        triggerArchitectureAudit(newConfig);
+      }}
+      initialTab={initialTab}
+    />
+  );
+
+  return (
+    <>
+      {createNode && (
+        <CreateNodeModal
+          type={createNode.type}
+          containers={containers}
+          onSubmit={createNode.onSubmit}
+          onCancel={createNode.onCancel}
+        />
+      )}
+
+      {deleteNode && (
+        <ConfirmModal
+          title="Delete Container"
+          message="This will permanently stop and remove this container. This action cannot be undone."
+          confirmText="Delete"
+          variant="danger"
+          onConfirm={deleteNode.onConfirm}
+          onCancel={deleteNode.onCancel}
+        />
+      )}
+
+      {renameNode && (
+        <InputModal
+          title="Rename Node"
+          label="Enter a new name for this node."
+          placeholder="e.g. api-gateway"
+          maxLength={20}
+          restrictPattern={/[^a-zA-Z0-9-]/g}
+          defaultValue={renameNode.currentName}
+          submitText="Rename"
+          onSubmit={renameNode.onSubmit}
+          onCancel={renameNode.onCancel}
+        />
+      )}
+
+      {inspector?.kind === 'postgres' && (
+        <PostgresModal
+          containerId={inspector.id}
+          nodeName={inspector.name}
+          projectId={projectId}
+          onClose={onCloseInspector}
+        />
+      )}
+
+      {inspector?.kind === 'nosql' && (
+        <NoSqlModal
+          containerId={inspector.id}
+          nodeName={inspector.name}
+          projectId={projectId}
+          onClose={onCloseInspector}
+        />
+      )}
+
+      {inspector?.kind === 'redis' && (
+        <RedisModal
+          containerId={inspector.id}
+          nodeName={inspector.name}
+          projectId={projectId}
+          onClose={onCloseInspector}
+        />
+      )}
+
+      {inspector?.kind === 'nat' && (
+        <NatGatewayModal
+          nodeName={inspector.name}
+          ipAddress={containers.find(c => c.id === inspector.id)?.ip || networkConfig.nodeIpMap?.[inspector.id]}
+          state={containers.find(c => c.id === inspector.id)?.state || 'stopped'}
+          onClose={onCloseInspector}
+        />
+      )}
+
+      {inspector?.kind === 'loadbalancer' && (
+        <LoadBalancerModal
+          containerId={inspector.id}
+          nodeName={inspector.name}
+          ipAddress={containers.find(c => c.id === inspector.id)?.ip || networkConfig.nodeIpMap?.[inspector.id]}
+          port={containers.find(c => c.id === inspector.id)?.port}
+          state={containers.find(c => c.id === inspector.id)?.state || 'stopped'}
+          config={{
+            loadBalancerAlgorithm: networkConfig.loadBalancerAlgorithms?.[inspector.id],
+            loadBalancerTargets: networkConfig.loadBalancerTargets?.[inspector.id],
+            loadBalancerTargetPort: networkConfig.loadBalancerTargetPorts?.[inspector.id],
+            loadBalancerRoutingRules: networkConfig.loadBalancerRoutingRules?.[inspector.id]
+          }}
+          allNodes={containers}
+          onClose={onCloseInspector}
+          onSaveConfig={async (algorithm, targets, targetPort, routingRules) => {
+            const newConfig = {
+              ...networkConfig,
+              loadBalancerAlgorithms: { ...(networkConfig.loadBalancerAlgorithms || {}), [inspector.id]: algorithm },
+              loadBalancerTargets: { ...(networkConfig.loadBalancerTargets || {}), [inspector.id]: targets },
+              loadBalancerTargetPorts: { ...(networkConfig.loadBalancerTargetPorts || {}), [inspector.id]: targetPort },
+              loadBalancerRoutingRules: { ...(networkConfig.loadBalancerRoutingRules || {}), [inspector.id]: routingRules }
+            };
+            await saveNetworkConfig(newConfig);
+            showToast("Load Balancer configuration applied");
+            triggerArchitectureAudit(newConfig);
+          }}
+        />
+      )}
+
+      {inspector?.kind === 'asg' && (
+        <AsgModal
+          asgId={inspector.id}
+          nodeName={inspector.name}
+          projectId={projectId}
+          config={networkConfig}
+          containers={containers}
+          onClose={onCloseInspector}
+          onSaveConfig={async (asgConfig) => {
+            const newConfig = {
+              ...networkConfig,
+              asgs: { ...(networkConfig.asgs || {}), [inspector.id]: asgConfig }
+            };
+            await saveNetworkConfig(newConfig);
+            showToast("Auto Scaling Group configuration saved");
+            triggerArchitectureAudit(newConfig);
+          }}
+          onRefreshContainers={fetchContainers}
+        />
+      )}
+
+      {inspector?.kind === 'subnet-routes' && (
+        <RoutingTableModal
+          subnetId={inspector.id}
+          subnetName={inspector.name}
+          routes={networkConfig.subnets.find(s => s.id === inspector.id)?.routes || []}
+          natGateways={containers.filter(c => c.type === 'nat').map(c => c.name)}
+          onClose={onCloseInspector}
+          onSave={async (updatedRoutes) => {
+            const updatedSubnets = networkConfig.subnets.map(s => {
+              if (s.id === inspector.id) {
+                return { ...s, routes: updatedRoutes };
+              }
+              return s;
+            });
+            await saveNetworkConfig({ ...networkConfig, subnets: updatedSubnets });
+          }}
+        />
+      )}
+
+      {inspector?.kind === 'security-group' && (
+        <SecurityGroupsModal
+          nodeId={inspector.id}
+          nodeName={inspector.name}
+          nodeType={inspector.nodeType || 'ubuntu'}
+          allNodes={containers}
+          allSubnets={networkConfig.subnets.map(s => ({ id: s.id, name: s.name }))}
+          rules={networkConfig.nodeSecurityGroups[inspector.id] || []}
+          onClose={onCloseInspector}
+          onSaveRules={(rules) => {
+            const newConfig = {
+              ...networkConfig,
+              nodeSecurityGroups: { ...networkConfig.nodeSecurityGroups, [inspector.id]: rules }
+            };
+            saveNetworkConfig(newConfig);
+            triggerArchitectureAudit(newConfig);
+          }}
+        />
+      )}
+
+      {vpcSettings && renderVpcModal('info', vpcSettings.onClose)}
+
+      {trafficSimulator && renderVpcModal('simulator', trafficSimulator.onClose)}
+    </>
+  );
+}

--- a/frontend/src/pages/CanvasPage/components/CreateNodeModal.tsx
+++ b/frontend/src/pages/CanvasPage/components/CreateNodeModal.tsx
@@ -1,0 +1,44 @@
+import InputModal from '../../../shared/components/InputModal';
+import type { ContainerData } from '../../../shared/types';
+
+const COPY_BY_TYPE: Record<string, { title: string; placeholder: string; prefix: string }> = {
+  ubuntu: { title: 'Create Ubuntu Node', placeholder: 'e.g. server-1', prefix: 'srv-' },
+  postgres: { title: 'Create SQL Database Node', placeholder: 'e.g. sql-1', prefix: 'sql-' },
+  sql: { title: 'Create SQL Database Node', placeholder: 'e.g. sql-1', prefix: 'sql-' },
+  nosql: { title: 'Create NoSQL Database Node', placeholder: 'e.g. nosql-1', prefix: 'nosql-' },
+  redis: { title: 'Create Cache Store Node', placeholder: 'e.g. redis-1', prefix: 'redis-' },
+  nat: { title: 'Create NAT Gateway Node', placeholder: 'e.g. nat-1', prefix: 'nat-' },
+  loadbalancer: { title: 'Create Load Balancer Node', placeholder: 'e.g. alb-1', prefix: 'alb-' },
+  autoscalinggroup: { title: 'Create Auto Scaling Group Node', placeholder: 'e.g. asg-1', prefix: 'asg-' },
+};
+
+interface CreateNodeModalProps {
+  type: string;
+  containers: ContainerData[];
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+}
+
+/** Name prompt for a dropped node, pre-filled with the first free `<prefix><n>` name. */
+export default function CreateNodeModal({ type, containers, onSubmit, onCancel }: CreateNodeModalProps) {
+  const copy = COPY_BY_TYPE[type] ?? COPY_BY_TYPE.ubuntu;
+
+  let suffix = 1;
+  while (containers.some(c => c.name === `${copy.prefix}${suffix}`)) {
+    suffix++;
+  }
+
+  return (
+    <InputModal
+      title={copy.title}
+      label="Give your new container a descriptive name."
+      placeholder={copy.placeholder}
+      maxLength={20}
+      restrictPattern={/[^a-zA-Z0-9-]/g}
+      defaultValue={`${copy.prefix}${suffix}`}
+      submitText="Create Node"
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/frontend/src/pages/CanvasPage/hooks/useCanvasDragDrop.ts
+++ b/frontend/src/pages/CanvasPage/hooks/useCanvasDragDrop.ts
@@ -1,0 +1,341 @@
+import { useCallback, useRef } from 'react';
+import type { MutableRefObject, Dispatch, SetStateAction } from 'react';
+import type { Node, ReactFlowInstance } from '@xyflow/react';
+import type { ContainerData } from '../../../shared/types';
+import type { NetworkConfig } from '../../../shared/types/network';
+import { getAbsoluteCoordinates, findSubnetAtPoint, clampToCell } from '../utils/canvasGeometry';
+import { autoGrowContainers, assignNodeToSubnet, createSubnet } from '../utils/networkConfigOps';
+
+interface UseCanvasDragDropArgs {
+  reactFlowInstance: ReactFlowInstance | null;
+  networkConfig: NetworkConfig;
+  containers: ContainerData[];
+  positionsRef: MutableRefObject<Record<string, { x: number; y: number }>>;
+  setNodes: Dispatch<SetStateAction<Node[]>>;
+  projectId: string;
+  saveNetworkConfig: (config: NetworkConfig) => Promise<unknown>;
+  triggerArchitectureAudit: (config: NetworkConfig) => void;
+  showNotification: (notification: { type: 'error' | 'warning' | 'success'; message: string }) => void;
+  fetchContainers: () => void;
+  /** Bridge to the create-node modal: a service was dropped inside a subnet. */
+  onRequestCreateNode: (drop: { position: { x: number; y: number }; type: string; subnetId: string }) => void;
+}
+
+/**
+ * All React Flow drag/drop/delete handlers: reparenting nodes between
+ * subnets (with revert on invalid placement), live hover feedback while
+ * dragging, palette drops and the delete-key cascade.
+ */
+export function useCanvasDragDrop({
+  reactFlowInstance,
+  networkConfig,
+  containers,
+  positionsRef,
+  setNodes,
+  projectId,
+  saveNetworkConfig,
+  triggerArchitectureAudit,
+  showNotification,
+  fetchContainers,
+  onRequestCreateNode,
+}: UseCanvasDragDropArgs) {
+  const dragStartPositionsRef = useRef<Record<string, { x: number; y: number; parentId?: string }>>({});
+  const draggingNodeIdRef = useRef<string | null>(null);
+
+  // Track start position on drag start to allow rollback/reversion if drop is invalid
+  const onNodeDragStart = useCallback((_event: unknown, node: Node) => {
+    draggingNodeIdRef.current = node.id;
+    dragStartPositionsRef.current[node.id] = {
+      x: node.position.x,
+      y: node.position.y,
+      parentId: node.parentId
+    };
+  }, []);
+
+  const onNodeDrag = useCallback((_event: unknown, draggedNode: Node) => {
+    if (!reactFlowInstance) return;
+
+    const currentNodes = reactFlowInstance.getNodes();
+
+    // Calculate absolute coordinates of dragged node center
+    let absX = draggedNode.position.x;
+    let absY = draggedNode.position.y;
+    if (draggedNode.parentId) {
+      const parentPos = getAbsoluteCoordinates(draggedNode.parentId, currentNodes);
+      absX += parentPos.x;
+      absY += parentPos.y;
+    }
+
+    const nodeWidth = draggedNode.width || (draggedNode.type === 'subnet' ? 260 : 220);
+    const nodeHeight = draggedNode.height || (draggedNode.type === 'subnet' ? 180 : 140);
+
+    // Check intersection with subnets: hovering one is valid for a service
+    // node, invalid for a subnet (no nesting).
+    const center = { x: absX + nodeWidth / 2, y: absY + nodeHeight / 2 };
+    const hoveredSubnet = draggedNode.type !== 'subnet'
+      ? findSubnetAtPoint(center, networkConfig.subnets)
+      : findSubnetAtPoint(center, networkConfig.subnets, draggedNode.id);
+    const hoveredId = hoveredSubnet?.id ?? null;
+    const isValid = !!hoveredSubnet && draggedNode.type !== 'subnet';
+
+    // Update real-time position in coordinates map for auto-growing calculations
+    const tempNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
+
+    // If we are hovering a valid container, assume it's parented temporarily for sizing check
+    if (hoveredId && isValid) {
+      tempNodeSubnetMap[draggedNode.id] = hoveredId;
+    } else if (draggedNode.type !== 'subnet') {
+      // Dragging service node outside of any container
+      delete tempNodeSubnetMap[draggedNode.id];
+    }
+
+    const grownConfig = autoGrowContainers({
+      ...networkConfig,
+      nodeSubnetMap: tempNodeSubnetMap
+    });
+
+    setNodes(prev => prev.map(n => {
+      // Apply grew sizes to subnets
+      if (n.type === 'subnet') {
+        const subnet = grownConfig.subnets.find(s => s.id === n.id);
+        const isHoverTarget = n.id === hoveredId;
+        return {
+          ...n,
+          style: { ...n.style, width: subnet?.width, height: subnet?.height },
+          data: {
+            ...n.data,
+            hoverStatus: isHoverTarget ? (isValid ? 'valid' : 'invalid') : null
+          }
+        };
+      }
+      return n;
+    }));
+  }, [reactFlowInstance, networkConfig, setNodes]);
+
+  // Save position to ref and localStorage when drag ends (auto-save with overlapping logic)
+  const onNodeDragStop = useCallback((_event: unknown, draggedNode: Node) => {
+    draggingNodeIdRef.current = null;
+    if (!reactFlowInstance) return;
+
+    const currentNodes = reactFlowInstance.getNodes();
+
+    // Reset all hoverStatus
+    setNodes(prev => prev.map(n => {
+      if (n.data && n.data.hoverStatus) {
+        return { ...n, data: { ...n.data, hoverStatus: null } };
+      }
+      return n;
+    }));
+
+    // Calculate final absolute coordinates of dragged node
+    let absX = draggedNode.position.x;
+    let absY = draggedNode.position.y;
+    if (draggedNode.parentId) {
+      const parentPos = getAbsoluteCoordinates(draggedNode.parentId, currentNodes);
+      absX += parentPos.x;
+      absY += parentPos.y;
+    }
+
+    const revertNode = (message: { type: 'error' | 'warning'; text: string }) => {
+      showNotification({ type: message.type, message: message.text });
+      const original = dragStartPositionsRef.current[draggedNode.id];
+      if (original) {
+        setNodes(prev => prev.map(n => {
+          if (n.id === draggedNode.id) {
+            return {
+              ...n,
+              position: { x: original.x, y: original.y },
+              parentId: original.parentId
+            };
+          }
+          return n;
+        }));
+      }
+    };
+
+    if (draggedNode.type === 'subnet') {
+      const subnetWidth = 260;
+      const subnetHeight = 180;
+      const subnetCenter = { x: absX + subnetWidth / 2, y: absY + subnetHeight / 2 };
+
+      // Check if dropped inside another subnet
+      if (findSubnetAtPoint(subnetCenter, networkConfig.subnets, draggedNode.id)) {
+        revertNode({ type: 'error', text: 'Invalid placement: Subnets cannot be nested inside other subnets.' });
+        return;
+      }
+
+      const updatedSubnets = networkConfig.subnets.map(s => {
+        if (s.id === draggedNode.id) {
+          return {
+            ...s,
+            position: { x: absX, y: absY }
+          };
+        }
+        return s;
+      });
+
+      const newConfig = { ...networkConfig, subnets: updatedSubnets };
+      saveNetworkConfig(newConfig);
+      triggerArchitectureAudit(newConfig);
+    }
+    else {
+      // Container/Service node
+      const nodeCenter = { x: absX + 110, y: absY + 70 };
+      const targetSubnet = findSubnetAtPoint(nodeCenter, networkConfig.subnets);
+
+      const original = dragStartPositionsRef.current[draggedNode.id];
+      const oldParentId = original?.parentId;
+      const newParentId = targetSubnet?.id;
+
+      if (oldParentId !== newParentId) {
+        const oldSubnet = networkConfig.subnets.find(s => s.id === oldParentId);
+
+        if (oldParentId && oldParentId.startsWith('subnet-')) {
+          showNotification({ type: 'warning', message: `Node "${draggedNode.data.name}" removed from Subnet "${oldSubnet?.name || 'Subnet'}"` });
+        }
+
+        if (newParentId && newParentId.startsWith('subnet-')) {
+          showNotification({ type: 'success', message: `Node "${draggedNode.data.name}" added to Subnet "${targetSubnet?.name || 'Subnet'}"` });
+        }
+      }
+
+      if (!targetSubnet) {
+        // Revert container node drag to its original subnet position
+        revertNode({ type: 'warning', text: 'Nodes must reside within a subnet.' });
+        return;
+      }
+
+      positionsRef.current[draggedNode.id] = clampToCell(
+        { x: absX - targetSubnet.position.x, y: absY - targetSubnet.position.y },
+        targetSubnet.columns || 2,
+        targetSubnet.rows || 1
+      );
+      localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(positionsRef.current));
+
+      const newConfig = assignNodeToSubnet(networkConfig, draggedNode.id, targetSubnet.id);
+      saveNetworkConfig(newConfig);
+      triggerArchitectureAudit(newConfig);
+    }
+  }, [reactFlowInstance, networkConfig, projectId, positionsRef, saveNetworkConfig, setNodes, triggerArchitectureAudit, showNotification]);
+
+  const onNodesDelete = useCallback((deleted: Node[]) => {
+    const blockedNode = deleted.find(node => {
+      const usingAsgs = Object.keys(networkConfig?.asgs || {}).filter(asgId => networkConfig?.asgs?.[asgId]?.parentId === node.id);
+      return usingAsgs.some(asgId => {
+        const container = containers.find(c => c.id === asgId);
+        return container && container.state === 'running';
+      });
+    });
+
+    if (blockedNode) {
+      showNotification({
+        type: 'error',
+        message: `Cannot delete node "${blockedNode.data?.name || 'Node'}": it is used as a template by an active Auto Scaling Group. Please stop the ASG first.`
+      });
+      fetchContainers();
+      return;
+    }
+
+    let updatedSubnets = [...networkConfig.subnets];
+    const updatedNodeSubnetMap = { ...networkConfig.nodeSubnetMap };
+    const updatedNodeIpMap = { ...networkConfig.nodeIpMap || {} };
+
+    deleted.forEach(node => {
+      if (node.type === 'subnet') {
+        updatedSubnets = updatedSubnets.filter(s => s.id !== node.id);
+        Object.keys(updatedNodeSubnetMap).forEach(nodeId => {
+          if (updatedNodeSubnetMap[nodeId] === node.id) {
+            delete updatedNodeSubnetMap[nodeId];
+            delete updatedNodeIpMap[nodeId];
+          }
+        });
+      }
+      // If it's a node being deleted directly
+      if (updatedNodeSubnetMap[node.id]) {
+        delete updatedNodeSubnetMap[node.id];
+        delete updatedNodeIpMap[node.id];
+      }
+    });
+
+    if (deleted.length > 0) {
+      saveNetworkConfig({
+        ...networkConfig,
+        subnets: updatedSubnets,
+        nodeSubnetMap: updatedNodeSubnetMap,
+        nodeIpMap: updatedNodeIpMap
+      });
+    }
+  }, [networkConfig, saveNetworkConfig, containers, fetchContainers, showNotification]);
+
+  // React Flow Drag-and-Drop handlers
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+
+      if (!reactFlowInstance) return;
+
+      const type = event.dataTransfer.getData('application/reactflow');
+      if (!type) return;
+
+      const position = reactFlowInstance.screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      if (type === 'subnet-public' || type === 'subnet-private') {
+        const newSubnet = createSubnet(
+          type === 'subnet-public' ? 'public' : 'private',
+          position,
+          networkConfig.vpcConfig.cidr,
+          networkConfig.subnets.length
+        );
+
+        // Check if dropped inside another subnet
+        const subnetCenter = { x: position.x + newSubnet.width / 2, y: position.y + newSubnet.height / 2 };
+        if (findSubnetAtPoint(subnetCenter, networkConfig.subnets)) {
+          showNotification({ type: 'error', message: 'Invalid placement: Subnets cannot be nested inside other subnets.' });
+          return;
+        }
+
+        const newConfig = {
+          ...networkConfig,
+          subnets: [...networkConfig.subnets, newSubnet]
+        };
+        saveNetworkConfig(newConfig);
+        triggerArchitectureAudit(newConfig);
+      } else {
+        const nodeCenter = { x: position.x + 110, y: position.y + 70 };
+        const targetSubnet = findSubnetAtPoint(nodeCenter, networkConfig.subnets);
+
+        if (!targetSubnet) {
+          showNotification({ type: 'error', message: 'Nodes must reside within a subnet.' });
+          return;
+        }
+
+        const finalDropPos = clampToCell(
+          { x: position.x - targetSubnet.position.x, y: position.y - targetSubnet.position.y },
+          targetSubnet.columns || 2,
+          targetSubnet.rows || 1
+        );
+
+        onRequestCreateNode({ position: finalDropPos, type, subnetId: targetSubnet.id });
+      }
+    },
+    [reactFlowInstance, networkConfig, saveNetworkConfig, showNotification, triggerArchitectureAudit, onRequestCreateNode]
+  );
+
+  return {
+    onNodeDragStart,
+    onNodeDrag,
+    onNodeDragStop,
+    onNodesDelete,
+    onDragOver,
+    onDrop,
+    draggingNodeIdRef,
+  };
+}

--- a/frontend/src/pages/CanvasPage/hooks/useNetworkConfig.ts
+++ b/frontend/src/pages/CanvasPage/hooks/useNetworkConfig.ts
@@ -1,0 +1,150 @@
+import { useState, useMemo, useRef, useCallback } from 'react';
+import type { ContainerData } from '../../../shared/types';
+import { API_BASE } from '../../../shared/types';
+import type { NetworkConfig } from '../../../shared/types/network';
+import { validateArchitecture } from '../../../shared/utils/architectureValidator';
+import { autoGrowContainers } from '../utils/networkConfigOps';
+
+interface UseNetworkConfigArgs {
+  projectId: string;
+  containers: ContainerData[];
+  showNotification: (notification: { type: 'error' | 'warning' | 'success'; message: string }) => void;
+}
+
+/**
+ * Owns the network config: state, backend fetch (with localStorage fallback),
+ * the save path (localStorage + backend sync, applying the server's corrected
+ * config from the response) and the architecture audit toasts.
+ */
+export function useNetworkConfig({ projectId, containers, showNotification }: UseNetworkConfigArgs) {
+  const prevDbCountRef = useRef(0);
+  const hasShownCacheWarningRef = useRef(false);
+
+  const defaultVpcConfig = useMemo(() => ({
+    name: 'Main Network',
+    cidr: '10.0.0.0/16',
+    dnsEnabled: true,
+    igwEnabled: true,
+    description: 'Project-wide Virtual Private Cloud'
+  }), []);
+
+  const [networkConfig, setNetworkConfig] = useState<NetworkConfig>({
+    vpcConfig: defaultVpcConfig,
+    subnets: [],
+    nodeSubnetMap: {},
+    nodeSecurityGroups: {},
+    nodeIpMap: {}
+  });
+
+  const saveNetworkConfig = useCallback((newConfig: NetworkConfig) => {
+    const grownConfig = autoGrowContainers(newConfig);
+    setNetworkConfig(grownConfig);
+    localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(grownConfig));
+
+    // Sync to backend to trigger runtime enforcement
+    return fetch(`${API_BASE}/api/projects/${projectId}/network-config`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ networkConfig: grownConfig })
+    })
+    .then(res => {
+      if (!res.ok) {
+        throw new Error(`Failed to save network config (HTTP ${res.status})`);
+      }
+      return res.json();
+    })
+    .then(data => {
+      if (data && data.vpcConfig) {
+        setNetworkConfig(data);
+        localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(data));
+      }
+    })
+    .catch(err => {
+      console.error('Failed to sync network configuration to backend:', err);
+      throw err;
+    });
+  }, [projectId]);
+
+  const fetchNetworkConfig = useCallback(() => {
+    fetch(`${API_BASE}/api/projects/${projectId}/network-config`)
+      .then(res => res.json())
+      .then(data => {
+        if (data && data.vpcConfig) {
+          setNetworkConfig(data);
+          localStorage.setItem(`akal-lab-network-config-${projectId}`, JSON.stringify(data));
+        } else {
+          const savedConfig = localStorage.getItem(`akal-lab-network-config-${projectId}`);
+          if (savedConfig) {
+            const parsed = JSON.parse(savedConfig);
+            if (!parsed.vpcConfig) {
+              parsed.vpcConfig = defaultVpcConfig;
+            }
+            setNetworkConfig(parsed);
+          } else {
+            setNetworkConfig({
+              vpcConfig: defaultVpcConfig,
+              subnets: [],
+              nodeSubnetMap: {},
+              nodeSecurityGroups: {},
+              nodeIpMap: {}
+            });
+          }
+        }
+      })
+      .catch(err => {
+        console.error('Failed to fetch network config from backend, using localStorage:', err);
+        const savedConfig = localStorage.getItem(`akal-lab-network-config-${projectId}`);
+        if (savedConfig) {
+          try {
+            const parsed = JSON.parse(savedConfig);
+            if (!parsed.vpcConfig) {
+              parsed.vpcConfig = defaultVpcConfig;
+            }
+            setNetworkConfig(parsed);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      });
+  }, [projectId, defaultVpcConfig]);
+
+  const triggerArchitectureAudit = useCallback((configToValidate: NetworkConfig) => {
+    const result = validateArchitecture(configToValidate, containers);
+
+    // Detect DB nodes count
+    const currentDbCount = containers.filter(c => ['postgres', 'sql', 'nosql'].includes(c.type || '')).length;
+    if (currentDbCount > prevDbCountRef.current) {
+      hasShownCacheWarningRef.current = false;
+    }
+    prevDbCountRef.current = currentDbCount;
+
+    let warnings = result.warnings;
+    const hasCacheWarning = warnings.some(w => w.includes('No caching tier'));
+
+    if (hasCacheWarning) {
+      if (hasShownCacheWarningRef.current) {
+        // Filter it out so it doesn't toast again
+        warnings = warnings.filter(w => !w.includes('No caching tier'));
+      } else {
+        // Mark as shown so subsequent non-add actions don't trigger it
+        hasShownCacheWarningRef.current = true;
+      }
+    } else {
+      if (currentDbCount === 0) {
+        hasShownCacheWarningRef.current = false;
+      }
+    }
+
+    if (result.errors.length > 0) {
+      showNotification({ type: 'error', message: result.errors[0] });
+    } else if (warnings.length > 0) {
+      showNotification({ type: 'warning', message: warnings[0] });
+    } else if (result.successes.length > 0) {
+      showNotification({ type: 'success', message: result.successes[0] });
+    }
+  }, [containers, showNotification]);
+
+  return { networkConfig, saveNetworkConfig, fetchNetworkConfig, triggerArchitectureAudit };
+}

--- a/frontend/src/pages/CanvasPage/utils/canvasGeometry.test.ts
+++ b/frontend/src/pages/CanvasPage/utils/canvasGeometry.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import type { Subnet } from '../../../shared/types/network';
+import {
+  GRID,
+  subnetSize,
+  getAbsoluteCoordinates,
+  findSubnetAtPoint,
+  positionToCell,
+  cellToPosition,
+  clampToCell,
+  resolveSubnetChildPosition,
+} from './canvasGeometry';
+
+function subnet(overrides: Partial<Subnet> & { id: string }): Subnet {
+  return {
+    name: overrides.id,
+    type: 'public',
+    vpcId: 'root-vpc',
+    position: { x: 0, y: 0 },
+    width: 680,
+    height: 260,
+    routes: [],
+    ...overrides,
+  };
+}
+
+function node(overrides: Partial<Node> & { id: string }): Node {
+  return {
+    position: { x: 0, y: 0 },
+    data: {},
+    ...overrides,
+  } as Node;
+}
+
+describe('subnetSize', () => {
+  it('computes outer dimensions from the grid size', () => {
+    expect(subnetSize(2, 1)).toEqual({ width: 2 * GRID.cellW, height: GRID.headerH + GRID.cellH });
+    expect(subnetSize(3, 2)).toEqual({ width: 1020, height: 450 });
+  });
+});
+
+describe('getAbsoluteCoordinates', () => {
+  it('returns the node position when it has no parent', () => {
+    const nodes = [node({ id: 'a', position: { x: 10, y: 20 } })];
+    expect(getAbsoluteCoordinates('a', nodes)).toEqual({ x: 10, y: 20 });
+  });
+
+  it('accumulates positions through nested parents', () => {
+    const nodes = [
+      node({ id: 'grandparent', position: { x: 100, y: 200 } }),
+      node({ id: 'parent', position: { x: 30, y: 40 }, parentId: 'grandparent' }),
+      node({ id: 'child', position: { x: 5, y: 6 }, parentId: 'parent' }),
+    ];
+    expect(getAbsoluteCoordinates('child', nodes)).toEqual({ x: 135, y: 246 });
+  });
+
+  it('returns the origin for an unknown node', () => {
+    expect(getAbsoluteCoordinates('missing', [])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('findSubnetAtPoint', () => {
+  const subnets = [
+    subnet({ id: 'sub-1', position: { x: 0, y: 0 }, width: 680, height: 260 }),
+    subnet({ id: 'sub-2', position: { x: 1000, y: 0 }, width: 680, height: 260 }),
+  ];
+
+  it('returns the subnet containing the point', () => {
+    expect(findSubnetAtPoint({ x: 50, y: 50 }, subnets)?.id).toBe('sub-1');
+    expect(findSubnetAtPoint({ x: 1100, y: 100 }, subnets)?.id).toBe('sub-2');
+  });
+
+  it('treats subnet edges as inside', () => {
+    expect(findSubnetAtPoint({ x: 0, y: 0 }, subnets)?.id).toBe('sub-1');
+    expect(findSubnetAtPoint({ x: 680, y: 260 }, subnets)?.id).toBe('sub-1');
+  });
+
+  it('returns null when no subnet contains the point', () => {
+    expect(findSubnetAtPoint({ x: 800, y: 50 }, subnets)).toBeNull();
+  });
+
+  it('skips the excluded subnet (self hit-test while dragging)', () => {
+    expect(findSubnetAtPoint({ x: 50, y: 50 }, subnets, 'sub-1')).toBeNull();
+  });
+});
+
+describe('positionToCell / cellToPosition', () => {
+  it('round-trips a cell through its snap position', () => {
+    expect(positionToCell(cellToPosition(0, 0))).toEqual({ col: 0, row: 0 });
+    expect(positionToCell(cellToPosition(2, 3))).toEqual({ col: 2, row: 3 });
+  });
+
+  it('maps a position near a cell to that cell', () => {
+    const snap = cellToPosition(1, 1);
+    expect(positionToCell({ x: snap.x + 40, y: snap.y - 30 })).toEqual({ col: 1, row: 1 });
+  });
+});
+
+describe('clampToCell', () => {
+  it('snaps an in-bounds position to its nearest cell', () => {
+    expect(clampToCell(cellToPosition(1, 0), 2, 1)).toEqual(cellToPosition(1, 0));
+  });
+
+  it('clamps positions beyond the grid to the last cell', () => {
+    expect(clampToCell({ x: 5000, y: 5000 }, 2, 1)).toEqual(cellToPosition(1, 0));
+  });
+
+  it('clamps negative positions to the first cell', () => {
+    expect(clampToCell({ x: -500, y: -500 }, 2, 1)).toEqual(cellToPosition(0, 0));
+  });
+});
+
+describe('resolveSubnetChildPosition', () => {
+  it('keeps a saved position that maps to a valid cell', () => {
+    expect(
+      resolveSubnetChildPosition({
+        savedPos: cellToPosition(1, 0),
+        columns: 2,
+        rows: 1,
+        occupiedCells: [],
+      })
+    ).toEqual(cellToPosition(1, 0));
+  });
+
+  it('keeps a valid saved cell even when that cell is occupied (no eviction)', () => {
+    expect(
+      resolveSubnetChildPosition({
+        savedPos: cellToPosition(0, 0),
+        columns: 2,
+        rows: 1,
+        occupiedCells: [{ col: 0, row: 0 }],
+      })
+    ).toEqual(cellToPosition(0, 0));
+  });
+
+  it('assigns the first free cell (row-major) when there is no saved position', () => {
+    expect(
+      resolveSubnetChildPosition({
+        savedPos: undefined,
+        columns: 2,
+        rows: 2,
+        occupiedCells: [
+          { col: 0, row: 0 },
+          { col: 1, row: 0 },
+        ],
+      })
+    ).toEqual(cellToPosition(0, 1));
+  });
+
+  it('reassigns an out-of-bounds saved position to the first free cell', () => {
+    expect(
+      resolveSubnetChildPosition({
+        savedPos: cellToPosition(5, 5),
+        columns: 2,
+        rows: 1,
+        occupiedCells: [{ col: 0, row: 0 }],
+      })
+    ).toEqual(cellToPosition(1, 0));
+  });
+
+  it('falls back to the origin cell when the grid is full', () => {
+    expect(
+      resolveSubnetChildPosition({
+        savedPos: undefined,
+        columns: 1,
+        rows: 1,
+        occupiedCells: [{ col: 0, row: 0 }],
+      })
+    ).toEqual(cellToPosition(0, 0));
+  });
+});

--- a/frontend/src/pages/CanvasPage/utils/canvasGeometry.ts
+++ b/frontend/src/pages/CanvasPage/utils/canvasGeometry.ts
@@ -1,0 +1,121 @@
+import type { Node } from '@xyflow/react';
+import type { Subnet } from '../../../shared/types/network';
+
+/**
+ * Subnet grid geometry: children snap to cells of a fixed-size grid with a
+ * padded origin and a header strip at the top of the subnet card.
+ */
+export const GRID = {
+  cellW: 340,
+  cellH: 190,
+  pad: 60,
+  headerH: 70,
+} as const;
+
+/** Outer pixel dimensions of a subnet card for a given grid size. */
+export function subnetSize(columns: number, rows: number): { width: number; height: number } {
+  return {
+    width: columns * GRID.cellW,
+    height: GRID.headerH + rows * GRID.cellH,
+  };
+}
+
+/** Recursively calculate absolute coordinates of a node by walking up its parent chain. */
+export function getAbsoluteCoordinates(nodeId: string, currentNodes: Node[]): { x: number; y: number } {
+  const node = currentNodes.find(n => n.id === nodeId);
+  if (!node) return { x: 0, y: 0 };
+  if (!node.parentId) return node.position;
+  const parentPos = getAbsoluteCoordinates(node.parentId, currentNodes);
+  return {
+    x: parentPos.x + node.position.x,
+    y: parentPos.y + node.position.y,
+  };
+}
+
+/** First subnet whose bounds contain the given absolute point, or null. */
+export function findSubnetAtPoint(
+  point: { x: number; y: number },
+  subnets: Subnet[],
+  excludeId?: string
+): Subnet | null {
+  for (const subnet of subnets) {
+    if (subnet.id === excludeId) continue;
+    if (
+      point.x >= subnet.position.x &&
+      point.x <= subnet.position.x + subnet.width &&
+      point.y >= subnet.position.y &&
+      point.y <= subnet.position.y + subnet.height
+    ) {
+      return subnet;
+    }
+  }
+  return null;
+}
+
+/** Nearest grid cell for a subnet-relative position (may be out of bounds). */
+export function positionToCell(pos: { x: number; y: number }): { col: number; row: number } {
+  return {
+    col: Math.round((pos.x - GRID.pad) / GRID.cellW),
+    row: Math.round((pos.y - GRID.pad) / GRID.cellH),
+  };
+}
+
+/** Subnet-relative position of a grid cell's snap point. */
+export function cellToPosition(col: number, row: number): { x: number; y: number } {
+  return {
+    x: GRID.pad + col * GRID.cellW,
+    y: GRID.pad + row * GRID.cellH,
+  };
+}
+
+/** Snap a subnet-relative position to the nearest cell, clamped inside the grid. */
+export function clampToCell(
+  rel: { x: number; y: number },
+  columns: number,
+  rows: number
+): { x: number; y: number } {
+  const { col, row } = positionToCell(rel);
+  return cellToPosition(
+    Math.max(0, Math.min(columns - 1, col)),
+    Math.max(0, Math.min(rows - 1, row))
+  );
+}
+
+/**
+ * Resolve where a subnet child should sit: keep its saved cell when it is
+ * still inside the grid, otherwise take the first free cell (row-major).
+ * Falls back to (0, 0) when the grid is full.
+ */
+export function resolveSubnetChildPosition(args: {
+  savedPos: { x: number; y: number } | undefined;
+  columns: number;
+  rows: number;
+  occupiedCells: Array<{ col: number; row: number }>;
+}): { x: number; y: number } {
+  const { savedPos, columns, rows, occupiedCells } = args;
+
+  let col = -1;
+  let row = -1;
+  if (savedPos) {
+    ({ col, row } = positionToCell(savedPos));
+  }
+
+  if (col < 0 || col >= columns || row < 0 || row >= rows) {
+    let found = false;
+    for (let r = 0; r < rows && !found; r++) {
+      for (let c = 0; c < columns && !found; c++) {
+        if (!occupiedCells.some(cell => cell.col === c && cell.row === r)) {
+          col = c;
+          row = r;
+          found = true;
+        }
+      }
+    }
+    if (!found) {
+      col = 0;
+      row = 0;
+    }
+  }
+
+  return cellToPosition(col, row);
+}

--- a/frontend/src/pages/CanvasPage/utils/networkConfigOps.test.ts
+++ b/frontend/src/pages/CanvasPage/utils/networkConfigOps.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import type { NetworkConfig, Subnet } from '../../../shared/types/network';
+import { subnetSize } from './canvasGeometry';
+import {
+  autoGrowContainers,
+  allocateIpForNode,
+  assignNodeToSubnet,
+  removeNodeFromConfig,
+  createSubnet,
+} from './networkConfigOps';
+
+function subnet(overrides: Partial<Subnet> & { id: string }): Subnet {
+  return {
+    name: overrides.id,
+    type: 'private',
+    cidr: '10.0.1.0/24',
+    vpcId: 'root-vpc',
+    position: { x: 0, y: 0 },
+    width: 680,
+    height: 260,
+    columns: 2,
+    rows: 1,
+    routes: [],
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<NetworkConfig> = {}): NetworkConfig {
+  return {
+    vpcConfig: { name: 'VPC', cidr: '10.0.0.0/16', dnsEnabled: true, igwEnabled: true, description: '' },
+    subnets: [subnet({ id: 'subnet-1' })],
+    nodeSubnetMap: {},
+    nodeSecurityGroups: {},
+    nodeIpMap: {},
+    ...overrides,
+  };
+}
+
+describe('autoGrowContainers', () => {
+  it('recomputes subnet dimensions from their grid size', () => {
+    const base = config({
+      subnets: [subnet({ id: 'subnet-1', columns: 3, rows: 2, width: 1, height: 1 })],
+    });
+
+    const grown = autoGrowContainers(base);
+
+    expect(grown.subnets[0]).toMatchObject(subnetSize(3, 2));
+    // input untouched
+    expect(base.subnets[0].width).toBe(1);
+  });
+
+  it('defaults missing grid sizes to 2x1', () => {
+    const base = config({
+      subnets: [subnet({ id: 'subnet-1', columns: undefined, rows: undefined, width: 1, height: 1 })],
+    });
+
+    expect(autoGrowContainers(base).subnets[0]).toMatchObject(subnetSize(2, 1));
+  });
+});
+
+describe('allocateIpForNode', () => {
+  it('allocates .2 in an empty subnet', () => {
+    expect(allocateIpForNode('n1', 'subnet-1', config())).toBe('10.0.1.2');
+  });
+
+  it('keeps the existing IP when it already matches the subnet prefix', () => {
+    const base = config({ nodeIpMap: { n1: '10.0.1.7' }, nodeSubnetMap: { n1: 'subnet-1' } });
+
+    expect(allocateIpForNode('n1', 'subnet-1', base)).toBe('10.0.1.7');
+  });
+
+  it('skips suffixes taken by other nodes in the same subnet', () => {
+    const base = config({
+      nodeSubnetMap: { a: 'subnet-1', b: 'subnet-1' },
+      nodeIpMap: { a: '10.0.1.2', b: '10.0.1.3' },
+    });
+
+    expect(allocateIpForNode('n1', 'subnet-1', base)).toBe('10.0.1.4');
+  });
+
+  it('ignores IPs assigned in other subnets', () => {
+    const base = config({
+      subnets: [subnet({ id: 'subnet-1' }), subnet({ id: 'subnet-2', cidr: '10.0.2.0/24' })],
+      nodeSubnetMap: { other: 'subnet-2' },
+      nodeIpMap: { other: '10.0.2.2' },
+    });
+
+    expect(allocateIpForNode('n1', 'subnet-1', base)).toBe('10.0.1.2');
+  });
+
+  it('returns an empty string for an unknown subnet or malformed CIDR', () => {
+    expect(allocateIpForNode('n1', 'missing', config())).toBe('');
+
+    const bad = config({ subnets: [subnet({ id: 'subnet-1', cidr: 'not-a-cidr' })] });
+    expect(allocateIpForNode('n1', 'subnet-1', bad)).toBe('');
+  });
+});
+
+describe('assignNodeToSubnet', () => {
+  it('maps the node, seeds default rules and allocates an IP', () => {
+    const result = assignNodeToSubnet(config(), 'n1', 'subnet-1');
+
+    expect(result.nodeSubnetMap['n1']).toBe('subnet-1');
+    expect(result.nodeIpMap['n1']).toBe('10.0.1.2');
+    expect(result.nodeSecurityGroups['n1']).toHaveLength(2);
+    expect(result.nodeSecurityGroups['n1'][0]).toMatchObject({ type: 'inbound', action: 'DENY' });
+  });
+
+  it('keeps an existing non-empty security group', () => {
+    const rules = [{ id: 'r1', type: 'inbound' as const, action: 'ALLOW' as const, protocol: 'TCP' as const, port: '80', source: 'x' }];
+    const base = config({ nodeSecurityGroups: { n1: rules } });
+
+    expect(assignNodeToSubnet(base, 'n1', 'subnet-1').nodeSecurityGroups['n1']).toBe(rules);
+  });
+
+  it('accumulates IPs when assigning several nodes in sequence', () => {
+    let cfg = config();
+    cfg = assignNodeToSubnet(cfg, 'a', 'subnet-1');
+    cfg = assignNodeToSubnet(cfg, 'b', 'subnet-1');
+
+    expect(cfg.nodeIpMap).toMatchObject({ a: '10.0.1.2', b: '10.0.1.3' });
+  });
+});
+
+describe('removeNodeFromConfig', () => {
+  it('cascades subnet mapping, security group, IP and rules referencing the node', () => {
+    const base = config({
+      nodeSubnetMap: { victim: 'subnet-1', other: 'subnet-1' },
+      nodeIpMap: { victim: '10.0.1.2', other: '10.0.1.3' },
+      nodeSecurityGroups: {
+        victim: [{ id: 'r1', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '80', source: 'other' }],
+        other: [
+          { id: 'r2', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '80', source: 'victim' },
+          { id: 'r3', type: 'inbound', action: 'DENY', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
+        ],
+      },
+    });
+
+    const result = removeNodeFromConfig(base, 'victim');
+
+    expect(result.nodeSubnetMap).toEqual({ other: 'subnet-1' });
+    expect(result.nodeIpMap).toEqual({ other: '10.0.1.3' });
+    expect(result.nodeSecurityGroups['victim']).toBeUndefined();
+    expect(result.nodeSecurityGroups['other']).toEqual([
+      { id: 'r3', type: 'inbound', action: 'DENY', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
+    ]);
+    // input untouched
+    expect(base.nodeSubnetMap['victim']).toBe('subnet-1');
+  });
+});
+
+describe('createSubnet', () => {
+  it('creates a public subnet with local and igw routes derived from the VPC CIDR', () => {
+    const created = createSubnet('public', { x: 10, y: 20 }, '172.16.0.0/16', 0);
+
+    expect(created).toMatchObject({
+      type: 'public',
+      name: 'Public Subnet-1',
+      cidr: '172.16.1.0/24',
+      vpcId: 'root-vpc',
+      position: { x: 10, y: 20 },
+      columns: 2,
+      rows: 1,
+      ...subnetSize(2, 1),
+    });
+    expect(created.routes).toEqual([
+      { destination: '172.16.0.0/16', target: 'local', description: 'Local VPC routing' },
+      { destination: '0.0.0.0/0', target: 'igw', description: 'Internet access' },
+    ]);
+  });
+
+  it('creates a private subnet without the igw route and numbers it from the count', () => {
+    const created = createSubnet('private', { x: 0, y: 0 }, '10.0.0.0/16', 2);
+
+    expect(created.name).toBe('Private Subnet-3');
+    expect(created.cidr).toBe('10.0.3.0/24');
+    expect(created.routes).toEqual([
+      { destination: '10.0.0.0/16', target: 'local', description: 'Local VPC routing' },
+    ]);
+  });
+});

--- a/frontend/src/pages/CanvasPage/utils/networkConfigOps.ts
+++ b/frontend/src/pages/CanvasPage/utils/networkConfigOps.ts
@@ -1,0 +1,128 @@
+import type { NetworkConfig, Subnet } from '../../../shared/types/network';
+import { subnetSize } from './canvasGeometry';
+import { createDefaultRules } from './securityRules';
+
+/**
+ * Pure transforms of the NetworkConfig: subnet creation/sizing, node↔subnet
+ * assignment and the cleanup cascades. All functions return a new config and
+ * never mutate their input.
+ */
+
+/** Recompute every subnet's pixel dimensions from its grid size. */
+export function autoGrowContainers(config: NetworkConfig): NetworkConfig {
+  return {
+    ...config,
+    subnets: config.subnets.map(subnet => ({
+      ...subnet,
+      ...subnetSize(subnet.columns || 2, subnet.rows || 1),
+    })),
+  };
+}
+
+/**
+ * IP for a node inside a subnet: keep its current IP when it already belongs
+ * to the subnet's CIDR, otherwise the lowest free host suffix starting at .2.
+ * Returns '' when the subnet is unknown or its CIDR is malformed.
+ */
+export function allocateIpForNode(nodeId: string, subnetId: string, currentConfig: NetworkConfig): string {
+  const subnet = currentConfig.subnets.find(s => s.id === subnetId);
+  if (!subnet) return '';
+  const cidr = subnet.cidr || '10.99.1.0/24';
+  const match = cidr.match(/^(\d+\.\d+\.\d+)\./);
+  if (!match) return '';
+  const prefix = match[1] + '.';
+
+  const existingIp = currentConfig.nodeIpMap?.[nodeId];
+  if (existingIp && existingIp.startsWith(prefix)) {
+    return existingIp;
+  }
+
+  const assignedIps = Object.entries(currentConfig.nodeIpMap || {})
+    .filter(([nid, ip]) => currentConfig.nodeSubnetMap[nid] === subnetId && ip.startsWith(prefix))
+    .map(([, ip]) => {
+      const parts = ip.split('.');
+      return parseInt(parts[3], 10);
+    });
+
+  let suffix = 2;
+  while (assignedIps.includes(suffix)) {
+    suffix++;
+  }
+
+  return `${prefix}${suffix}`;
+}
+
+/**
+ * Place a node in a subnet: map it, give it the default security group when
+ * it has none, and allocate its IP.
+ */
+export function assignNodeToSubnet(config: NetworkConfig, nodeId: string, subnetId: string): NetworkConfig {
+  const nodeSecurityGroups = { ...config.nodeSecurityGroups };
+  if (!nodeSecurityGroups[nodeId] || nodeSecurityGroups[nodeId].length === 0) {
+    nodeSecurityGroups[nodeId] = createDefaultRules();
+  }
+
+  const assigned: NetworkConfig = {
+    ...config,
+    nodeSubnetMap: { ...config.nodeSubnetMap, [nodeId]: subnetId },
+    nodeSecurityGroups,
+  };
+
+  return {
+    ...assigned,
+    nodeIpMap: { ...assigned.nodeIpMap, [nodeId]: allocateIpForNode(nodeId, subnetId, assigned) },
+  };
+}
+
+/**
+ * Cascade a node deletion: drop its subnet mapping, security group and IP,
+ * and strip other nodes' rules that referenced it as a source.
+ */
+export function removeNodeFromConfig(config: NetworkConfig, nodeId: string): NetworkConfig {
+  const nodeSubnetMap = { ...config.nodeSubnetMap };
+  delete nodeSubnetMap[nodeId];
+
+  const nodeSecurityGroups = { ...config.nodeSecurityGroups };
+  delete nodeSecurityGroups[nodeId];
+  Object.keys(nodeSecurityGroups).forEach(otherId => {
+    nodeSecurityGroups[otherId] = nodeSecurityGroups[otherId].filter(rule => rule.source !== nodeId);
+  });
+
+  const nodeIpMap = { ...(config.nodeIpMap || {}) };
+  delete nodeIpMap[nodeId];
+
+  return { ...config, nodeSubnetMap, nodeSecurityGroups, nodeIpMap };
+}
+
+/**
+ * New 2x1 subnet dropped on the canvas. The subnet CIDR and local route are
+ * derived from the current VPC CIDR: it may have shifted from the default
+ * 10.0.0.0/16 when Docker's address pool overlapped the requested range.
+ */
+export function createSubnet(
+  type: 'public' | 'private',
+  position: { x: number; y: number },
+  vpcCidr: string,
+  existingCount: number
+): Subnet {
+  const isPublic = type === 'public';
+  const cols = 2;
+  const rows = 1;
+  const vpcPrefix = vpcCidr.split('.').slice(0, 2).join('.');
+
+  return {
+    id: `subnet-${Math.random().toString(36).substr(2, 9)}`,
+    name: `${isPublic ? 'Public' : 'Private'} Subnet-${existingCount + 1}`,
+    type,
+    cidr: `${vpcPrefix}.${existingCount + 1}.0/24`,
+    vpcId: 'root-vpc',
+    position,
+    ...subnetSize(cols, rows),
+    columns: cols,
+    rows,
+    routes: [
+      { destination: vpcCidr, target: 'local', description: 'Local VPC routing' },
+      ...(isPublic ? [{ destination: '0.0.0.0/0', target: 'igw', description: 'Internet access' }] : []),
+    ],
+  };
+}

--- a/frontend/src/pages/CanvasPage/utils/securityRules.test.ts
+++ b/frontend/src/pages/CanvasPage/utils/securityRules.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ContainerData } from '../../../shared/types';
+import type { NetworkConfig, SecurityGroupRule, Subnet } from '../../../shared/types/network';
+import {
+  createDefaultRules,
+  buildConnectionRule,
+  addConnectionRule,
+  parseEdgeId,
+  removeEdgeRule,
+  removeRulesForConnections,
+  buildFirewallEdges,
+} from './securityRules';
+
+function container(overrides: Partial<ContainerData> & { id: string; name: string }): ContainerData {
+  return { state: 'running', status: 'running', ...overrides };
+}
+
+function subnet(overrides: Partial<Subnet> & { id: string }): Subnet {
+  return {
+    name: overrides.id,
+    type: 'private',
+    vpcId: 'root-vpc',
+    position: { x: 0, y: 0 },
+    width: 680,
+    height: 260,
+    routes: [],
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<NetworkConfig> = {}): NetworkConfig {
+  return {
+    vpcConfig: { name: 'VPC', cidr: '10.0.0.0/16', dnsEnabled: true, igwEnabled: true, description: '' },
+    subnets: [],
+    nodeSubnetMap: {},
+    nodeSecurityGroups: {},
+    nodeIpMap: {},
+    ...overrides,
+  };
+}
+
+function allowRule(source: string, port: string): SecurityGroupRule {
+  return { id: `rule-${source}-${port}`, type: 'inbound', action: 'ALLOW', protocol: 'TCP', port, source };
+}
+
+describe('createDefaultRules', () => {
+  it('returns deny-all-inbound and allow-all-outbound', () => {
+    const rules = createDefaultRules();
+    expect(rules).toHaveLength(2);
+    expect(rules[0]).toMatchObject({ type: 'inbound', action: 'DENY', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' });
+    expect(rules[1]).toMatchObject({ type: 'outbound', action: 'ALLOW', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' });
+    expect(rules[0].id).not.toBe(rules[1].id);
+  });
+});
+
+describe('buildConnectionRule', () => {
+  it.each([
+    ['postgres', '5432', 'TCP'],
+    ['sql', '5432', 'TCP'],
+    ['nosql', '27017', 'TCP'],
+    ['mysql', '3306', 'TCP'],
+    ['redis', '6379', 'TCP'],
+    ['ubuntu', 'ALL', 'ALL'],
+    ['loadbalancer', 'ALL', 'ALL'],
+  ])('gives a %s target port %s and protocol %s', (targetType, port, protocol) => {
+    const rule = buildConnectionRule('src-1', targetType);
+    expect(rule).toMatchObject({ type: 'inbound', action: 'ALLOW', port, protocol, source: 'src-1' });
+  });
+});
+
+describe('addConnectionRule', () => {
+  it('prepends the connection rule to the target security group', () => {
+    const base = config({ nodeSecurityGroups: { 'db-1': createDefaultRules() } });
+
+    const result = addConnectionRule(base, 'web-1', 'db-1', 'postgres');
+
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe('5432');
+    const rules = result!.config.nodeSecurityGroups['db-1'];
+    expect(rules).toHaveLength(3);
+    expect(rules[0]).toMatchObject({ type: 'inbound', action: 'ALLOW', port: '5432', source: 'web-1' });
+    // Original config untouched
+    expect(base.nodeSecurityGroups['db-1']).toHaveLength(2);
+  });
+
+  it('returns null when an equivalent rule already exists', () => {
+    const base = config({ nodeSecurityGroups: { 'db-1': [allowRule('web-1', '5432')] } });
+
+    expect(addConnectionRule(base, 'web-1', 'db-1', 'postgres')).toBeNull();
+  });
+
+  it('creates the group when the target has no rules yet', () => {
+    const result = addConnectionRule(config(), 'web-1', 'srv-1', 'ubuntu');
+
+    expect(result!.config.nodeSecurityGroups['srv-1']).toHaveLength(1);
+    expect(result!.port).toBe('ALL');
+  });
+});
+
+describe('parseEdgeId', () => {
+  it('parses ids produced by buildFirewallEdges', () => {
+    expect(parseEdgeId('edge-abc123-def456-5432')).toEqual({ sourceId: 'abc123', targetId: 'def456', port: '5432' });
+    expect(parseEdgeId('edge-a-b-ALL')).toEqual({ sourceId: 'a', targetId: 'b', port: 'ALL' });
+  });
+
+  it('returns null for malformed ids', () => {
+    expect(parseEdgeId('not-an-edge')).toBeNull();
+    expect(parseEdgeId('edge-only')).toBeNull();
+    expect(parseEdgeId('')).toBeNull();
+  });
+});
+
+describe('removeEdgeRule', () => {
+  it('removes the inbound ALLOW rule matching source and port', () => {
+    const base = config({
+      nodeSecurityGroups: { 'db-1': [allowRule('web-1', '5432'), allowRule('web-2', '5432')] },
+    });
+
+    const result = removeEdgeRule(base, 'web-1', 'db-1', '5432');
+
+    expect(result!.nodeSecurityGroups['db-1']).toEqual([allowRule('web-2', '5432')]);
+  });
+
+  it('also removes a wildcard-source rule on the same port', () => {
+    const base = config({
+      nodeSecurityGroups: { 'db-1': [allowRule('0.0.0.0/0', '5432')] },
+    });
+
+    const result = removeEdgeRule(base, 'web-1', 'db-1', '5432');
+
+    expect(result!.nodeSecurityGroups['db-1']).toEqual([]);
+  });
+
+  it('keeps rules on other ports and DENY rules', () => {
+    const deny = createDefaultRules()[0];
+    const base = config({
+      nodeSecurityGroups: { 'db-1': [deny, allowRule('web-1', '80')] },
+    });
+
+    const result = removeEdgeRule(base, 'web-1', 'db-1', '5432');
+
+    expect(result!.nodeSecurityGroups['db-1']).toEqual([deny, allowRule('web-1', '80')]);
+  });
+
+  it('returns null when the target has no security group', () => {
+    expect(removeEdgeRule(config(), 'web-1', 'db-1', '5432')).toBeNull();
+  });
+});
+
+describe('removeRulesForConnections', () => {
+  it('removes matching inbound ALLOW rules on any port', () => {
+    const base = config({
+      nodeSecurityGroups: { 'db-1': [allowRule('web-1', '5432'), allowRule('web-1', '80'), allowRule('web-2', '80')] },
+    });
+
+    const result = removeRulesForConnections(base, [{ source: 'web-1', target: 'db-1' }]);
+
+    expect(result!.nodeSecurityGroups['db-1']).toEqual([allowRule('web-2', '80')]);
+  });
+
+  it('returns null when nothing matched', () => {
+    const base = config({
+      nodeSecurityGroups: { 'db-1': [allowRule('web-2', '80')] },
+    });
+
+    expect(removeRulesForConnections(base, [{ source: 'web-1', target: 'db-1' }])).toBeNull();
+    expect(removeRulesForConnections(base, [{ source: 'web-1', target: 'unknown' }])).toBeNull();
+  });
+});
+
+describe('buildFirewallEdges', () => {
+  const twoSubnetsSameVpc = [subnet({ id: 'subnet-a' }), subnet({ id: 'subnet-b' })];
+
+  function topology(rules: Record<string, SecurityGroupRule[]>, overrides: Partial<NetworkConfig> = {}) {
+    return config({
+      subnets: twoSubnetsSameVpc,
+      nodeSubnetMap: { 'web-1': 'subnet-a', 'db-1': 'subnet-b' },
+      nodeSecurityGroups: rules,
+      ...overrides,
+    });
+  }
+
+  const nodes = [container({ id: 'web-1', name: 'web-1' }), container({ id: 'db-1', name: 'db-1', type: 'postgres' })];
+
+  it('builds an edge for an inbound ALLOW rule matching the source node id', () => {
+    const edges = buildFirewallEdges(nodes, topology({ 'db-1': [allowRule('web-1', '5432')] }), vi.fn());
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      id: 'edge-web-1-db-1-5432',
+      source: 'web-1',
+      target: 'db-1',
+      type: 'buttonEdge',
+      label: 'Port 5432',
+    });
+  });
+
+  it('matches wildcard and subnet-id sources', () => {
+    expect(buildFirewallEdges(nodes, topology({ 'db-1': [allowRule('0.0.0.0/0', '5432')] }), vi.fn())).toHaveLength(1);
+    expect(buildFirewallEdges(nodes, topology({ 'db-1': [allowRule('subnet-a', '5432')] }), vi.fn())).toHaveLength(1);
+    expect(buildFirewallEdges(nodes, topology({ 'db-1': [allowRule('subnet-b', '5432')] }), vi.fn())).toHaveLength(0);
+  });
+
+  it('ignores DENY and outbound rules', () => {
+    const outbound: SecurityGroupRule = { ...allowRule('web-1', '5432'), type: 'outbound' };
+    const deny: SecurityGroupRule = { ...allowRule('web-1', '5432'), action: 'DENY' };
+
+    expect(buildFirewallEdges(nodes, topology({ 'db-1': [outbound, deny] }), vi.fn())).toHaveLength(0);
+  });
+
+  it('excludes NAT gateways as source and destination', () => {
+    const withNat = [...nodes, container({ id: 'nat-1', name: 'nat-1', type: 'nat' })];
+    const cfg = topology(
+      { 'db-1': [allowRule('0.0.0.0/0', '5432')], 'nat-1': [allowRule('0.0.0.0/0', 'ALL')] },
+      { nodeSubnetMap: { 'web-1': 'subnet-a', 'db-1': 'subnet-b', 'nat-1': 'subnet-a' } }
+    );
+
+    const edges = buildFirewallEdges(withNat, cfg, vi.fn());
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe('web-1');
+  });
+
+  it('skips nodes without a subnet and pairs in different VPCs', () => {
+    // db-1 has no subnet assignment
+    const noSubnet = topology({ 'db-1': [allowRule('0.0.0.0/0', '5432')] }, { nodeSubnetMap: { 'web-1': 'subnet-a' } });
+    expect(buildFirewallEdges(nodes, noSubnet, vi.fn())).toHaveLength(0);
+
+    // source sits in a subnet of another VPC
+    const otherVpc = config({
+      subnets: [subnet({ id: 'subnet-a', vpcId: 'other-vpc' }), subnet({ id: 'subnet-b' })],
+      nodeSubnetMap: { 'web-1': 'subnet-a', 'db-1': 'subnet-b' },
+      nodeSecurityGroups: { 'db-1': [allowRule('0.0.0.0/0', '5432')] },
+    });
+    expect(buildFirewallEdges(nodes, otherVpc, vi.fn())).toHaveLength(0);
+  });
+
+  it('dedupes edges when several rules resolve to the same source/target/port', () => {
+    const cfg = topology({ 'db-1': [allowRule('0.0.0.0/0', '5432'), allowRule('web-1', '5432')] });
+
+    expect(buildFirewallEdges(nodes, cfg, vi.fn())).toHaveLength(1);
+  });
+
+  it('threads the onDelete callback into edge data', () => {
+    const onDelete = vi.fn();
+    const edges = buildFirewallEdges(nodes, topology({ 'db-1': [allowRule('web-1', '5432')] }), onDelete);
+
+    expect(edges[0].data?.onDelete).toBe(onDelete);
+  });
+});

--- a/frontend/src/pages/CanvasPage/utils/securityRules.ts
+++ b/frontend/src/pages/CanvasPage/utils/securityRules.ts
@@ -1,0 +1,208 @@
+import type { Edge } from '@xyflow/react';
+import type { ContainerData } from '../../../shared/types';
+import type { NetworkConfig, SecurityGroupRule } from '../../../shared/types/network';
+
+/**
+ * Pure security-group rule logic: the canvas edges are a projection of the
+ * inbound ALLOW rules, so edge create/delete always translates to rule
+ * add/remove on the target node's security group.
+ */
+
+/** Default security group: deny all inbound, allow all outbound. */
+export function createDefaultRules(): SecurityGroupRule[] {
+  return [
+    {
+      id: `rule-${Math.random().toString(36).substr(2, 9)}`,
+      type: 'inbound',
+      action: 'DENY',
+      protocol: 'ALL',
+      port: 'ALL',
+      source: '0.0.0.0/0',
+    },
+    {
+      id: `rule-${Math.random().toString(36).substr(2, 9)}`,
+      type: 'outbound',
+      action: 'ALLOW',
+      protocol: 'ALL',
+      port: 'ALL',
+      source: '0.0.0.0/0',
+    },
+  ];
+}
+
+/** Inbound ALLOW rule for a manual connection, with the target type's default port. */
+export function buildConnectionRule(sourceId: string, targetType: string): SecurityGroupRule {
+  const isDb = ['postgres', 'sql', 'nosql', 'mysql', 'redis'].includes(targetType);
+  const port =
+    (targetType === 'postgres' || targetType === 'sql') ? '5432'
+      : targetType === 'nosql' ? '27017'
+      : targetType === 'mysql' ? '3306'
+      : targetType === 'redis' ? '6379'
+      : 'ALL';
+
+  return {
+    id: `rule-${Math.random().toString(36).substr(2, 9)}`,
+    type: 'inbound',
+    action: 'ALLOW',
+    protocol: isDb ? 'TCP' : 'ALL',
+    port,
+    source: sourceId,
+  };
+}
+
+/**
+ * Add the connection rule for source → target to the config.
+ * Returns null when an equivalent rule already exists (no-op).
+ */
+export function addConnectionRule(
+  config: NetworkConfig,
+  sourceId: string,
+  targetId: string,
+  targetType: string
+): { config: NetworkConfig; port: string } | null {
+  const newRule = buildConnectionRule(sourceId, targetType);
+  const currentRules = config.nodeSecurityGroups[targetId] || [];
+  const alreadyExists = currentRules.some(
+    r => r.type === 'inbound' && r.action === 'ALLOW' && r.port === newRule.port && r.source === sourceId
+  );
+  if (alreadyExists) return null;
+
+  return {
+    config: {
+      ...config,
+      nodeSecurityGroups: {
+        ...config.nodeSecurityGroups,
+        [targetId]: [newRule, ...currentRules],
+      },
+    },
+    port: newRule.port,
+  };
+}
+
+/** Parse an `edge-{sourceId}-{targetId}-{port}` id built by buildFirewallEdges. */
+export function parseEdgeId(edgeId: string): { sourceId: string; targetId: string; port: string } | null {
+  const match = edgeId.match(/^edge-([^-]+)-([^-]+)-(.+)$/);
+  if (!match) return null;
+  const [, sourceId, targetId, port] = match;
+  return { sourceId, targetId, port };
+}
+
+/**
+ * Remove the inbound ALLOW rule matching a deleted edge from the target's
+ * security group. Returns null when the target has no security group.
+ */
+export function removeEdgeRule(
+  config: NetworkConfig,
+  sourceId: string,
+  targetId: string,
+  port: string
+): NetworkConfig | null {
+  const targetRules = config.nodeSecurityGroups[targetId];
+  if (!targetRules) return null;
+
+  return {
+    ...config,
+    nodeSecurityGroups: {
+      ...config.nodeSecurityGroups,
+      [targetId]: targetRules.filter(
+        rule => !(
+          rule.type === 'inbound' &&
+          rule.action === 'ALLOW' &&
+          rule.port === port &&
+          (rule.source === sourceId || rule.source === '0.0.0.0/0')
+        )
+      ),
+    },
+  };
+}
+
+/**
+ * Remove the inbound ALLOW rules matching the given source → target pairs
+ * (any port). Returns null when nothing matched.
+ */
+export function removeRulesForConnections(
+  config: NetworkConfig,
+  pairs: Array<{ source: string; target: string }>
+): NetworkConfig | null {
+  const updatedSecurityGroups = { ...config.nodeSecurityGroups };
+  let changed = false;
+
+  pairs.forEach(({ source, target }) => {
+    if (updatedSecurityGroups[target]) {
+      updatedSecurityGroups[target] = updatedSecurityGroups[target].filter(rule => {
+        const isMatch = rule.type === 'inbound' && rule.action === 'ALLOW' && (rule.source === source || rule.source === '0.0.0.0/0');
+        if (isMatch) changed = true;
+        return !isMatch;
+      });
+    }
+  });
+
+  if (!changed) return null;
+  return { ...config, nodeSecurityGroups: updatedSecurityGroups };
+}
+
+/**
+ * Project the inbound ALLOW rules onto canvas edges: one edge per
+ * (source, target, port) where both nodes sit in subnets of the same VPC and
+ * the source matches the rule (wildcard, subnet id or node id). NAT gateways
+ * never appear as edge endpoints.
+ */
+export function buildFirewallEdges(
+  containers: ContainerData[],
+  config: NetworkConfig,
+  onDelete: (edgeId: string) => void
+): Edge[] {
+  const edgesList: Edge[] = [];
+
+  containers.forEach(destNode => {
+    if (destNode.type === 'nat') return;
+    const destRules = config.nodeSecurityGroups[destNode.id] || [];
+    const destSubnetId = config.nodeSubnetMap[destNode.id];
+    if (!destSubnetId) return;
+    const destSubnet = config.subnets.find(s => s.id === destSubnetId);
+    const destVpcId = destSubnet?.vpcId;
+    if (!destVpcId) return;
+
+    const inboundAllowRules = destRules.filter(r => r.type === 'inbound' && r.action === 'ALLOW');
+
+    inboundAllowRules.forEach(rule => {
+      containers.forEach(srcNode => {
+        if (srcNode.id === destNode.id) return;
+        if (srcNode.type === 'nat') return;
+
+        const srcSubnetId = config.nodeSubnetMap[srcNode.id];
+        if (!srcSubnetId) return;
+        const srcSubnet = config.subnets.find(s => s.id === srcSubnetId);
+        const srcVpcId = srcSubnet?.vpcId;
+
+        // Must be in the same VPC
+        if (srcVpcId !== destVpcId) return;
+
+        // Check if source matches rule
+        const isMatch =
+          rule.source === '0.0.0.0/0' ||
+          rule.source === srcSubnetId ||
+          rule.source === srcNode.id;
+
+        if (isMatch) {
+          const edgeId = `edge-${srcNode.id}-${destNode.id}-${rule.port}`;
+          if (!edgesList.some(e => e.id === edgeId)) {
+            edgesList.push({
+              id: edgeId,
+              source: srcNode.id,
+              target: destNode.id,
+              type: 'buttonEdge',
+              data: { onDelete },
+              animated: true,
+              label: `Port ${rule.port}`,
+              style: { stroke: '#10B981', strokeWidth: 2 },
+              labelStyle: { fill: '#374151', fontSize: 9, fontWeight: 700 },
+            });
+          }
+        }
+      });
+    });
+  });
+
+  return edgesList;
+}

--- a/frontend/src/shared/types/network.ts
+++ b/frontend/src/shared/types/network.ts
@@ -1,0 +1,62 @@
+/**
+ * Canonical network topology types shared across the canvas, node modals
+ * and the architecture validator.
+ */
+
+export interface VPCConfig {
+  name: string;
+  cidr: string;
+  dnsEnabled: boolean;
+  igwEnabled: boolean;
+  description: string;
+}
+
+export interface SecurityGroupRule {
+  id: string;
+  type: 'inbound' | 'outbound';
+  action: 'ALLOW' | 'DENY';
+  protocol: 'ALL' | 'TCP' | 'UDP' | 'ICMP';
+  port: string; // e.g. "80", "5432", "ALL"
+  source: string; // e.g. "0.0.0.0/0", "subnet-id", "node-id"
+}
+
+export interface SubnetRoute {
+  destination: string;
+  target: string;
+  description: string;
+}
+
+export interface Subnet {
+  id: string;
+  name: string;
+  type: 'public' | 'private';
+  cidr?: string;
+  vpcId: string | null;
+  position: { x: number; y: number };
+  width: number;
+  height: number;
+  columns?: number;
+  rows?: number;
+  routes: SubnetRoute[];
+}
+
+export interface AsgConfig {
+  desiredCapacity: number;
+  minCapacity: number;
+  maxCapacity: number;
+  parentId: string;
+  subnetIds: string[];
+}
+
+export interface NetworkConfig {
+  vpcConfig: VPCConfig;
+  subnets: Subnet[];
+  nodeSubnetMap: Record<string, string>; // nodeId -> subnetId or vpcId
+  nodeSecurityGroups: Record<string, SecurityGroupRule[]>; // nodeId -> SecurityGroupRule[]
+  nodeIpMap: Record<string, string>; // nodeId -> ipAddress
+  loadBalancerAlgorithms?: Record<string, 'round_robin' | 'least_conn'>;
+  loadBalancerTargets?: Record<string, string[]>;
+  loadBalancerTargetPorts?: Record<string, number>;
+  loadBalancerRoutingRules?: Record<string, Array<{ path: string; targetId: string }>>;
+  asgs?: Record<string, AsgConfig>;
+}

--- a/frontend/src/shared/utils/architectureValidator.ts
+++ b/frontend/src/shared/utils/architectureValidator.ts
@@ -1,31 +1,8 @@
 import type { ContainerData } from '../types';
-import type { SecurityGroupRule } from '../../features/nodes/SecurityGroups/SecurityGroupsModal';
+import type { NetworkConfig as FullNetworkConfig } from '../types/network';
 
-export interface VPC {
-  id: string;
-  name: string;
-  position: { x: number; y: number };
-  width: number;
-  height: number;
-}
-
-export interface Subnet {
-  id: string;
-  name: string;
-  type: 'public' | 'private';
-  vpcId: string | null;
-  position: { x: number; y: number };
-  width: number;
-  height: number;
-  routes: Array<{ destination: string; target: string; description: string }>;
-}
-
-export interface NetworkConfig {
-  vpcs?: VPC[];
-  subnets: Subnet[];
-  nodeSubnetMap: Record<string, string>;
-  nodeSecurityGroups: Record<string, SecurityGroupRule[]>;
-}
+/** The validator only reads the topology-related slice of the network config. */
+export type NetworkConfig = Pick<FullNetworkConfig, 'subnets' | 'nodeSubnetMap' | 'nodeSecurityGroups'>;
 
 export interface ValidationResult {
   errors: string[];


### PR DESCRIPTION
## Summary

`CanvasPage.tsx` had grown to ~1,800 lines, mixing drag-and-drop geometry, IP allocation, firewall-rule generation, edge derivation, persistence and the orchestration of 13 modals in one component. This PR splits it into focused modules while keeping behavior identical — CanvasPage is now a ~690-line orchestrator.

### Extracted pure modules (each with direct unit tests)
- `utils/canvasGeometry.ts` — grid math, subnet sizing, point-in-subnet hit-testing, absolute coordinates, cell snapping/collision search (was duplicated inline ~6×).
- `utils/securityRules.ts` — default deny/allow rules, connection→rule creation, edge-id parsing, rule removal, and `buildFirewallEdges` (the rules→edges projection).
- `utils/networkConfigOps.ts` — `autoGrowContainers`, IP allocation, `assignNodeToSubnet` (dedupes the drop and drag-reparent paths), delete cascade, subnet creation (CIDR derived from the VPC CIDR).

### Extracted hooks
- `hooks/useNetworkConfig.ts` — config state, backend fetch with localStorage fallback, the save path (applies the server's corrected config), and the architecture-audit toasts.
- `hooks/useCanvasDragDrop.ts` — all React Flow drag/drop/delete handlers, now thin glue over the pure modules.

### Extracted components
- `components/CanvasModals.tsx` + `components/CreateNodeModal.tsx` — the 13 modal blocks relocated verbatim; the nested title/placeholder/prefix ternaries replaced by a per-type copy record.

### Other changes
- Canonical network types in `shared/types/network.ts`; `architectureValidator`, `VpcModal`, `SecurityGroupsModal` and CanvasPage now share them instead of duplicating.
- The six `inspecting*` modal states consolidated into one `InspectorState` union (they were mutually exclusive).

### Test coverage
This closes the jsdom coverage gaps documented in `CanvasPage.test.tsx`: drag/reparent geometry, `onConnect` rule creation and edge derivation are now unit-tested directly (57 new tests). Existing tests pass without assertion changes.

## Test plan
- [x] `npm test` (frontend) — 168 passed (111 before)
- [x] `npm run build` + `npm run lint` (frontend) — clean
- [x] `npm test` + `npm run build` (backend, untouched) — 55 passed
- [ ] Manual Docker pass: subnet + node drop, drag between subnets (IP reallocation), drag outside (revert), connection edge create/delete, node/subnet delete, reload persistence