### PR TITLE
feat(learning): the 8 base validators for the roadmap engine

### DIFF
--- a/backend/src/modules/learning/engine/engine.test.ts
+++ b/backend/src/modules/learning/engine/engine.test.ts
@@ -18,7 +18,13 @@ function makeStep(validators: RoadmapStep['validators']): RoadmapStep {
 function makeDeps(impl?: EngineDeps['listContainersByProject']): EngineDeps & {
   listContainersByProject: jest.Mock;
 } {
-  return { listContainersByProject: jest.fn(impl ?? (() => Promise.resolve([runningWeb]))) };
+  return {
+    listContainersByProject: jest.fn(impl ?? (() => Promise.resolve([runningWeb]))),
+    getNetworkConfig: () => Promise.resolve(null),
+    executePsqlCommand: () => Promise.resolve(''),
+    executeRedisCommand: () => Promise.resolve(''),
+    executeMongoCommand: () => Promise.resolve(''),
+  };
 }
 
 describe('runStepValidators', () => {

--- a/backend/src/modules/learning/engine/engine.ts
+++ b/backend/src/modules/learning/engine/engine.ts
@@ -2,17 +2,27 @@ import { RoadmapStep } from '../format/roadmapTypes';
 import { classifyDockerError } from '../../../infrastructure/docker/dockerErrors';
 import { containerProvider } from '../../../infrastructure/docker/providers/dockerContainerProvider';
 import { ContainerInfo } from '../../../infrastructure/docker/providers/containerProvider';
+import { ProjectService } from '../../projects/services/projectService';
+import { NetworkService } from '../../network/services/networkService';
+import { SemanticRule } from '../../network/models/networkPolicy';
 import { validatorRegistry } from './registry';
 import {
   EngineDeps,
   InvalidParamsError,
   ValidatorContext,
   ValidatorHandler,
+  ValidatorNetworkConfig,
   ValidatorResult,
 } from './types';
 
 export const defaultEngineDeps: EngineDeps = {
   listContainersByProject: (projectId) => containerProvider.listContainersByProject(projectId),
+  getNetworkConfig: (projectId) => ProjectService.getNetworkConfig(projectId),
+  executePsqlCommand: (containerId, database, sqlQuery, extraArgs) =>
+    containerProvider.executePsqlCommand(containerId, database, sqlQuery, extraArgs),
+  executeRedisCommand: (containerId, args) => containerProvider.executeRedisCommand(containerId, args),
+  executeMongoCommand: (containerId, evalExpression) =>
+    containerProvider.executeMongoCommand(containerId, evalExpression),
 };
 
 /**
@@ -29,16 +39,34 @@ export async function runStepValidators(
   deps: EngineDeps = defaultEngineDeps,
   registry: Readonly<Record<string, ValidatorHandler>> = validatorRegistry
 ): Promise<ValidatorResult[]> {
-  // Memoized on the promise: one Docker call per step run, shared by all
-  // validators — including a rejection, so every Docker-backed validator of
-  // the step reports the same infrastructure error from a single attempt.
+  // Memoized on the promise: one Docker/config call per step run, shared by
+  // all validators — including a rejection, so every backed validator of the
+  // step reports the same infrastructure error from a single attempt.
   let containersPromise: Promise<ContainerInfo[]> | undefined;
+  let networkConfigPromise: Promise<ValidatorNetworkConfig | null> | undefined;
+  let semanticRulesPromise: Promise<SemanticRule[]> | undefined;
   const ctx: ValidatorContext = {
     projectId,
     getContainers: () => {
       containersPromise ??= deps.listContainersByProject(projectId);
       return containersPromise;
     },
+    getNetworkConfig: () => {
+      networkConfigPromise ??= deps.getNetworkConfig(projectId);
+      return networkConfigPromise;
+    },
+    getSemanticRules: () => {
+      networkConfigPromise ??= deps.getNetworkConfig(projectId);
+      semanticRulesPromise ??= networkConfigPromise.then((config) =>
+        config ? NetworkService.computeSemanticRules(projectId, config) : []
+      );
+      return semanticRulesPromise;
+    },
+    executePsqlCommand: (containerId, database, sqlQuery, extraArgs) =>
+      deps.executePsqlCommand(containerId, database, sqlQuery, extraArgs),
+    executeRedisCommand: (containerId, args) => deps.executeRedisCommand(containerId, args),
+    executeMongoCommand: (containerId, evalExpression) =>
+      deps.executeMongoCommand(containerId, evalExpression),
   };
 
   const results: ValidatorResult[] = [];

--- a/backend/src/modules/learning/engine/params.ts
+++ b/backend/src/modules/learning/engine/params.ts
@@ -12,3 +12,36 @@ export function requireStringParam(params: Record<string, unknown>, name: string
   }
   return value;
 }
+
+export function requireNumberParam(params: Record<string, unknown>, name: string): number {
+  const value = params[name];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new InvalidParamsError(`validator param "${name}" must be a number`);
+  }
+  return value;
+}
+
+export function optionalStringParam(
+  params: Record<string, unknown>,
+  name: string,
+  fallback: string
+): string {
+  const value = params[name];
+  if (value === undefined) return fallback;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new InvalidParamsError(`validator param "${name}" must be a non-empty string when present`);
+  }
+  return value;
+}
+
+export function optionalNumberParam(
+  params: Record<string, unknown>,
+  name: string
+): number | undefined {
+  const value = params[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new InvalidParamsError(`validator param "${name}" must be a number when present`);
+  }
+  return value;
+}

--- a/backend/src/modules/learning/engine/registry.ts
+++ b/backend/src/modules/learning/engine/registry.ts
@@ -1,5 +1,12 @@
 import { ValidatorHandler } from './types';
 import { containerRunning } from './validators/containerRunning';
+import { tableExists } from './validators/tableExists';
+import { redisKeyExists } from './validators/redisKeyExists';
+import { mongoCollectionExists } from './validators/mongoCollectionExists';
+import { edgeExists } from './validators/edgeExists';
+import { lbUpstreams } from './validators/lbUpstreams';
+import { portDenied } from './validators/portDenied';
+import { asgReplicas } from './validators/asgReplicas';
 
 /**
  * The single extension point for validator types: adding a type to the
@@ -8,4 +15,11 @@ import { containerRunning } from './validators/containerRunning';
  */
 export const validatorRegistry: Readonly<Record<string, ValidatorHandler>> = {
   container_running: containerRunning,
+  table_exists: tableExists,
+  redis_key_exists: redisKeyExists,
+  mongo_collection_exists: mongoCollectionExists,
+  edge_exists: edgeExists,
+  lb_upstreams: lbUpstreams,
+  port_denied: portDenied,
+  asg_replicas: asgReplicas,
 };

--- a/backend/src/modules/learning/engine/types.ts
+++ b/backend/src/modules/learning/engine/types.ts
@@ -1,5 +1,6 @@
 import { ContainerInfo } from '../../../infrastructure/docker/providers/containerProvider';
 import { DockerErrorCode } from '../../../infrastructure/docker/dockerErrors';
+import { SemanticRule } from '../../network/models/networkPolicy';
 
 export type ValidatorStatus = 'pass' | 'fail' | 'error';
 
@@ -42,11 +43,37 @@ export interface ValidatorOutcome {
   observed?: string;
 }
 
+/**
+ * Local view of a project's network config — only the fields validators read.
+ * The canonical shape lives in the frontend package (`shared/types/network.ts`);
+ * the backend never imports it (package boundary), so this mirrors just the
+ * subset needed here. `ProjectService.getNetworkConfig` remains untyped at
+ * its own boundary — this interface is where the engine starts trusting it.
+ */
+export interface ValidatorNetworkConfig {
+  nodeSubnetMap?: Record<string, string>;
+  nodeSecurityGroups?: Record<string, unknown[]>;
+  loadBalancerTargets?: Record<string, string[]>;
+  asgs?: Record<string, { parentId: string }>;
+}
+
 /** Per-run context shared by every validator of a step. */
 export interface ValidatorContext {
   projectId: string;
   /** Lazy and memoized: one Docker call per step run, shared by all validators. */
   getContainers(): Promise<ContainerInfo[]>;
+  /** Lazy and memoized: one project read per step run, shared by all validators. */
+  getNetworkConfig(): Promise<ValidatorNetworkConfig | null>;
+  /** Lazy and memoized: the security-group rules expanded to real container ids. */
+  getSemanticRules(): Promise<SemanticRule[]>;
+  executePsqlCommand(
+    containerId: string,
+    database: string,
+    sqlQuery: string,
+    extraArgs?: string[]
+  ): Promise<string>;
+  executeRedisCommand(containerId: string, args: string[]): Promise<string>;
+  executeMongoCommand(containerId: string, evalExpression: string): Promise<string>;
 }
 
 export type ValidatorHandler = (
@@ -57,4 +84,13 @@ export type ValidatorHandler = (
 /** Everything the engine needs from the outside world (defaults are the real singletons). */
 export interface EngineDeps {
   listContainersByProject(projectId: string): Promise<ContainerInfo[]>;
+  getNetworkConfig(projectId: string): Promise<ValidatorNetworkConfig | null>;
+  executePsqlCommand(
+    containerId: string,
+    database: string,
+    sqlQuery: string,
+    extraArgs?: string[]
+  ): Promise<string>;
+  executeRedisCommand(containerId: string, args: string[]): Promise<string>;
+  executeMongoCommand(containerId: string, evalExpression: string): Promise<string>;
 }

--- a/backend/src/modules/learning/engine/validators/asgReplicas.test.ts
+++ b/backend/src/modules/learning/engine/validators/asgReplicas.test.ts
@@ -1,0 +1,52 @@
+import { asgReplicas } from './asgReplicas';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext } from './testSupport';
+
+const asg = makeContainer({ id: 'asg-1', name: 'web-fleet', type: 'autoscalinggroup' });
+
+function makeReplica(id: string, state = 'running') {
+  return makeContainer({ id, name: id, asgId: 'asg-1', isAsgInstance: true, state });
+}
+
+describe('asgReplicas', () => {
+  it('passes when the running replica count matches exactly', async () => {
+    const outcome = await asgReplicas(
+      { node: 'web-fleet', count: 2 },
+      makeContext({ containers: [asg, makeReplica('r1'), makeReplica('r2')] })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when there are fewer running replicas than expected', async () => {
+    const outcome = await asgReplicas(
+      { node: 'web-fleet', count: 2 },
+      makeContext({ containers: [asg, makeReplica('r1')] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('1 replica(s)');
+  });
+
+  it('does not count stopped replicas', async () => {
+    const outcome = await asgReplicas(
+      { node: 'web-fleet', count: 1 },
+      makeContext({ containers: [asg, makeReplica('r1'), makeReplica('r2', 'exited')] })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when the ASG node does not exist', async () => {
+    const outcome = await asgReplicas({ node: 'web-fleet', count: 1 }, makeContext({ containers: [] }));
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('no container with that name');
+  });
+
+  it('throws InvalidParamsError when "count" is missing', async () => {
+    await expect(asgReplicas({ node: 'web-fleet' }, makeContext())).rejects.toThrow(
+      InvalidParamsError
+    );
+  });
+});

--- a/backend/src/modules/learning/engine/validators/asgReplicas.ts
+++ b/backend/src/modules/learning/engine/validators/asgReplicas.ts
@@ -1,0 +1,38 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam, requireNumberParam } from '../params';
+import { countRunningAsgReplicas } from './shared';
+
+/**
+ * `asg_replicas` — checks that an auto-scaling group node runs exactly
+ * `count` instances. Params: `{ node: string, count: number }`
+ * (docs/roadmap-format.md). Only the replica count matters — the ASG's own
+ * boundary container doesn't need to be running itself.
+ */
+export const asgReplicas: ValidatorHandler = async (params, ctx) => {
+  const node = requireStringParam(params, 'node');
+  const count = requireNumberParam(params, 'count');
+
+  const containers = await ctx.getContainers();
+  const asgContainer = containers.find((c) => c.name === node);
+  if (!asgContainer) {
+    return {
+      status: 'fail',
+      message: `No auto-scaling group named "${node}" exists in this project yet. Create it on the canvas first.`,
+      expected: `an auto-scaling group named "${node}"`,
+      observed: 'no container with that name',
+    };
+  }
+
+  const runningReplicas = countRunningAsgReplicas(containers, asgContainer.id);
+
+  if (runningReplicas !== count) {
+    return {
+      status: 'fail',
+      message: `The auto-scaling group "${node}" runs ${runningReplicas} replica(s), but this step expects exactly ${count}. Scale it from the canvas.`,
+      expected: `exactly ${count} replica(s)`,
+      observed: `${runningReplicas} replica(s)`,
+    };
+  }
+
+  return { status: 'pass', message: `The auto-scaling group "${node}" runs exactly ${count} replica(s).` };
+};

--- a/backend/src/modules/learning/engine/validators/containerRunning.test.ts
+++ b/backend/src/modules/learning/engine/validators/containerRunning.test.ts
@@ -1,28 +1,13 @@
 import { containerRunning } from './containerRunning';
-import { InvalidParamsError, ValidatorContext } from '../types';
-import { ContainerInfo } from '../../../../infrastructure/docker/providers/containerProvider';
-
-function makeContainer(overrides: Partial<ContainerInfo>): ContainerInfo {
-  return {
-    id: 'abc123',
-    name: 'web',
-    image: 'ubuntu:22.04',
-    state: 'running',
-    status: 'Up 2 minutes',
-    ...overrides,
-  };
-}
-
-function makeContext(containers: ContainerInfo[]): ValidatorContext {
-  return {
-    projectId: 'project-1',
-    getContainers: () => Promise.resolve(containers),
-  };
-}
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext } from './testSupport';
 
 describe('containerRunning', () => {
   it('passes when the named container is running', async () => {
-    const outcome = await containerRunning({ node: 'web' }, makeContext([makeContainer({})]));
+    const outcome = await containerRunning(
+      { node: 'web' },
+      makeContext({ containers: [makeContainer({ name: 'web' })] })
+    );
 
     expect(outcome.status).toBe('pass');
     expect(outcome.message).toContain('"web"');
@@ -31,7 +16,7 @@ describe('containerRunning', () => {
   it('fails when no container has the given name', async () => {
     const outcome = await containerRunning(
       { node: 'web' },
-      makeContext([makeContainer({ name: 'db' })])
+      makeContext({ containers: [makeContainer({ name: 'db' })] })
     );
 
     expect(outcome.status).toBe('fail');
@@ -43,7 +28,7 @@ describe('containerRunning', () => {
   it('fails when the container exists but is not running', async () => {
     const outcome = await containerRunning(
       { node: 'web' },
-      makeContext([makeContainer({ state: 'exited' })])
+      makeContext({ containers: [makeContainer({ name: 'web', state: 'exited' })] })
     );
 
     expect(outcome.status).toBe('fail');
@@ -53,11 +38,11 @@ describe('containerRunning', () => {
   });
 
   it('throws InvalidParamsError when the "node" param is missing', async () => {
-    await expect(containerRunning({}, makeContext([]))).rejects.toThrow(InvalidParamsError);
+    await expect(containerRunning({}, makeContext())).rejects.toThrow(InvalidParamsError);
   });
 
   it('throws InvalidParamsError when the "node" param is not a string', async () => {
-    await expect(containerRunning({ node: 42 }, makeContext([]))).rejects.toThrow(
+    await expect(containerRunning({ node: 42 }, makeContext())).rejects.toThrow(
       InvalidParamsError
     );
   });

--- a/backend/src/modules/learning/engine/validators/edgeExists.test.ts
+++ b/backend/src/modules/learning/engine/validators/edgeExists.test.ts
@@ -1,0 +1,74 @@
+import { edgeExists } from './edgeExists';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext, makeSemanticRule } from './testSupport';
+
+const web = makeContainer({ id: 'web-1', name: 'web' });
+const db = makeContainer({ id: 'db-1', name: 'db' });
+
+describe('edgeExists', () => {
+  it('passes when an ALLOW rule matches source and target on any port', async () => {
+    const outcome = await edgeExists(
+      { source: 'web', target: 'db' },
+      makeContext({
+        containers: [web, db],
+        semanticRules: [makeSemanticRule({ sourceNodeId: 'web-1', targetNodeId: 'db-1' })],
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('passes when the ALLOW rule matches the requested port', async () => {
+    const outcome = await edgeExists(
+      { source: 'web', target: 'db', port: 5432 },
+      makeContext({
+        containers: [web, db],
+        semanticRules: [
+          makeSemanticRule({ sourceNodeId: 'web-1', targetNodeId: 'db-1', port: '5432' }),
+        ],
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when the ALLOW rule is for a different port', async () => {
+    const outcome = await edgeExists(
+      { source: 'web', target: 'db', port: 5432 },
+      makeContext({
+        containers: [web, db],
+        semanticRules: [
+          makeSemanticRule({ sourceNodeId: 'web-1', targetNodeId: 'db-1', port: '80' }),
+        ],
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('no matching rule');
+  });
+
+  it('fails when no rule matches source and target at all', async () => {
+    const outcome = await edgeExists(
+      { source: 'web', target: 'db' },
+      makeContext({ containers: [web, db], semanticRules: [] })
+    );
+
+    expect(outcome.status).toBe('fail');
+  });
+
+  it('fails when the source node does not exist', async () => {
+    const outcome = await edgeExists(
+      { source: 'web', target: 'db' },
+      makeContext({ containers: [db] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('"web" does not exist');
+  });
+
+  it('throws InvalidParamsError when "target" is missing', async () => {
+    await expect(edgeExists({ source: 'web' }, makeContext())).rejects.toThrow(
+      InvalidParamsError
+    );
+  });
+});

--- a/backend/src/modules/learning/engine/validators/edgeExists.ts
+++ b/backend/src/modules/learning/engine/validators/edgeExists.ts
@@ -1,0 +1,41 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam, optionalNumberParam } from '../params';
+import { resolveSourceAndTarget } from './shared';
+
+/**
+ * `edge_exists` — checks that an allowed connection exists from `source` to
+ * `target` (omit `port` to accept any port). Params: `{ source: string,
+ * target: string, port?: number }` (docs/roadmap-format.md). Connectivity is
+ * about security-group configuration, not container liveness, so — unlike
+ * `container_running` — a stopped node still counts as long as it exists.
+ */
+export const edgeExists: ValidatorHandler = async (params, ctx) => {
+  const source = requireStringParam(params, 'source');
+  const target = requireStringParam(params, 'target');
+  const port = optionalNumberParam(params, 'port');
+
+  const containers = await ctx.getContainers();
+  const resolved = resolveSourceAndTarget(containers, source, target);
+  if ('outcome' in resolved) return resolved.outcome;
+
+  const rules = await ctx.getSemanticRules();
+  const allowed = rules.some(
+    (rule) =>
+      rule.action === 'ALLOW' &&
+      rule.sourceNodeId === resolved.sourceContainer.id &&
+      rule.targetNodeId === resolved.targetContainer.id &&
+      (port === undefined || rule.port === 'ALL' || rule.port === String(port))
+  );
+
+  const portLabel = port === undefined ? '' : ` on port ${port}`;
+  if (!allowed) {
+    return {
+      status: 'fail',
+      message: `There is no allowed connection from "${source}" to "${target}"${portLabel} yet. Add a security group rule allowing it.`,
+      expected: `an allowed connection from "${source}" to "${target}"${portLabel}`,
+      observed: 'no matching rule',
+    };
+  }
+
+  return { status: 'pass', message: `"${source}" can reach "${target}"${portLabel}.` };
+};

--- a/backend/src/modules/learning/engine/validators/lbUpstreams.test.ts
+++ b/backend/src/modules/learning/engine/validators/lbUpstreams.test.ts
@@ -1,0 +1,74 @@
+import { lbUpstreams } from './lbUpstreams';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext } from './testSupport';
+
+const lb = makeContainer({ id: 'lb-1', name: 'lb', type: 'loadbalancer' });
+const target1 = makeContainer({ id: 'app-1', name: 'app-1' });
+const target2 = makeContainer({ id: 'app-2', name: 'app-2', state: 'exited' });
+
+describe('lbUpstreams', () => {
+  it('passes when at least "min" targets are running', async () => {
+    const outcome = await lbUpstreams(
+      { node: 'lb', min: 1 },
+      makeContext({
+        containers: [lb, target1],
+        networkConfig: { loadBalancerTargets: { 'lb-1': ['app-1'] } },
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when fewer targets are running than "min"', async () => {
+    const outcome = await lbUpstreams(
+      { node: 'lb', min: 2 },
+      makeContext({
+        containers: [lb, target1, target2],
+        networkConfig: { loadBalancerTargets: { 'lb-1': ['app-1', 'app-2'] } },
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('1 running upstream target(s)');
+  });
+
+  it('counts running ASG replicas as upstream targets', async () => {
+    const asgReplica = makeContainer({ id: 'r1', name: 'r1', asgId: 'asg-1', isAsgInstance: true });
+    const outcome = await lbUpstreams(
+      { node: 'lb', min: 1 },
+      makeContext({
+        containers: [lb, asgReplica],
+        networkConfig: {
+          loadBalancerTargets: { 'lb-1': ['asg-1'] },
+          asgs: { 'asg-1': { parentId: 'template-1' } },
+        },
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('treats no network config as zero upstreams', async () => {
+    const outcome = await lbUpstreams(
+      { node: 'lb', min: 1 },
+      makeContext({ containers: [lb], networkConfig: null })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('0 running upstream target(s)');
+  });
+
+  it('fails when the node is not a load balancer', async () => {
+    const outcome = await lbUpstreams(
+      { node: 'lb', min: 1 },
+      makeContext({ containers: [makeContainer({ name: 'lb', type: 'redis' })] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('not a load balancer node');
+  });
+
+  it('throws InvalidParamsError when "min" is missing', async () => {
+    await expect(lbUpstreams({ node: 'lb' }, makeContext())).rejects.toThrow(InvalidParamsError);
+  });
+});

--- a/backend/src/modules/learning/engine/validators/lbUpstreams.ts
+++ b/backend/src/modules/learning/engine/validators/lbUpstreams.ts
@@ -1,0 +1,45 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam, requireNumberParam } from '../params';
+import { resolveRunningContainer, countRunningAsgReplicas } from './shared';
+
+/**
+ * `lb_upstreams` — checks that a load balancer node has at least `min`
+ * running upstream targets. Params: `{ node: string, min: number }`
+ * (docs/roadmap-format.md). Reads the declared targets from the project's
+ * network config and counts how many currently resolve to a running
+ * container — an ASG target counts its running replicas.
+ */
+export const lbUpstreams: ValidatorHandler = async (params, ctx) => {
+  const node = requireStringParam(params, 'node');
+  const min = requireNumberParam(params, 'min');
+
+  const containers = await ctx.getContainers();
+  const resolved = resolveRunningContainer(containers, node, ['loadbalancer'], 'load balancer');
+  if ('outcome' in resolved) return resolved.outcome;
+
+  const config = await ctx.getNetworkConfig();
+  const targetIds = config?.loadBalancerTargets?.[resolved.container.id] ?? [];
+
+  let runningCount = 0;
+  for (const targetId of targetIds) {
+    if (config?.asgs?.[targetId]) {
+      runningCount += countRunningAsgReplicas(containers, targetId);
+    } else if (containers.find((c) => c.id === targetId)?.state === 'running') {
+      runningCount += 1;
+    }
+  }
+
+  if (runningCount < min) {
+    return {
+      status: 'fail',
+      message: `The load balancer "${node}" has ${runningCount} running upstream target(s), but needs at least ${min}. Add or start more targets.`,
+      expected: `at least ${min} running upstream target(s)`,
+      observed: `${runningCount} running upstream target(s)`,
+    };
+  }
+
+  return {
+    status: 'pass',
+    message: `The load balancer "${node}" has ${runningCount} running upstream target(s) (at least ${min} required).`,
+  };
+};

--- a/backend/src/modules/learning/engine/validators/mongoCollectionExists.test.ts
+++ b/backend/src/modules/learning/engine/validators/mongoCollectionExists.test.ts
@@ -1,0 +1,71 @@
+import { mongoCollectionExists } from './mongoCollectionExists';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext } from './testSupport';
+
+const mongoContainer = makeContainer({ id: 'mongo-1', name: 'db', type: 'mongo' });
+
+describe('mongoCollectionExists', () => {
+  it('passes when the collection exists', async () => {
+    const outcome = await mongoCollectionExists(
+      { node: 'db', collection: 'orders' },
+      makeContext({
+        containers: [mongoContainer],
+        executeMongoCommand: () => Promise.resolve(JSON.stringify(['orders', 'users'])),
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when the collection does not exist', async () => {
+    const outcome = await mongoCollectionExists(
+      { node: 'db', collection: 'orders' },
+      makeContext({
+        containers: [mongoContainer],
+        executeMongoCommand: () => Promise.resolve(JSON.stringify(['users'])),
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toContain('users');
+  });
+
+  it('uses the "database" param when given', async () => {
+    const executeMongoCommand = jest.fn(() => Promise.resolve(JSON.stringify(['orders'])));
+    await mongoCollectionExists(
+      { node: 'db', collection: 'orders', database: 'shop' },
+      makeContext({ containers: [mongoContainer], executeMongoCommand })
+    );
+
+    expect(executeMongoCommand).toHaveBeenCalledWith('mongo-1', expect.stringContaining("'shop'"));
+  });
+
+  it('fails pedagogically when MongoDB is still starting up', async () => {
+    const outcome = await mongoCollectionExists(
+      { node: 'db', collection: 'orders' },
+      makeContext({
+        containers: [mongoContainer],
+        executeMongoCommand: () => Promise.resolve('ERROR: Database server is still starting up.'),
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('database not ready yet');
+  });
+
+  it('fails when the node is not a MongoDB node', async () => {
+    const outcome = await mongoCollectionExists(
+      { node: 'db', collection: 'orders' },
+      makeContext({ containers: [makeContainer({ name: 'db', type: 'redis' })] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('not a MongoDB node');
+  });
+
+  it('throws InvalidParamsError when "collection" is missing', async () => {
+    await expect(mongoCollectionExists({ node: 'db' }, makeContext())).rejects.toThrow(
+      InvalidParamsError
+    );
+  });
+});

--- a/backend/src/modules/learning/engine/validators/mongoCollectionExists.ts
+++ b/backend/src/modules/learning/engine/validators/mongoCollectionExists.ts
@@ -1,0 +1,59 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam, optionalStringParam } from '../params';
+import { resolveRunningContainer } from './shared';
+
+/** mongosh's implicit default database when none is selected. */
+const DEFAULT_DATABASE = 'test';
+
+const escapeJsStringLiteral = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+/**
+ * `mongo_collection_exists` — checks that a collection exists in a node's
+ * MongoDB. Params: `{ node: string, collection: string, database?: string }`
+ * (docs/roadmap-format.md); `database` defaults to `"test"`.
+ */
+export const mongoCollectionExists: ValidatorHandler = async (params, ctx) => {
+  const node = requireStringParam(params, 'node');
+  const collection = requireStringParam(params, 'collection');
+  const database = optionalStringParam(params, 'database', DEFAULT_DATABASE);
+
+  const containers = await ctx.getContainers();
+  const resolved = resolveRunningContainer(containers, node, ['mongo', 'nosql'], 'MongoDB');
+  if ('outcome' in resolved) return resolved.outcome;
+
+  const output = await ctx.executeMongoCommand(
+    resolved.container.id,
+    `JSON.stringify(db.getSiblingDB('${escapeJsStringLiteral(database)}').getCollectionNames())`
+  );
+
+  if (output.startsWith('ERROR')) {
+    return {
+      status: 'fail',
+      message: `MongoDB on "${node}" is still starting up. Wait a few seconds and try again.`,
+      expected: `collection "${collection}" in database "${database}"`,
+      observed: 'database not ready yet',
+    };
+  }
+
+  let collections: string[];
+  try {
+    collections = JSON.parse(output);
+  } catch {
+    collections = [];
+  }
+
+  if (!collections.includes(collection)) {
+    return {
+      status: 'fail',
+      message: `No collection named "${collection}" exists in the "${database}" database on "${node}" yet.`,
+      expected: `collection "${collection}"`,
+      observed: collections.length > 0 ? `collections found: ${collections.join(', ')}` : 'no collections yet',
+    };
+  }
+
+  return {
+    status: 'pass',
+    message: `Collection "${collection}" exists in the "${database}" database on "${node}".`,
+  };
+};

--- a/backend/src/modules/learning/engine/validators/portDenied.test.ts
+++ b/backend/src/modules/learning/engine/validators/portDenied.test.ts
@@ -1,0 +1,77 @@
+import { portDenied } from './portDenied';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext, makeSemanticRule } from './testSupport';
+
+const web = makeContainer({ id: 'web-1', name: 'web' });
+const db = makeContainer({ id: 'db-1', name: 'db' });
+
+describe('portDenied', () => {
+  it('passes when no ALLOW rule covers the port', async () => {
+    const outcome = await portDenied(
+      { source: 'web', target: 'db', port: 5432 },
+      makeContext({ containers: [web, db], semanticRules: [] })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when an ALLOW rule explicitly opens the port', async () => {
+    const outcome = await portDenied(
+      { source: 'web', target: 'db', port: 5432 },
+      makeContext({
+        containers: [web, db],
+        semanticRules: [
+          makeSemanticRule({ sourceNodeId: 'web-1', targetNodeId: 'db-1', port: '5432' }),
+        ],
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('Port 5432 is still open');
+  });
+
+  it('fails when an ALLOW rule opens all ports', async () => {
+    const outcome = await portDenied(
+      { source: 'web', target: 'db', port: 5432 },
+      makeContext({
+        containers: [web, db],
+        semanticRules: [
+          makeSemanticRule({ sourceNodeId: 'web-1', targetNodeId: 'db-1', port: 'ALL' }),
+        ],
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toContain('all ports are allowed');
+  });
+
+  it('passes when an ALLOW rule exists for a different port', async () => {
+    const outcome = await portDenied(
+      { source: 'web', target: 'db', port: 5432 },
+      makeContext({
+        containers: [web, db],
+        semanticRules: [
+          makeSemanticRule({ sourceNodeId: 'web-1', targetNodeId: 'db-1', port: '80' }),
+        ],
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when the target node does not exist', async () => {
+    const outcome = await portDenied(
+      { source: 'web', target: 'db', port: 5432 },
+      makeContext({ containers: [web] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('"db" does not exist');
+  });
+
+  it('throws InvalidParamsError when "port" is missing', async () => {
+    await expect(
+      portDenied({ source: 'web', target: 'db' }, makeContext())
+    ).rejects.toThrow(InvalidParamsError);
+  });
+});

--- a/backend/src/modules/learning/engine/validators/portDenied.ts
+++ b/backend/src/modules/learning/engine/validators/portDenied.ts
@@ -1,0 +1,44 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam, requireNumberParam } from '../params';
+import { resolveSourceAndTarget } from './shared';
+
+/**
+ * `port_denied` — checks that traffic from `source` to `target` on `port` is
+ * blocked. Params: `{ source: string, target: string, port: number }`
+ * (docs/roadmap-format.md). Reads the same computed security-group rules as
+ * `edge_exists`: the port is "denied" when no `ALLOW` rule covers it, mirroring
+ * the zero-trust default the enforcement planner applies to real containers —
+ * no live connection attempt is made (that would be slow and flaky).
+ */
+export const portDenied: ValidatorHandler = async (params, ctx) => {
+  const source = requireStringParam(params, 'source');
+  const target = requireStringParam(params, 'target');
+  const port = requireNumberParam(params, 'port');
+
+  const containers = await ctx.getContainers();
+  const resolved = resolveSourceAndTarget(containers, source, target);
+  if ('outcome' in resolved) return resolved.outcome;
+
+  const rules = await ctx.getSemanticRules();
+  const openRule = rules.find(
+    (rule) =>
+      rule.action === 'ALLOW' &&
+      rule.sourceNodeId === resolved.sourceContainer.id &&
+      rule.targetNodeId === resolved.targetContainer.id &&
+      (rule.port === 'ALL' || rule.port === String(port))
+  );
+
+  if (openRule) {
+    return {
+      status: 'fail',
+      message: `Port ${port} is still open from "${source}" to "${target}". Add or tighten a security group rule to block it.`,
+      expected: `port ${port} blocked from "${source}" to "${target}"`,
+      observed:
+        openRule.port === 'ALL'
+          ? `all ports are allowed from "${source}" to "${target}"`
+          : `port ${port} is explicitly allowed from "${source}" to "${target}"`,
+    };
+  }
+
+  return { status: 'pass', message: `Port ${port} is blocked from "${source}" to "${target}".` };
+};

--- a/backend/src/modules/learning/engine/validators/redisKeyExists.test.ts
+++ b/backend/src/modules/learning/engine/validators/redisKeyExists.test.ts
@@ -1,0 +1,58 @@
+import { redisKeyExists } from './redisKeyExists';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext } from './testSupport';
+
+const redisContainer = makeContainer({ id: 'redis-1', name: 'cache', type: 'redis' });
+
+describe('redisKeyExists', () => {
+  it('passes when a matching key exists', async () => {
+    const outcome = await redisKeyExists(
+      { node: 'cache', key: 'session:*' },
+      makeContext({
+        containers: [redisContainer],
+        executeRedisCommand: () => Promise.resolve('session:abc\n'),
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+  });
+
+  it('fails when no key matches', async () => {
+    const outcome = await redisKeyExists(
+      { node: 'cache', key: 'session:*' },
+      makeContext({ containers: [redisContainer], executeRedisCommand: () => Promise.resolve('') })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('no matching key');
+  });
+
+  it('fails pedagogically when Redis is still starting up', async () => {
+    const outcome = await redisKeyExists(
+      { node: 'cache', key: 'session:*' },
+      makeContext({
+        containers: [redisContainer],
+        executeRedisCommand: () => Promise.resolve('ERROR: Redis server is still starting up.'),
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('database not ready yet');
+  });
+
+  it('fails when the node is not a Redis node', async () => {
+    const outcome = await redisKeyExists(
+      { node: 'cache', key: 'session:*' },
+      makeContext({ containers: [makeContainer({ name: 'cache', type: 'postgres' })] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('not a Redis node');
+  });
+
+  it('throws InvalidParamsError when "key" is missing', async () => {
+    await expect(redisKeyExists({ node: 'cache' }, makeContext())).rejects.toThrow(
+      InvalidParamsError
+    );
+  });
+});

--- a/backend/src/modules/learning/engine/validators/redisKeyExists.ts
+++ b/backend/src/modules/learning/engine/validators/redisKeyExists.ts
@@ -1,0 +1,38 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam } from '../params';
+import { resolveRunningContainer } from './shared';
+
+/**
+ * `redis_key_exists` — checks that a key (or glob pattern, e.g. `session:*`)
+ * exists in a node's Redis. Params: `{ node: string, key: string }` (docs/roadmap-format.md).
+ */
+export const redisKeyExists: ValidatorHandler = async (params, ctx) => {
+  const node = requireStringParam(params, 'node');
+  const key = requireStringParam(params, 'key');
+
+  const containers = await ctx.getContainers();
+  const resolved = resolveRunningContainer(containers, node, ['redis'], 'Redis');
+  if ('outcome' in resolved) return resolved.outcome;
+
+  const output = await ctx.executeRedisCommand(resolved.container.id, ['KEYS', key]);
+
+  if (output.startsWith('ERROR')) {
+    return {
+      status: 'fail',
+      message: `Redis on "${node}" is still starting up. Wait a few seconds and try again.`,
+      expected: `a key matching "${key}"`,
+      observed: 'database not ready yet',
+    };
+  }
+
+  if (output.trim().length === 0) {
+    return {
+      status: 'fail',
+      message: `No key matching "${key}" exists in Redis on "${node}" yet.`,
+      expected: `a key matching "${key}"`,
+      observed: 'no matching key',
+    };
+  }
+
+  return { status: 'pass', message: `A key matching "${key}" exists in Redis on "${node}".` };
+};

--- a/backend/src/modules/learning/engine/validators/shared.test.ts
+++ b/backend/src/modules/learning/engine/validators/shared.test.ts
@@ -1,0 +1,94 @@
+import { resolveRunningContainer, resolveSourceAndTarget } from './shared';
+import { ContainerInfo } from '../../../../infrastructure/docker/providers/containerProvider';
+
+function makeContainer(overrides: Partial<ContainerInfo>): ContainerInfo {
+  return {
+    id: 'abc123',
+    name: 'db',
+    image: 'postgres:15-alpine',
+    state: 'running',
+    status: 'Up 2 minutes',
+    type: 'postgres',
+    ...overrides,
+  };
+}
+
+describe('resolveRunningContainer', () => {
+  it('resolves a running container of an expected type', () => {
+    const result = resolveRunningContainer([makeContainer({})], 'db', ['postgres'], 'PostgreSQL');
+
+    expect('container' in result && result.container.id).toBe('abc123');
+  });
+
+  it('fails when no container has the given name', () => {
+    const result = resolveRunningContainer([], 'db', ['postgres'], 'PostgreSQL');
+
+    expect('outcome' in result && result.outcome).toMatchObject({
+      status: 'fail',
+      observed: 'no container with that name',
+    });
+  });
+
+  it('fails when the container is of the wrong type', () => {
+    const result = resolveRunningContainer(
+      [makeContainer({ type: 'redis' })],
+      'db',
+      ['postgres'],
+      'PostgreSQL'
+    );
+
+    expect('outcome' in result && result.outcome).toMatchObject({
+      status: 'fail',
+      message: expect.stringContaining('not a PostgreSQL node'),
+      observed: 'a redis node',
+    });
+  });
+
+  it('fails when the container exists but is not running', () => {
+    const result = resolveRunningContainer(
+      [makeContainer({ state: 'exited' })],
+      'db',
+      ['postgres'],
+      'PostgreSQL'
+    );
+
+    expect('outcome' in result && result.outcome).toMatchObject({
+      status: 'fail',
+      observed: 'exited',
+    });
+  });
+});
+
+describe('resolveSourceAndTarget', () => {
+  it('resolves both containers regardless of running state', () => {
+    const source = makeContainer({ id: 'src-1', name: 'web', state: 'exited' });
+    const target = makeContainer({ id: 'dst-1', name: 'db' });
+
+    const result = resolveSourceAndTarget([source, target], 'web', 'db');
+
+    expect('sourceContainer' in result && result.sourceContainer.id).toBe('src-1');
+    expect('sourceContainer' in result && result.targetContainer.id).toBe('dst-1');
+  });
+
+  it('fails when the source container is missing', () => {
+    const target = makeContainer({ name: 'db' });
+
+    const result = resolveSourceAndTarget([target], 'web', 'db');
+
+    expect('outcome' in result && result.outcome).toMatchObject({
+      status: 'fail',
+      observed: '"web" does not exist',
+    });
+  });
+
+  it('fails when the target container is missing', () => {
+    const source = makeContainer({ name: 'web' });
+
+    const result = resolveSourceAndTarget([source], 'web', 'db');
+
+    expect('outcome' in result && result.outcome).toMatchObject({
+      status: 'fail',
+      observed: '"db" does not exist',
+    });
+  });
+});

--- a/backend/src/modules/learning/engine/validators/shared.ts
+++ b/backend/src/modules/learning/engine/validators/shared.ts
@@ -1,0 +1,104 @@
+import { ContainerInfo } from '../../../../infrastructure/docker/providers/containerProvider';
+import { ValidatorOutcome } from '../types';
+
+export type ResolvedContainer = { container: ContainerInfo } | { outcome: ValidatorOutcome };
+
+/**
+ * Resolves a canvas node name to its container, checking it is of one of the
+ * expected node types and currently running. Never throws: a missing, wrong
+ * type or stopped node is a pedagogical fail, not an infrastructure error —
+ * callers check `'outcome' in result` and return it as-is on failure.
+ */
+export function resolveRunningContainer(
+  containers: ContainerInfo[],
+  node: string,
+  expectedTypes: string[],
+  expectedLabel: string
+): ResolvedContainer {
+  const container = containers.find((c) => c.name === node);
+  if (!container) {
+    return {
+      outcome: {
+        status: 'fail',
+        message:
+          `No container named "${node}" exists in this project yet. ` +
+          `Create the node on the canvas, name it "${node}" and start it.`,
+        expected: `a running ${expectedLabel} node named "${node}"`,
+        observed: 'no container with that name',
+      },
+    };
+  }
+
+  const type = container.type ?? 'ubuntu';
+  if (!expectedTypes.includes(type)) {
+    return {
+      outcome: {
+        status: 'fail',
+        message: `"${node}" is not a ${expectedLabel} node (it's a ${type} node). Point this check at your ${expectedLabel} node.`,
+        expected: `a ${expectedLabel} node named "${node}"`,
+        observed: `a ${type} node`,
+      },
+    };
+  }
+
+  if (container.state !== 'running') {
+    return {
+      outcome: {
+        status: 'fail',
+        message:
+          `The container "${node}" exists but is not running (current state: ${container.state}). ` +
+          `Start it from the canvas.`,
+        expected: 'running',
+        observed: container.state,
+      },
+    };
+  }
+
+  return { container };
+}
+
+export type ResolvedEndpoints =
+  | { sourceContainer: ContainerInfo; targetContainer: ContainerInfo }
+  | { outcome: ValidatorOutcome };
+
+/**
+ * Resolves a `source`/`target` node-name pair to their containers for
+ * connectivity checks (`edge_exists`, `port_denied`). Only existence is
+ * checked — connectivity is a property of the security-group configuration,
+ * independent of whether the containers currently happen to be running.
+ */
+export function resolveSourceAndTarget(
+  containers: ContainerInfo[],
+  source: string,
+  target: string
+): ResolvedEndpoints {
+  const sourceContainer = containers.find((c) => c.name === source);
+  const targetContainer = containers.find((c) => c.name === target);
+
+  if (!sourceContainer || !targetContainer) {
+    const missing = !sourceContainer ? source : target;
+    return {
+      outcome: {
+        status: 'fail',
+        message:
+          `No container named "${missing}" exists in this project yet. ` +
+          `Create both "${source}" and "${target}" on the canvas first.`,
+        expected: `both "${source}" and "${target}" to exist`,
+        observed: `"${missing}" does not exist`,
+      },
+    };
+  }
+
+  return { sourceContainer, targetContainer };
+}
+
+/**
+ * Counts running replica containers belonging to the ASG whose own boundary
+ * container has this id — reused by `asg_replicas` and `lb_upstreams` (an
+ * ASG upstream target counts its running replicas, not itself).
+ */
+export function countRunningAsgReplicas(containers: ContainerInfo[], asgContainerId: string): number {
+  return containers.filter(
+    (c) => c.asgId === asgContainerId && c.isAsgInstance && c.state === 'running'
+  ).length;
+}

--- a/backend/src/modules/learning/engine/validators/tableExists.test.ts
+++ b/backend/src/modules/learning/engine/validators/tableExists.test.ts
@@ -1,0 +1,61 @@
+import { tableExists } from './tableExists';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext } from './testSupport';
+
+const postgresContainer = makeContainer({ id: 'pg-1', name: 'db', type: 'postgres' });
+
+describe('tableExists', () => {
+  it('passes when the table exists in the public schema', async () => {
+    const outcome = await tableExists(
+      { node: 'db', table: 'users' },
+      makeContext({
+        containers: [postgresContainer],
+        executePsqlCommand: () => Promise.resolve('1\n'),
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+    expect(outcome.message).toContain('"users"');
+  });
+
+  it('fails when the table does not exist', async () => {
+    const outcome = await tableExists(
+      { node: 'db', table: 'users' },
+      makeContext({
+        containers: [postgresContainer],
+        executePsqlCommand: () => Promise.resolve(''),
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('no such table');
+  });
+
+  it('fails pedagogically when the database is still starting up', async () => {
+    const outcome = await tableExists(
+      { node: 'db', table: 'users' },
+      makeContext({
+        containers: [postgresContainer],
+        executePsqlCommand: () =>
+          Promise.resolve('ERROR: Database server is still starting up. Please wait 5-10 seconds.'),
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.observed).toBe('database not ready yet');
+  });
+
+  it('fails when the node is not a Postgres node', async () => {
+    const outcome = await tableExists(
+      { node: 'db', table: 'users' },
+      makeContext({ containers: [makeContainer({ name: 'db', type: 'redis' })] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('not a PostgreSQL node');
+  });
+
+  it('throws InvalidParamsError when "table" is missing', async () => {
+    await expect(tableExists({ node: 'db' }, makeContext())).rejects.toThrow(InvalidParamsError);
+  });
+});

--- a/backend/src/modules/learning/engine/validators/tableExists.ts
+++ b/backend/src/modules/learning/engine/validators/tableExists.ts
@@ -1,0 +1,48 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam } from '../params';
+import { resolveRunningContainer } from './shared';
+
+/** Postgres nodes only ever provision the default `postgres` database. */
+const DEFAULT_DATABASE = 'postgres';
+
+const escapeSqlLiteral = (value: string): string => value.replace(/'/g, "''");
+
+/**
+ * `table_exists` — checks that a table exists in the `public` schema of a
+ * node's PostgreSQL. Params: `{ node: string, table: string }` (docs/roadmap-format.md).
+ */
+export const tableExists: ValidatorHandler = async (params, ctx) => {
+  const node = requireStringParam(params, 'node');
+  const table = requireStringParam(params, 'table');
+
+  const containers = await ctx.getContainers();
+  const resolved = resolveRunningContainer(containers, node, ['postgres', 'sql'], 'PostgreSQL');
+  if ('outcome' in resolved) return resolved.outcome;
+
+  const output = await ctx.executePsqlCommand(
+    resolved.container.id,
+    DEFAULT_DATABASE,
+    `SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = '${escapeSqlLiteral(table)}';`,
+    ['-t', '-A']
+  );
+
+  if (output.startsWith('ERROR')) {
+    return {
+      status: 'fail',
+      message: `PostgreSQL on "${node}" is still starting up. Wait a few seconds and try again.`,
+      expected: `table "${table}"`,
+      observed: 'database not ready yet',
+    };
+  }
+
+  if (output.trim().length === 0) {
+    return {
+      status: 'fail',
+      message: `No table named "${table}" exists in PostgreSQL on "${node}" yet.`,
+      expected: `table "${table}"`,
+      observed: 'no such table',
+    };
+  }
+
+  return { status: 'pass', message: `Table "${table}" exists in PostgreSQL on "${node}".` };
+};

--- a/backend/src/modules/learning/engine/validators/testSupport.ts
+++ b/backend/src/modules/learning/engine/validators/testSupport.ts
@@ -1,0 +1,49 @@
+import { ContainerInfo } from '../../../../infrastructure/docker/providers/containerProvider';
+import { SemanticRule } from '../../../network/models/networkPolicy';
+import { ValidatorContext, ValidatorNetworkConfig } from '../types';
+
+/** Shared test fixtures for validator tests — not a test file itself (no `*.test.ts` suffix). */
+export function makeContainer(overrides: Partial<ContainerInfo>): ContainerInfo {
+  return {
+    id: 'container-1',
+    name: 'node',
+    image: 'image:latest',
+    state: 'running',
+    status: 'Up 2 minutes',
+    ...overrides,
+  };
+}
+
+interface ContextOverrides {
+  containers?: ContainerInfo[];
+  networkConfig?: ValidatorNetworkConfig | null;
+  semanticRules?: SemanticRule[];
+  executePsqlCommand?: ValidatorContext['executePsqlCommand'];
+  executeRedisCommand?: ValidatorContext['executeRedisCommand'];
+  executeMongoCommand?: ValidatorContext['executeMongoCommand'];
+}
+
+export function makeContext(overrides: ContextOverrides = {}): ValidatorContext {
+  return {
+    projectId: 'project-1',
+    getContainers: () => Promise.resolve(overrides.containers ?? []),
+    getNetworkConfig: () => Promise.resolve(overrides.networkConfig ?? null),
+    getSemanticRules: () => Promise.resolve(overrides.semanticRules ?? []),
+    executePsqlCommand: overrides.executePsqlCommand ?? (() => Promise.resolve('')),
+    executeRedisCommand: overrides.executeRedisCommand ?? (() => Promise.resolve('')),
+    executeMongoCommand: overrides.executeMongoCommand ?? (() => Promise.resolve('')),
+  };
+}
+
+export function makeSemanticRule(overrides: Partial<SemanticRule>): SemanticRule {
+  return {
+    sourceNodeId: 'src',
+    targetNodeId: 'dst',
+    protocol: 'tcp',
+    port: 'ALL',
+    action: 'ALLOW',
+    direction: 'outbound',
+    ownerNodeId: 'src',
+    ...overrides,
+  };
+}

--- a/backend/src/modules/network/services/networkService.ts
+++ b/backend/src/modules/network/services/networkService.ts
@@ -64,7 +64,13 @@ export class NetworkService {
     delete this.policyHashes[projectId];
   }
 
-  private static async computeSemanticRules(projectId: string, config: any): Promise<SemanticRule[]> {
+  /**
+   * Expands security-group rules into pairwise semantic rules (real container
+   * ids, ASG replicas resolved). This is the single source of truth for "can
+   * X reach Y" — reused by the learning engine's `edge_exists`/`port_denied`
+   * validators so they never re-derive connectivity from raw security groups.
+   */
+  public static async computeSemanticRules(projectId: string, config: any): Promise<SemanticRule[]> {
     const rules: SemanticRule[] = [];
     const nodeIds = Object.keys(config.nodeSubnetMap || {});
     const sgs = config.nodeSecurityGroups || {};


### PR DESCRIPTION
## Summary of Changes

Implements the 7 remaining validator types for the learning/roadmap validation engine — `table_exists`, `redis_key_exists`, `mongo_collection_exists`, `edge_exists`, `lb_upstreams`, `port_denied`, `asg_replicas` — alongside the existing `container_running`. Roadmap steps can now check real Postgres/Redis/Mongo state, network connectivity, and ASG replica counts, not just container liveness.

Design choices, in short:
- DB validators (`table_exists`, `redis_key_exists`, `mongo_collection_exists`) go through `containerProvider`'s `executePsqlCommand`/`executeRedisCommand`/`executeMongoCommand`, using the same query idiom already used by the Postgres/Redis/Mongo explorers.
- `edge_exists`/`port_denied` reuse `NetworkService`'s security-group rule expansion (`computeSemanticRules`, now exposed publicly) instead of re-deriving connectivity from raw security groups — this is the same logic that drives real iptables enforcement, so a validator's verdict always matches what's actually applied.
- `asg_replicas`/`lb_upstreams` read directly off `ContainerInfo.asgId`/`isAsgInstance`, no new dependency needed.
- A shared `resolveRunningContainer`/`resolveSourceAndTarget` helper keeps node targeting, type checks, and pedagogical fail messages (observed vs. expected, plain language, no raw Docker ids) consistent across all 7 validators.
- Docker-not-ready responses from Postgres/Redis/Mongo are treated as a pedagogical `fail` ("still starting up, try again"), not an infrastructure error — only a genuinely unreachable Docker daemon propagates as `error`.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass — 206 tests, 25 suites)

### Manual Verification

Ran the backend against real Docker and exercised `container_running`, `table_exists`, `edge_exists` and `port_denied` in both pass **and** fail against real containers, using the existing example roadmap (`roadmaps/example-first-architecture.json`), which already targets 4 of these 8 types:
- Created/started a real `ubuntu` node → `container_running` flips fail → pass.
- Created a real Postgres node, ran `CREATE TABLE users (...)` through it → `table_exists` flips fail → pass, including the "database still starting up" pedagogical message before Postgres was ready.
- Applied a real network config with a security-group rule → `edge_exists` flips fail → pass; widened the rule to all ports → `port_denied` flips pass → fail, matching the real enforcement policy.
- Cleaned up the demo project/containers afterwards.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing