### PR TITLE
feat(learning): validator execution engine and learning API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env.js
 
 # Rapport d'audit local (ne pas publier)
 doc/
+CLAUDE.md

--- a/backend/src/modules/learning/controllers/learningController.test.ts
+++ b/backend/src/modules/learning/controllers/learningController.test.ts
@@ -1,0 +1,165 @@
+import request from 'supertest';
+import express from 'express';
+import learningRouter from '../routes/learningRoutes';
+import { RoadmapService } from '../services/roadmapService';
+import { runStepValidators } from '../engine/engine';
+import { ValidatorResult } from '../engine/types';
+import { ProjectService } from '../../projects/services/projectService';
+import { Roadmap } from '../format/roadmapTypes';
+
+jest.mock('../services/roadmapService');
+jest.mock('../engine/engine');
+jest.mock('../../projects/services/projectService');
+
+const app = express();
+app.use(express.json());
+app.use('/api/learning', learningRouter);
+
+const roadmap: Roadmap = {
+  schemaVersion: 1,
+  id: 'example-roadmap',
+  title: 'Example roadmap',
+  description: 'For controller tests.',
+  language: 'en',
+  steps: [
+    {
+      id: 'step-one',
+      title: 'Step one',
+      instruction: 'Do it.',
+      validators: [{ type: 'container_running', params: { node: 'web' } }],
+    },
+  ],
+};
+
+const passResult: ValidatorResult = {
+  index: 0,
+  type: 'container_running',
+  status: 'pass',
+  message: 'The container "web" is running.',
+};
+
+const failResult: ValidatorResult = {
+  index: 0,
+  type: 'container_running',
+  status: 'fail',
+  message: 'No container named "web" exists in this project yet.',
+  expected: 'a running container named "web"',
+  observed: 'no container with that name',
+};
+
+const validBody = { projectId: 'project-1', roadmapId: 'example-roadmap', stepId: 'step-one' };
+
+describe('LearningController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (ProjectService.listProjects as jest.Mock).mockResolvedValue([{ id: 'project-1' }]);
+    (RoadmapService.getRoadmap as jest.Mock).mockReturnValue(roadmap);
+    (runStepValidators as jest.Mock).mockResolvedValue([passResult]);
+  });
+
+  describe('GET /api/learning/roadmaps', () => {
+    it('returns the roadmap summaries', async () => {
+      const summaries = [{ id: 'example-roadmap', title: 'Example roadmap', stepCount: 1 }];
+      (RoadmapService.listRoadmaps as jest.Mock).mockReturnValue(summaries);
+
+      const res = await request(app).get('/api/learning/roadmaps');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(summaries);
+    });
+  });
+
+  describe('GET /api/learning/roadmaps/:id', () => {
+    it('returns the full roadmap for a known id', async () => {
+      const res = await request(app).get('/api/learning/roadmaps/example-roadmap');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(roadmap);
+      expect(RoadmapService.getRoadmap).toHaveBeenCalledWith('example-roadmap');
+    });
+
+    it('returns 404 for an unknown id', async () => {
+      (RoadmapService.getRoadmap as jest.Mock).mockReturnValue(null);
+
+      const res = await request(app).get('/api/learning/roadmaps/nope');
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('ROADMAP_NOT_FOUND');
+    });
+  });
+
+  describe('POST /api/learning/validate', () => {
+    it('runs the step validators and returns the structured response', async () => {
+      const res = await request(app).post('/api/learning/validate').send(validBody);
+
+      expect(res.status).toBe(200);
+      expect(runStepValidators).toHaveBeenCalledWith('project-1', roadmap.steps[0]);
+      expect(res.body).toEqual({
+        roadmapId: 'example-roadmap',
+        stepId: 'step-one',
+        stepPassed: true,
+        results: [passResult],
+        checkedAt: expect.any(String),
+      });
+    });
+
+    it('marks the step as not passed when a validator fails', async () => {
+      (runStepValidators as jest.Mock).mockResolvedValue([failResult]);
+
+      const res = await request(app).post('/api/learning/validate').send(validBody);
+
+      expect(res.status).toBe(200);
+      expect(res.body.stepPassed).toBe(false);
+      expect(res.body.results).toEqual([failResult]);
+    });
+
+    it.each(['projectId', 'roadmapId', 'stepId'])(
+      'returns 400 when "%s" is missing',
+      async (field) => {
+        const body: Record<string, string> = { ...validBody };
+        delete body[field];
+
+        const res = await request(app).post('/api/learning/validate').send(body);
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toContain(`"${field}"`);
+      }
+    );
+
+    it('returns 404 when the project does not exist', async () => {
+      (ProjectService.listProjects as jest.Mock).mockResolvedValue([]);
+
+      const res = await request(app).post('/api/learning/validate').send(validBody);
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('PROJECT_NOT_FOUND');
+    });
+
+    it('returns 404 when the roadmap does not exist', async () => {
+      (RoadmapService.getRoadmap as jest.Mock).mockReturnValue(null);
+
+      const res = await request(app).post('/api/learning/validate').send(validBody);
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('ROADMAP_NOT_FOUND');
+    });
+
+    it('returns 404 when the step does not exist in the roadmap', async () => {
+      const res = await request(app)
+        .post('/api/learning/validate')
+        .send({ ...validBody, stepId: 'nope' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('STEP_NOT_FOUND');
+    });
+
+    it('returns 500 when the engine throws unexpectedly', async () => {
+      (runStepValidators as jest.Mock).mockRejectedValue(new Error('boom'));
+
+      const res = await request(app).post('/api/learning/validate').send(validBody);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: 'boom' });
+    });
+  });
+});

--- a/backend/src/modules/learning/controllers/learningController.ts
+++ b/backend/src/modules/learning/controllers/learningController.ts
@@ -1,0 +1,94 @@
+import { Request, Response } from 'express';
+import { RoadmapService } from '../services/roadmapService';
+import { runStepValidators } from '../engine/engine';
+import { ValidatorResult } from '../engine/types';
+import { ProjectService } from '../../projects/services/projectService';
+
+/** Contract of POST /api/learning/validate — documented in docs/learning-api.md. */
+export interface StepValidationResponse {
+  roadmapId: string;
+  stepId: string;
+  /** true iff every result is 'pass' — an 'error' never validates a step. */
+  stepPassed: boolean;
+  results: ValidatorResult[];
+  checkedAt: string;
+}
+
+export class LearningController {
+  public static async listRoadmaps(req: Request, res: Response): Promise<void> {
+    try {
+      res.json(RoadmapService.listRoadmaps());
+    } catch (err: unknown) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  public static async getRoadmap(req: Request, res: Response): Promise<void> {
+    try {
+      const roadmap = RoadmapService.getRoadmap(req.params.id as string);
+      if (!roadmap) {
+        res.status(404).json({
+          error: `No roadmap found with id "${req.params.id}".`,
+          code: 'ROADMAP_NOT_FOUND',
+        });
+        return;
+      }
+      res.json(roadmap);
+    } catch (err: unknown) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  public static async validate(req: Request, res: Response): Promise<void> {
+    try {
+      const { projectId, roadmapId, stepId } = req.body as Record<string, unknown>;
+      for (const [name, value] of Object.entries({ projectId, roadmapId, stepId })) {
+        if (typeof value !== 'string' || value.length === 0) {
+          res.status(400).json({ error: `"${name}" is required and must be a string` });
+          return;
+        }
+      }
+
+      // Guard against a stale projectId: without it, an empty container list
+      // would produce plausible-looking pedagogical failures on a wrong target.
+      const projects = await ProjectService.listProjects();
+      if (!projects.some(p => p.id === projectId)) {
+        res.status(404).json({
+          error: `No project found with id "${projectId}".`,
+          code: 'PROJECT_NOT_FOUND',
+        });
+        return;
+      }
+
+      const roadmap = RoadmapService.getRoadmap(roadmapId as string);
+      if (!roadmap) {
+        res.status(404).json({
+          error: `No roadmap found with id "${roadmapId}".`,
+          code: 'ROADMAP_NOT_FOUND',
+        });
+        return;
+      }
+
+      const step = roadmap.steps.find(s => s.id === stepId);
+      if (!step) {
+        res.status(404).json({
+          error: `Roadmap "${roadmapId}" has no step with id "${stepId}".`,
+          code: 'STEP_NOT_FOUND',
+        });
+        return;
+      }
+
+      const results = await runStepValidators(projectId as string, step);
+      const response: StepValidationResponse = {
+        roadmapId: roadmap.id,
+        stepId: step.id,
+        stepPassed: results.every(r => r.status === 'pass'),
+        results,
+        checkedAt: new Date().toISOString(),
+      };
+      res.json(response);
+    } catch (err: unknown) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+}

--- a/backend/src/modules/learning/engine/engine.test.ts
+++ b/backend/src/modules/learning/engine/engine.test.ts
@@ -1,0 +1,163 @@
+import { runStepValidators } from './engine';
+import { EngineDeps, InvalidParamsError, ValidatorHandler } from './types';
+import { RoadmapStep } from '../format/roadmapTypes';
+import { ContainerInfo } from '../../../infrastructure/docker/providers/containerProvider';
+
+const runningWeb: ContainerInfo = {
+  id: 'abc123',
+  name: 'web',
+  image: 'ubuntu:22.04',
+  state: 'running',
+  status: 'Up 2 minutes',
+};
+
+function makeStep(validators: RoadmapStep['validators']): RoadmapStep {
+  return { id: 'step-1', title: 'Step 1', instruction: 'Do the thing.', validators };
+}
+
+function makeDeps(impl?: EngineDeps['listContainersByProject']): EngineDeps & {
+  listContainersByProject: jest.Mock;
+} {
+  return { listContainersByProject: jest.fn(impl ?? (() => Promise.resolve([runningWeb]))) };
+}
+
+describe('runStepValidators', () => {
+  it('dispatches each validator by type with its params and keeps roadmap order', async () => {
+    const first = jest.fn<ReturnType<ValidatorHandler>, Parameters<ValidatorHandler>>(
+      async () => ({ status: 'pass', message: 'first ok' })
+    );
+    const second = jest.fn<ReturnType<ValidatorHandler>, Parameters<ValidatorHandler>>(
+      async () => ({ status: 'fail', message: 'second ko', expected: 'a', observed: 'b' })
+    );
+    const step = makeStep([
+      { type: 'first_check', params: { node: 'web' } },
+      { type: 'second_check', params: { node: 'db' } },
+    ]);
+
+    const results = await runStepValidators('project-1', step, makeDeps(), {
+      first_check: first,
+      second_check: second,
+    });
+
+    expect(first).toHaveBeenCalledWith({ node: 'web' }, expect.anything());
+    expect(second).toHaveBeenCalledWith({ node: 'db' }, expect.anything());
+    expect(results).toEqual([
+      { index: 0, type: 'first_check', status: 'pass', message: 'first ok' },
+      {
+        index: 1,
+        type: 'second_check',
+        status: 'fail',
+        message: 'second ko',
+        expected: 'a',
+        observed: 'b',
+      },
+    ]);
+  });
+
+  it('reports an unknown validator type as an error and still runs the others', async () => {
+    const known = jest.fn(async () => ({ status: 'pass' as const, message: 'ok' }));
+    const step = makeStep([
+      { type: 'does_not_exist', params: {} },
+      { type: 'known_check', params: {} },
+    ]);
+
+    const results = await runStepValidators('project-1', step, makeDeps(), {
+      known_check: known,
+    });
+
+    expect(results[0]).toMatchObject({
+      status: 'error',
+      errorCode: 'UNKNOWN_VALIDATOR',
+      message: expect.stringContaining('does_not_exist'),
+    });
+    expect(results[1]).toMatchObject({ status: 'pass', message: 'ok' });
+  });
+
+  it('classifies a Docker daemon failure as an infrastructure error without stopping the others', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const broken: ValidatorHandler = async () => {
+      throw Object.assign(new Error('connect ECONNREFUSED /var/run/docker.sock'), {
+        code: 'ECONNREFUSED',
+      });
+    };
+    const healthy: ValidatorHandler = async () => ({ status: 'pass', message: 'ok' });
+    const step = makeStep([
+      { type: 'broken_check', params: {} },
+      { type: 'healthy_check', params: {} },
+    ]);
+
+    const results = await runStepValidators('project-1', step, makeDeps(), {
+      broken_check: broken,
+      healthy_check: healthy,
+    });
+
+    expect(results[0]).toMatchObject({ status: 'error', errorCode: 'DOCKER_UNAVAILABLE' });
+    expect(results[0].message).toContain('Docker');
+    expect(results[1]).toMatchObject({ status: 'pass' });
+  });
+
+  it('reports InvalidParamsError as a roadmap authoring error', async () => {
+    const picky: ValidatorHandler = async () => {
+      throw new InvalidParamsError('validator param "node" must be a non-empty string');
+    };
+    const step = makeStep([{ type: 'picky_check', params: {} }]);
+
+    const results = await runStepValidators('project-1', step, makeDeps(), {
+      picky_check: picky,
+    });
+
+    expect(results[0]).toMatchObject({
+      status: 'error',
+      errorCode: 'INVALID_PARAMS',
+      message: expect.stringContaining('"node" must be a non-empty string'),
+    });
+  });
+
+  it('fetches the container list once for all validators of the step', async () => {
+    const usesContainers: ValidatorHandler = async (_params, ctx) => {
+      await ctx.getContainers();
+      return { status: 'pass', message: 'ok' };
+    };
+    const deps = makeDeps();
+    const step = makeStep([
+      { type: 'check_a', params: {} },
+      { type: 'check_b', params: {} },
+    ]);
+
+    await runStepValidators('project-1', step, deps, {
+      check_a: usesContainers,
+      check_b: usesContainers,
+    });
+
+    expect(deps.listContainersByProject).toHaveBeenCalledTimes(1);
+    expect(deps.listContainersByProject).toHaveBeenCalledWith('project-1');
+  });
+
+  it('shares a failed container fetch: every Docker-backed validator reports the same error', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const usesContainers: ValidatorHandler = async (_params, ctx) => {
+      await ctx.getContainers();
+      return { status: 'pass', message: 'ok' };
+    };
+    const deps = makeDeps(() =>
+      Promise.reject(
+        Object.assign(new Error('connect ECONNREFUSED /var/run/docker.sock'), {
+          code: 'ECONNREFUSED',
+        })
+      )
+    );
+    const step = makeStep([
+      { type: 'check_a', params: {} },
+      { type: 'check_b', params: {} },
+    ]);
+
+    const results = await runStepValidators('project-1', step, deps, {
+      check_a: usesContainers,
+      check_b: usesContainers,
+    });
+
+    expect(deps.listContainersByProject).toHaveBeenCalledTimes(1);
+    expect(results[0]).toMatchObject({ status: 'error', errorCode: 'DOCKER_UNAVAILABLE' });
+    expect(results[1]).toMatchObject({ status: 'error', errorCode: 'DOCKER_UNAVAILABLE' });
+  });
+});

--- a/backend/src/modules/learning/engine/engine.ts
+++ b/backend/src/modules/learning/engine/engine.ts
@@ -1,0 +1,84 @@
+import { RoadmapStep } from '../format/roadmapTypes';
+import { classifyDockerError } from '../../../infrastructure/docker/dockerErrors';
+import { containerProvider } from '../../../infrastructure/docker/providers/dockerContainerProvider';
+import { ContainerInfo } from '../../../infrastructure/docker/providers/containerProvider';
+import { validatorRegistry } from './registry';
+import {
+  EngineDeps,
+  InvalidParamsError,
+  ValidatorContext,
+  ValidatorHandler,
+  ValidatorResult,
+} from './types';
+
+export const defaultEngineDeps: EngineDeps = {
+  listContainersByProject: (projectId) => containerProvider.listContainersByProject(projectId),
+};
+
+/**
+ * Runs every validator of a step against the real state of the project.
+ *
+ * Validators run sequentially, in roadmap order, and each failure is isolated:
+ * an unknown type, bad params or an infrastructure error (Docker down, ...)
+ * produce an `error` result for that validator and the others still run.
+ * The engine is stateless — it evaluates, it never records.
+ */
+export async function runStepValidators(
+  projectId: string,
+  step: RoadmapStep,
+  deps: EngineDeps = defaultEngineDeps,
+  registry: Readonly<Record<string, ValidatorHandler>> = validatorRegistry
+): Promise<ValidatorResult[]> {
+  // Memoized on the promise: one Docker call per step run, shared by all
+  // validators — including a rejection, so every Docker-backed validator of
+  // the step reports the same infrastructure error from a single attempt.
+  let containersPromise: Promise<ContainerInfo[]> | undefined;
+  const ctx: ValidatorContext = {
+    projectId,
+    getContainers: () => {
+      containersPromise ??= deps.listContainersByProject(projectId);
+      return containersPromise;
+    },
+  };
+
+  const results: ValidatorResult[] = [];
+  for (const [index, validator] of step.validators.entries()) {
+    const handler = registry[validator.type];
+    if (!handler) {
+      results.push({
+        index,
+        type: validator.type,
+        status: 'error',
+        errorCode: 'UNKNOWN_VALIDATOR',
+        message: `Unknown validator type "${validator.type}" — this roadmap may require a newer version of Torollo.`,
+      });
+      continue;
+    }
+
+    try {
+      const outcome = await handler(validator.params, ctx);
+      results.push({ index, type: validator.type, ...outcome });
+    } catch (err: unknown) {
+      if (err instanceof InvalidParamsError) {
+        results.push({
+          index,
+          type: validator.type,
+          status: 'error',
+          errorCode: 'INVALID_PARAMS',
+          message: `This roadmap step is misconfigured: ${err.message}.`,
+        });
+        continue;
+      }
+      const classified = classifyDockerError(err, `running the "${validator.type}" check`);
+      console.error(`[learning] Validator "${validator.type}" failed to run:`, err);
+      results.push({
+        index,
+        type: validator.type,
+        status: 'error',
+        errorCode: classified.code,
+        message: classified.userMessage,
+      });
+    }
+  }
+  return results;
+}

--- a/backend/src/modules/learning/engine/params.ts
+++ b/backend/src/modules/learning/engine/params.ts
@@ -1,0 +1,14 @@
+import { InvalidParamsError } from './types';
+
+/**
+ * Helpers used by validator handlers to check their raw `params` (inert JSON
+ * from the roadmap file). Throwing InvalidParamsError makes the engine report
+ * the validator as an authoring error, not a learner failure.
+ */
+export function requireStringParam(params: Record<string, unknown>, name: string): string {
+  const value = params[name];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new InvalidParamsError(`validator param "${name}" must be a non-empty string`);
+  }
+  return value;
+}

--- a/backend/src/modules/learning/engine/registry.ts
+++ b/backend/src/modules/learning/engine/registry.ts
@@ -1,0 +1,11 @@
+import { ValidatorHandler } from './types';
+import { containerRunning } from './validators/containerRunning';
+
+/**
+ * The single extension point for validator types: adding a type to the
+ * roadmap palette means adding a file under validators/ and one entry here
+ * (see docs/learning-api.md, "Adding a validator type").
+ */
+export const validatorRegistry: Readonly<Record<string, ValidatorHandler>> = {
+  container_running: containerRunning,
+};

--- a/backend/src/modules/learning/engine/types.ts
+++ b/backend/src/modules/learning/engine/types.ts
@@ -1,0 +1,60 @@
+import { ContainerInfo } from '../../../infrastructure/docker/providers/containerProvider';
+import { DockerErrorCode } from '../../../infrastructure/docker/dockerErrors';
+
+export type ValidatorStatus = 'pass' | 'fail' | 'error';
+
+export type ValidatorErrorCode = DockerErrorCode | 'UNKNOWN_VALIDATOR' | 'INVALID_PARAMS';
+
+/**
+ * Result of running one validator of a step, as returned by the API.
+ *
+ * `pass`/`fail` are pedagogical verdicts for the learner; `error` means the
+ * check itself could not run (Docker down, unknown type, bad roadmap params)
+ * and is never the learner's fault.
+ */
+export interface ValidatorResult {
+  /** Position in `step.validators` — stable key for the frontend. */
+  index: number;
+  type: string;
+  status: ValidatorStatus;
+  message: string;
+  /** Present iff `status === 'error'`. */
+  errorCode?: ValidatorErrorCode;
+  /** Short human-readable snapshots, filled when the check can express them. */
+  expected?: string;
+  observed?: string;
+}
+
+/**
+ * Thrown by a handler when the roadmap file's params are unusable for its
+ * type — an authoring bug in the roadmap, not a learner failure.
+ */
+export class InvalidParamsError extends Error {}
+
+/**
+ * What a handler returns. Infrastructure problems are not returned: handlers
+ * just throw and the engine classifies the error.
+ */
+export interface ValidatorOutcome {
+  status: 'pass' | 'fail';
+  message: string;
+  expected?: string;
+  observed?: string;
+}
+
+/** Per-run context shared by every validator of a step. */
+export interface ValidatorContext {
+  projectId: string;
+  /** Lazy and memoized: one Docker call per step run, shared by all validators. */
+  getContainers(): Promise<ContainerInfo[]>;
+}
+
+export type ValidatorHandler = (
+  params: Record<string, unknown>,
+  ctx: ValidatorContext
+) => Promise<ValidatorOutcome>;
+
+/** Everything the engine needs from the outside world (defaults are the real singletons). */
+export interface EngineDeps {
+  listContainersByProject(projectId: string): Promise<ContainerInfo[]>;
+}

--- a/backend/src/modules/learning/engine/validators/containerRunning.test.ts
+++ b/backend/src/modules/learning/engine/validators/containerRunning.test.ts
@@ -1,0 +1,64 @@
+import { containerRunning } from './containerRunning';
+import { InvalidParamsError, ValidatorContext } from '../types';
+import { ContainerInfo } from '../../../../infrastructure/docker/providers/containerProvider';
+
+function makeContainer(overrides: Partial<ContainerInfo>): ContainerInfo {
+  return {
+    id: 'abc123',
+    name: 'web',
+    image: 'ubuntu:22.04',
+    state: 'running',
+    status: 'Up 2 minutes',
+    ...overrides,
+  };
+}
+
+function makeContext(containers: ContainerInfo[]): ValidatorContext {
+  return {
+    projectId: 'project-1',
+    getContainers: () => Promise.resolve(containers),
+  };
+}
+
+describe('containerRunning', () => {
+  it('passes when the named container is running', async () => {
+    const outcome = await containerRunning({ node: 'web' }, makeContext([makeContainer({})]));
+
+    expect(outcome.status).toBe('pass');
+    expect(outcome.message).toContain('"web"');
+  });
+
+  it('fails when no container has the given name', async () => {
+    const outcome = await containerRunning(
+      { node: 'web' },
+      makeContext([makeContainer({ name: 'db' })])
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('No container named "web"');
+    expect(outcome.expected).toBe('a running container named "web"');
+    expect(outcome.observed).toBe('no container with that name');
+  });
+
+  it('fails when the container exists but is not running', async () => {
+    const outcome = await containerRunning(
+      { node: 'web' },
+      makeContext([makeContainer({ state: 'exited' })])
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('not running (current state: exited)');
+    expect(outcome.expected).toBe('running');
+    expect(outcome.observed).toBe('exited');
+  });
+
+  it('throws InvalidParamsError when the "node" param is missing', async () => {
+    await expect(containerRunning({}, makeContext([]))).rejects.toThrow(InvalidParamsError);
+  });
+
+  it('throws InvalidParamsError when the "node" param is not a string', async () => {
+    await expect(containerRunning({ node: 42 }, makeContext([]))).rejects.toThrow(
+      InvalidParamsError
+    );
+  });
+});

--- a/backend/src/modules/learning/engine/validators/containerRunning.ts
+++ b/backend/src/modules/learning/engine/validators/containerRunning.ts
@@ -1,0 +1,37 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam } from '../params';
+
+/**
+ * `container_running` — checks that the container behind a canvas node is
+ * running. Params: `{ node: string }` where `node` is the canvas node name
+ * (the targeting convention of the roadmap format, docs/roadmap-format.md).
+ */
+export const containerRunning: ValidatorHandler = async (params, ctx) => {
+  const node = requireStringParam(params, 'node');
+  const containers = await ctx.getContainers();
+  const container = containers.find(c => c.name === node);
+
+  if (!container) {
+    return {
+      status: 'fail',
+      message:
+        `No container named "${node}" exists in this project yet. ` +
+        `Create the node on the canvas, name it "${node}" and start it.`,
+      expected: `a running container named "${node}"`,
+      observed: 'no container with that name',
+    };
+  }
+
+  if (container.state !== 'running') {
+    return {
+      status: 'fail',
+      message:
+        `The container "${node}" exists but is not running (current state: ${container.state}). ` +
+        `Start it from the canvas.`,
+      expected: 'running',
+      observed: container.state,
+    };
+  }
+
+  return { status: 'pass', message: `The container "${node}" is running.` };
+};

--- a/backend/src/modules/learning/routes/learningRoutes.ts
+++ b/backend/src/modules/learning/routes/learningRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { LearningController } from '../controllers/learningController';
+
+const router = Router();
+
+router.get('/roadmaps', LearningController.listRoadmaps);
+router.get('/roadmaps/:id', LearningController.getRoadmap);
+router.post('/validate', LearningController.validate);
+
+export default router;

--- a/backend/src/modules/learning/services/__fixtures__/roadmaps/invalid-missing-title.json
+++ b/backend/src/modules/learning/services/__fixtures__/roadmaps/invalid-missing-title.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "id": "broken-roadmap",
+  "description": "This roadmap is missing its title and must be skipped by the loader.",
+  "language": "en",
+  "steps": [
+    {
+      "id": "only-step",
+      "title": "Only step",
+      "instruction": "Nothing to do.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "web" }
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/modules/learning/services/__fixtures__/roadmaps/notes.txt
+++ b/backend/src/modules/learning/services/__fixtures__/roadmaps/notes.txt
@@ -1,0 +1,1 @@
+Non-JSON files in the roadmaps directory must be ignored by the loader.

--- a/backend/src/modules/learning/services/__fixtures__/roadmaps/valid.json
+++ b/backend/src/modules/learning/services/__fixtures__/roadmaps/valid.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "id": "fixture-roadmap",
+  "title": "Fixture roadmap",
+  "description": "A minimal valid roadmap used by roadmapService tests.",
+  "language": "en",
+  "estimatedMinutes": 10,
+  "difficulty": "beginner",
+  "steps": [
+    {
+      "id": "start-web",
+      "title": "Start the web server",
+      "instruction": "Create a node named `web` and start it.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "web" }
+        }
+      ]
+    },
+    {
+      "id": "start-db",
+      "title": "Start the database",
+      "instruction": "Create a node named `db` and start it.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "db" }
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/modules/learning/services/roadmapService.test.ts
+++ b/backend/src/modules/learning/services/roadmapService.test.ts
@@ -1,0 +1,60 @@
+import path from 'path';
+import { RoadmapService } from './roadmapService';
+
+const FIXTURES_DIR = path.resolve(__dirname, '__fixtures__/roadmaps');
+
+describe('RoadmapService', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  describe('listRoadmaps', () => {
+    it('lists valid roadmaps with their summary fields', () => {
+      const summaries = RoadmapService.listRoadmaps(FIXTURES_DIR);
+
+      expect(summaries).toEqual([
+        {
+          id: 'fixture-roadmap',
+          title: 'Fixture roadmap',
+          description: 'A minimal valid roadmap used by roadmapService tests.',
+          language: 'en',
+          difficulty: 'beginner',
+          estimatedMinutes: 10,
+          stepCount: 2,
+        },
+      ]);
+    });
+
+    it('skips invalid roadmap files and warns with the file name', () => {
+      RoadmapService.listRoadmaps(FIXTURES_DIR);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid-missing-title.json')
+      );
+    });
+
+    it('returns an empty list when the directory does not exist', () => {
+      expect(RoadmapService.listRoadmaps(path.join(FIXTURES_DIR, 'nope'))).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+    });
+  });
+
+  describe('getRoadmap', () => {
+    it('returns the full roadmap for a known id', () => {
+      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', FIXTURES_DIR);
+
+      expect(roadmap).not.toBeNull();
+      expect(roadmap?.steps.map(s => s.id)).toEqual(['start-web', 'start-db']);
+    });
+
+    it('returns null for an unknown id', () => {
+      expect(RoadmapService.getRoadmap('does-not-exist', FIXTURES_DIR)).toBeNull();
+    });
+
+    it('never serves a roadmap from an invalid file', () => {
+      expect(RoadmapService.getRoadmap('broken-roadmap', FIXTURES_DIR)).toBeNull();
+    });
+  });
+});

--- a/backend/src/modules/learning/services/roadmapService.ts
+++ b/backend/src/modules/learning/services/roadmapService.ts
@@ -1,0 +1,73 @@
+import fs from 'fs';
+import path from 'path';
+import { Roadmap, RoadmapDifficulty } from '../format/roadmapTypes';
+import { validateRoadmap } from '../format/validateRoadmap';
+
+/** What the roadmap catalogue exposes to the frontend (GET /api/learning/roadmaps). */
+export interface RoadmapSummary {
+  id: string;
+  title: string;
+  description: string;
+  language: string;
+  difficulty?: RoadmapDifficulty;
+  estimatedMinutes?: number;
+  stepCount: number;
+}
+
+// Resolved from this file, never from process.cwd(): the CLI spawns the server
+// without a cwd, and dist/ mirrors src/ so the same hops work in dev and prod.
+// services/ → learning → modules → src|dist → backend → repo root.
+const ROADMAPS_DIR = path.resolve(__dirname, '../../../../../roadmaps');
+
+/**
+ * Loads roadmap files (format v1) from the roadmaps/ directory.
+ *
+ * Files are re-read on every call — they are a few kB, requested at human
+ * frequency, and this gives roadmap authors hot reload for free. A file that
+ * is not valid JSON or does not pass the format schema is logged and skipped,
+ * never served. The optional `dir` parameter exists for tests only.
+ */
+export class RoadmapService {
+  public static listRoadmaps(dir: string = ROADMAPS_DIR): RoadmapSummary[] {
+    return this.readAll(dir).map(roadmap => ({
+      id: roadmap.id,
+      title: roadmap.title,
+      description: roadmap.description,
+      language: roadmap.language,
+      difficulty: roadmap.difficulty,
+      estimatedMinutes: roadmap.estimatedMinutes,
+      stepCount: roadmap.steps.length,
+    }));
+  }
+
+  public static getRoadmap(id: string, dir: string = ROADMAPS_DIR): Roadmap | null {
+    return this.readAll(dir).find(roadmap => roadmap.id === id) ?? null;
+  }
+
+  private static readAll(dir: string): Roadmap[] {
+    if (!fs.existsSync(dir)) {
+      console.warn(`[learning] Roadmaps directory not found: ${dir}`);
+      return [];
+    }
+
+    const roadmaps: Roadmap[] = [];
+    for (const file of fs.readdirSync(dir)) {
+      if (!file.endsWith('.json')) {
+        continue;
+      }
+      try {
+        const data: unknown = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8'));
+        const result = validateRoadmap(data);
+        if (!result.valid) {
+          console.warn(`[learning] Skipping invalid roadmap file ${file}: ${result.errors.join('; ')}`);
+          continue;
+        }
+        roadmaps.push(result.roadmap);
+      } catch (err: unknown) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`[learning] Skipping invalid roadmap file ${file}: ${reason}`);
+      }
+    }
+    return roadmaps;
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import { ENV } from './config/env';
 import projectRouter from './modules/projects/routes/projectRoutes';
 import containerRouter from './modules/containers/routes/containerRoutes';
 import healthRouter from './modules/health/routes/healthRoutes';
+import learningRouter from './modules/learning/routes/learningRoutes';
 import { TerminalGateway } from './modules/terminal/gateway/terminalGateway';
 import { DockerInitializer } from './infrastructure/docker/DockerInitializer';
 
@@ -24,6 +25,7 @@ app.use('/health', healthRouter);
 // Scoped APIs
 app.use('/api/projects', projectRouter);
 app.use('/api/projects/:projectId/containers', containerRouter);
+app.use('/api/learning', learningRouter);
 
 // Socket.IO Setup
 const io = new Server(server, {

--- a/docs/learning-api.md
+++ b/docs/learning-api.md
@@ -1,0 +1,148 @@
+# The learning API (validation engine)
+
+The learning module is the auto-corrector behind guided roadmaps: it runs the declarative validators of a roadmap step against the **real** state of your project (Docker containers, databases, network topology) and returns one structured result per validator.
+
+This document is the contract for API consumers (the roadmap player in the frontend). If you are writing roadmap *content*, read [`roadmap-format.md`](./roadmap-format.md) instead.
+
+- Backend module: `backend/src/modules/learning/`
+- Roadmap files are loaded from the `roadmaps/` directory at the repository root (shipped in the published npm package). Files that fail the format schema are logged on the server and excluded — they are never served.
+
+## Endpoints
+
+### `GET /api/learning/roadmaps`
+
+Lists the available roadmaps as summaries.
+
+```json
+[
+  {
+    "id": "example-first-architecture",
+    "title": "Your first architecture: a web server and its database",
+    "description": "Build a minimal two-tier architecture…",
+    "language": "en",
+    "difficulty": "beginner",
+    "estimatedMinutes": 30,
+    "stepCount": 4
+  }
+]
+```
+
+### `GET /api/learning/roadmaps/:id`
+
+Returns the full roadmap file (format v1, see [`roadmap-format.md`](./roadmap-format.md)) — steps, instructions, hints, solutions, validators.
+
+- `404 { "error": "...", "code": "ROADMAP_NOT_FOUND" }` if no valid roadmap has this id.
+
+### `POST /api/learning/validate`
+
+Runs every validator of one step against the real state of one project. The engine is **stateless**: it evaluates, it never records progression.
+
+Request body:
+
+```json
+{
+  "projectId": "project-1751883322290",
+  "roadmapId": "example-first-architecture",
+  "stepId": "create-web-server"
+}
+```
+
+`stepId` is the step's stable slug id, never its position — step ids are unique within a roadmap, which is why `roadmapId` is also required.
+
+Error responses (request problems only, see [status semantics](#http-status-semantics)):
+
+- `400 { "error": "\"stepId\" is required and must be a string" }` — missing or non-string field.
+- `404 { "error": "...", "code": "PROJECT_NOT_FOUND" | "ROADMAP_NOT_FOUND" | "STEP_NOT_FOUND" }`.
+- `500 { "error": "..." }` — unexpected server crash.
+
+Success response (`200`):
+
+```json
+{
+  "roadmapId": "example-first-architecture",
+  "stepId": "create-web-server",
+  "stepPassed": false,
+  "checkedAt": "2026-07-14T14:03:21.402Z",
+  "results": [
+    {
+      "index": 0,
+      "type": "container_running",
+      "status": "fail",
+      "message": "No container named \"web\" exists in this project yet. Create the node on the canvas, name it \"web\" and start it.",
+      "expected": "a running container named \"web\"",
+      "observed": "no container with that name"
+    }
+  ]
+}
+```
+
+- `results` is in the same order as `step.validators`; `index` is the validator's position there — use it as the stable key.
+- `stepPassed` is `true` iff **every** result has `status: "pass"`. An `error` result never validates a step (⚠ is not ✓).
+- `expected` / `observed` are short human-readable snapshots, present when the check can express them.
+
+## Result semantics: `pass` / `fail` / `error`
+
+| `status` | Meaning | Suggested UI |
+|---|---|---|
+| `pass` | The check succeeded. | ✓ |
+| `fail` | **Pedagogical failure** — the learner has not completed this part yet. `message` explains what was observed vs expected. This is a normal, frequent state, not an error. | ✗ |
+| `error` | **The check itself could not run.** Never the learner's fault, and the UI must not let them believe it is. `errorCode` is set. | ⚠ |
+
+`errorCode` values (present iff `status === "error"`):
+
+| `errorCode` | Meaning |
+|---|---|
+| `DOCKER_UNAVAILABLE` | The Docker daemon is unreachable (503-class infrastructure problem). |
+| `CONTAINER_NOT_FOUND`, `IMAGE_NOT_FOUND`, `PORT_IN_USE`, `NAME_CONFLICT`, `DOCKER_ERROR` | Other Docker-level failures, same taxonomy as the container API (`dockerErrors.ts`). |
+| `UNKNOWN_VALIDATOR` | The validator `type` is not implemented by this Torollo version (e.g. a newer community roadmap). |
+| `INVALID_PARAMS` | The roadmap file's `params` are unusable for this type — an authoring bug in the roadmap. |
+
+Two policies worth spelling out:
+
+- **A broken validator never blocks the others.** An unknown type, bad params or a Docker failure produce an `error` result for that validator and the remaining validators of the step still run.
+- **Infrastructure failures are `200`, not `5xx`.** The product of this endpoint *is* the per-validator report: if Docker is down, you still get one result per validator (each Docker-backed check reports `DOCKER_UNAVAILABLE`), and validators that don't need Docker still return their verdict. Do **not** treat `5xx` as a nominal case in the player — `4xx`/`5xx` mean the *request* was wrong or the server crashed, never "the learner hasn't finished".
+
+## HTTP status semantics
+
+- `200` — the evaluation ran; read `results`.
+- `400` / `404` — the request itself is wrong (missing field, unknown project/roadmap/step).
+- `500` — unexpected server error.
+
+## Try it with curl
+
+With the backend running (`cd backend && npm run dev`) and Docker started:
+
+```bash
+# 1. Create a project and note its id
+curl -s -X POST localhost:23233/api/projects -H 'Content-Type: application/json' \
+  -d '{"name": "learning-demo"}'
+
+# 2. Validate step 1 before doing anything → "fail" with a pedagogical message
+curl -s -X POST localhost:23233/api/learning/validate -H 'Content-Type: application/json' \
+  -d '{"projectId": "<id>", "roadmapId": "example-first-architecture", "stepId": "create-web-server"}'
+
+# 3. Create and start the "web" node, as the step instructs
+curl -s -X POST 'localhost:23233/api/projects/<id>/containers' -H 'Content-Type: application/json' \
+  -d '{"name": "web", "type": "ubuntu"}'
+
+# 4. Re-validate → "pass", stepPassed: true
+curl -s -X POST localhost:23233/api/learning/validate -H 'Content-Type: application/json' \
+  -d '{"projectId": "<id>", "roadmapId": "example-first-architecture", "stepId": "create-web-server"}'
+
+# 5. Stop the Docker daemon and re-validate → 200 with status "error", errorCode "DOCKER_UNAVAILABLE"
+```
+
+## Adding a validator type
+
+The engine dispatches on `validator.type` through a single extension point. To add a type:
+
+1. Create `backend/src/modules/learning/engine/validators/<yourType>.ts` exporting a `ValidatorHandler`: it receives the raw `params` (validate them with the helpers in `engine/params.ts` — throw `InvalidParamsError` on bad shapes) and a `ValidatorContext` (project id + memoized access to the project's containers). Return `{ status: 'pass' | 'fail', message, expected?, observed? }`; on infrastructure problems just let the error propagate — the engine classifies it.
+2. Register it: one line in `engine/registry.ts`.
+3. Add pass/fail/degraded unit tests next to it (see `containerRunning.test.ts`).
+4. Document its `params` in the validator table of [`roadmap-format.md`](./roadmap-format.md). New types are **not** format changes — no `schemaVersion` bump.
+
+Failure messages are half the product: always say what was observed and what was expected, in plain human language, never a raw Docker id.
+
+## Known limitation: message language
+
+Engine messages (`message`, `expected`, `observed`) are produced in **English**, regardless of the roadmap's `language` field. A French roadmap currently gets English correction messages. This is a known v1 limitation, to be revisited with the full validator palette (V-3) — options include message keys translated by the frontend.

--- a/docs/roadmap-format.md
+++ b/docs/roadmap-format.md
@@ -6,6 +6,7 @@ This document is the reference for authoring roadmap files. You should be able t
 
 - JSON Schema: [`backend/src/modules/learning/format/roadmap.schema.json`](../backend/src/modules/learning/format/roadmap.schema.json)
 - Reference example: [`roadmaps/example-first-architecture.json`](../roadmaps/example-first-architecture.json)
+- API that loads and runs roadmaps: [`learning-api.md`](./learning-api.md)
 
 ## Philosophy
 
@@ -117,4 +118,4 @@ A translation is a **separate file with the same `id` and a different `language`
 - **Newer players keep reading older files:** a Torollo that understands v2 must still read every valid v1 roadmap.
 - **New validator `type` values are *not* format changes.** The palette can grow within v1; an engine that meets a type it doesn't implement reports it as unknown at run time.
 
-> Note: the `roadmaps/` directory is reference content in the repository; it is not yet shipped inside the published npm package. How roadmap content is distributed is decided with the roadmap loader (V-2/R-1), not by the format.
+> Note: the `roadmaps/` directory at the repository root is where the engine loads roadmaps from, and it is shipped inside the published npm package. See [`learning-api.md`](./learning-api.md) for how roadmaps are listed and validated at run time.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "backend/package.json",
     "backend/projects.json",
     "frontend/dist/**/*",
-    "frontend/package.json"
+    "frontend/package.json",
+    "roadmaps/**/*"
   ]
 }


### PR DESCRIPTION
## Summary of Changes

The execution side of the roadmap format introduced in #54: a stateless engine that runs a step's declarative validators against the real state of a project's containers, so a learner's work can be auto-checked. Until now, roadmap files declared validators but nothing executed them.

New endpoints:

- `GET /api/learning/roadmaps` — catalogue of the valid roadmap files in `roadmaps/` (invalid files are logged server-side and never served)
- `GET /api/learning/roadmaps/:id` — full roadmap
- `POST /api/learning/validate` — `{projectId, roadmapId, stepId}` → one structured result per validator (`pass` / `fail` / `error` + message + optional `expected`/`observed`) and an aggregated `stepPassed`

Design notes:

- **Pedagogical failure vs infrastructure error are distinct.** `fail` means the learner hasn't completed the step yet; `error` means the check itself couldn't run (Docker daemon down, unknown validator type, bad params in the roadmap file) and carries an `errorCode` reusing the existing `dockerErrors` taxonomy. Infrastructure failures answer `200` with per-validator `error` results — `4xx`/`5xx` are reserved for request problems.
- **A broken validator never blocks the others**: each validator of a step is isolated, so an unknown type (e.g. a roadmap written for a newer Torollo) still lets the remaining checks report.
- **One extension point.** Adding a validator type = one file under `engine/validators/` + one line in `engine/registry.ts` (recipe in `docs/learning-api.md`). This PR ships the first one, `container_running`; the rest of the v1 palette comes next.
- **Nothing from a roadmap file is ever executed** — `params` are inert JSON interpreted by code in this repo.
- The container list is fetched lazily and memoized per run (one Docker call per step), and roadmap files are re-read per request, resolved from `__dirname` (the CLI spawns the server without a cwd). `roadmaps/` is now shipped in the published npm package so the catalogue isn't empty in production.

Full contract, semantics and a curl walkthrough: `docs/learning-api.md`.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

Ran the full loop against real containers with the backend in dev mode and Docker running:

1. Created a project, then `POST /api/learning/validate` on the example roadmap's first step before creating anything → `status: "fail"` with an actionable message ("No container named \"web\" exists in this project yet…").
2. Created and started the `web` node via the containers API, re-validated → `status: "pass"`, `stepPassed: true`.
3. Stopped the container, re-validated → `fail` with `observed: "exited"`.
4. Validated a step mixing an implemented and a not-yet-implemented validator type → the unknown type reports `error`/`UNKNOWN_VALIDATOR` while the other validator still returns its verdict.
5. Checked the request-error paths: unknown project/roadmap/step → typed `404`s, missing body field → `400`.
6. `GET /api/learning/roadmaps` lists the example roadmap with `stepCount: 4`.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing