### PR TITLE
test(learning): integration tests for the validation engine against real containers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,8 @@
-# Verifies that every node image ships iptables/iproute2 (required for Security
-# Group enforcement) — see docs/adding-a-node.md#required-tooling-inside-every-node-image.
+# Runs the backend's *.itest.ts suites against a real Docker daemon:
+# - node image requirements (iptables/iproute2 — docs/adding-a-node.md#required-tooling-inside-every-node-image)
+# - the learning engine's 8 validators, pass and fail, against real containers (V-4)
 #
-# This pulls the real images from Docker Hub, so it only runs when something that
+# This pulls real images from Docker Hub, so it only runs when something that
 # affects them changes. Image pushes to Docker Hub happen outside this repo and
 # can't trigger CI — use "Run workflow" (workflow_dispatch) after publishing one.
 name: Integration
@@ -12,6 +13,7 @@ on:
     paths:
       - 'backend/src/infrastructure/docker/nodeTypes.ts'
       - 'backend/src/infrastructure/docker/imageRequirements.itest.ts'
+      - 'backend/src/modules/learning/**'
       - 'backend/jest.integration.config.js'
       - 'backend/package.json'
       - 'backend/package-lock.json'
@@ -21,6 +23,7 @@ on:
     paths:
       - 'backend/src/infrastructure/docker/nodeTypes.ts'
       - 'backend/src/infrastructure/docker/imageRequirements.itest.ts'
+      - 'backend/src/modules/learning/**'
       - 'backend/jest.integration.config.js'
       - 'backend/package.json'
       - 'backend/package-lock.json'

--- a/backend/src/modules/learning/engine/engine.itest.ts
+++ b/backend/src/modules/learning/engine/engine.itest.ts
@@ -1,0 +1,219 @@
+import docker from '../../../infrastructure/docker/DockerClient';
+import { containerProvider } from '../../../infrastructure/docker/providers/dockerContainerProvider';
+import { ProjectService } from '../../projects/services/projectService';
+import { RoadmapStep } from '../format/roadmapTypes';
+import { runStepValidators } from './engine';
+import { ValidatorResult } from './types';
+
+/**
+ * Integration tests (run with `npm run test:integration`, requires a Docker daemon).
+ *
+ * The unit tests next to each validator mock every Docker/DB call — they prove the
+ * logic, not the contact with reality. This suite runs all 8 validators, pass and
+ * fail, through `runStepValidators` with its *default* dependencies (the real
+ * `containerProvider`/`ProjectService`/`NetworkService` singletons) against one
+ * disposable project with real containers.
+ *
+ * `edge_exists`/`port_denied`/`lb_upstreams` never touch iptables or attempt a live
+ * connection (see the comment in `validators/portDenied.ts`) — they only read the
+ * project's persisted network config, so no `NetworkService.applyPolicy` call is
+ * needed here, only `ProjectService.saveNetworkConfig`.
+ *
+ * To keep the suite non-flaky, every pass/fail pair reads the *same* static fixture
+ * with different params — nothing is mutated between assertions.
+ */
+
+async function waitUntilReady(check: () => Promise<string>, label: string): Promise<void> {
+  const deadline = Date.now() + 60000;
+  let lastOutput = '';
+  while (Date.now() < deadline) {
+    lastOutput = await check();
+    if (!lastOutput.startsWith('ERROR')) return;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`${label} did not become ready in time (last output: ${lastOutput})`);
+}
+
+describe('learning engine — real containers (V-4)', () => {
+  let projectId = '';
+  let stepCounter = 0;
+
+  async function runOne(type: string, params: Record<string, unknown>): Promise<ValidatorResult> {
+    const step: RoadmapStep = {
+      id: `check-${stepCounter++}`,
+      title: 'integration check',
+      instruction: 'n/a',
+      validators: [{ type, params }],
+    };
+    const [result] = await runStepValidators(projectId, step);
+    return result;
+  }
+
+  beforeAll(async () => {
+    try {
+      await docker.ping();
+    } catch {
+      throw new Error(
+        'Docker daemon is not reachable. Integration tests require a running Docker daemon.'
+      );
+    }
+
+    const project = await ProjectService.createProject('v4-integration-fixture');
+    projectId = project.id;
+
+    const web = await containerProvider.createContainer(projectId, 'web', 'ubuntu');
+    const stoppedWeb = await containerProvider.createContainer(projectId, 'stopped-web', 'ubuntu');
+    await containerProvider.stopContainer(stoppedWeb.id);
+    const db = await containerProvider.createContainer(projectId, 'db', 'postgres');
+    const cache = await containerProvider.createContainer(projectId, 'cache', 'redis');
+    const nosql = await containerProvider.createContainer(projectId, 'nosql', 'mongo');
+    const lb = await containerProvider.createContainer(projectId, 'lb', 'loadbalancer');
+    const asgBoundary = await containerProvider.createContainer(projectId, 'web-asg', 'ubuntu');
+    await containerProvider.createContainer(projectId, 'web-asg-replica-1', 'ubuntu', false, undefined, {
+      'akal.asg.id': asgBoundary.id,
+      'akal.asg.instance': 'true',
+    });
+    await containerProvider.createContainer(projectId, 'web-asg-replica-2', 'ubuntu', false, undefined, {
+      'akal.asg.id': asgBoundary.id,
+      'akal.asg.instance': 'true',
+    });
+
+    await waitUntilReady(
+      () => containerProvider.executePsqlCommand(db.id, 'postgres', 'SELECT 1;'),
+      'PostgreSQL'
+    );
+    await waitUntilReady(() => containerProvider.executeRedisCommand(cache.id, ['PING']), 'Redis');
+    await waitUntilReady(
+      () => containerProvider.executeMongoCommand(nosql.id, 'db.runCommand({ ping: 1 })'),
+      'MongoDB'
+    );
+
+    await containerProvider.executePsqlCommand(db.id, 'postgres', 'CREATE TABLE users (id serial primary key);');
+    await containerProvider.executeRedisCommand(cache.id, ['SET', 'session:abc123', 'value']);
+    await containerProvider.executeMongoCommand(
+      nosql.id,
+      "db.getSiblingDB('test').events.insertOne({ seed: true })"
+    );
+
+    await ProjectService.saveNetworkConfig(projectId, {
+      nodeSubnetMap: {
+        [web.id]: 'public',
+        [db.id]: 'private',
+        [cache.id]: 'private',
+        [nosql.id]: 'private',
+      },
+      nodeSecurityGroups: {
+        [web.id]: [
+          { id: 'sg-web-to-db', type: 'outbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: db.id },
+        ],
+      },
+      loadBalancerTargets: {
+        [lb.id]: [asgBoundary.id],
+      },
+      asgs: {
+        [asgBoundary.id]: { parentId: asgBoundary.id },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    if (!projectId) return;
+    await ProjectService.deleteProject(projectId);
+  });
+
+  it('container_running passes against a running container', async () => {
+    const result = await runOne('container_running', { node: 'web' });
+    expect(result.status).toBe('pass');
+  });
+
+  it('container_running fails against a stopped container', async () => {
+    const result = await runOne('container_running', { node: 'stopped-web' });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+
+  it('table_exists passes against a real table', async () => {
+    const result = await runOne('table_exists', { node: 'db', table: 'users' });
+    expect(result.status).toBe('pass');
+  });
+
+  it('table_exists fails against a table that was never created', async () => {
+    const result = await runOne('table_exists', { node: 'db', table: 'ghost_table' });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+
+  it('redis_key_exists passes against a real key', async () => {
+    const result = await runOne('redis_key_exists', { node: 'cache', key: 'session:*' });
+    expect(result.status).toBe('pass');
+  });
+
+  it('redis_key_exists fails against a key that was never set', async () => {
+    const result = await runOne('redis_key_exists', { node: 'cache', key: 'nope:*' });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+
+  it('mongo_collection_exists passes against a real collection', async () => {
+    const result = await runOne('mongo_collection_exists', { node: 'nosql', collection: 'events' });
+    expect(result.status).toBe('pass');
+  });
+
+  it('mongo_collection_exists fails against a collection that was never created', async () => {
+    const result = await runOne('mongo_collection_exists', { node: 'nosql', collection: 'ghost' });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+
+  it('edge_exists passes for an allowed source/target/port', async () => {
+    const result = await runOne('edge_exists', { source: 'web', target: 'db', port: 5432 });
+    expect(result.status).toBe('pass');
+  });
+
+  it('edge_exists fails for a pair with no security group rule', async () => {
+    const result = await runOne('edge_exists', { source: 'web', target: 'nosql', port: 5432 });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+
+  it('port_denied passes for a port with no allow rule', async () => {
+    const result = await runOne('port_denied', { source: 'web', target: 'db', port: 9999 });
+    expect(result.status).toBe('pass');
+  });
+
+  it('port_denied fails for a port that is explicitly allowed', async () => {
+    const result = await runOne('port_denied', { source: 'web', target: 'db', port: 5432 });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+
+  it('lb_upstreams passes when enough replicas are running', async () => {
+    const result = await runOne('lb_upstreams', { node: 'lb', min: 2 });
+    expect(result.status).toBe('pass');
+  });
+
+  it('lb_upstreams fails when fewer replicas are running than required', async () => {
+    const result = await runOne('lb_upstreams', { node: 'lb', min: 5 });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+
+  it('asg_replicas passes when the replica count matches', async () => {
+    const result = await runOne('asg_replicas', { node: 'web-asg', count: 2 });
+    expect(result.status).toBe('pass');
+  });
+
+  it('asg_replicas fails when the replica count does not match', async () => {
+    const result = await runOne('asg_replicas', { node: 'web-asg', count: 5 });
+    expect(result.status).toBe('fail');
+    expect(result.expected).toBeTruthy();
+    expect(result.observed).toBeTruthy();
+  });
+});

--- a/backend/src/modules/learning/engine/engine.itest.ts
+++ b/backend/src/modules/learning/engine/engine.itest.ts
@@ -23,6 +23,19 @@ import { ValidatorResult } from './types';
  * with different params — nothing is mutated between assertions.
  */
 
+/**
+ * `containerProvider.createContainer` attaches every container to this network
+ * (`HostConfig.NetworkMode: 'akal-lab-network'`). In the running app it's created
+ * once at server startup (`DockerInitializer.ensureSharedNetwork`), but this suite
+ * never boots the server, so a fresh Docker daemon (e.g. a CI runner) won't have it.
+ */
+async function ensureSharedNetwork(): Promise<void> {
+  const networks = await docker.listNetworks();
+  if (!networks.some((n) => n.Name === 'akal-lab-network')) {
+    await docker.createNetwork({ Name: 'akal-lab-network', Driver: 'bridge' });
+  }
+}
+
 async function waitUntilReady(check: () => Promise<string>, label: string): Promise<void> {
   const deadline = Date.now() + 60000;
   let lastOutput = '';
@@ -57,6 +70,8 @@ describe('learning engine — real containers (V-4)', () => {
         'Docker daemon is not reachable. Integration tests require a running Docker daemon.'
       );
     }
+
+    await ensureSharedNetwork();
 
     const project = await ProjectService.createProject('v4-integration-fixture');
     projectId = project.id;

--- a/docs/learning-api.md
+++ b/docs/learning-api.md
@@ -143,6 +143,21 @@ The engine dispatches on `validator.type` through a single extension point. To a
 
 Failure messages are half the product: always say what was observed and what was expected, in plain human language, never a raw Docker id.
 
+## Integration tests against real containers
+
+The engine's unit tests (co-located `*.test.ts` next to each validator) mock every Docker/DB call — they prove the logic, not the contact with reality. `backend/src/modules/learning/engine/engine.itest.ts` covers that gap: it stands up one disposable project with real containers (Postgres/Redis/Mongo seeded with real data, a load balancer, a running auto-scaling group) and runs all 8 validators, pass **and** fail, through `runStepValidators` with its default (real) dependencies.
+
+Run it locally with Docker started:
+
+```bash
+cd backend && npm run test:integration
+```
+
+Kept out of the default `npm test` run (see `jest.integration.config.js`) and off the main CI job — it runs in the dedicated `Integration` GitHub Actions workflow instead. Anti-flakiness choices worth knowing if you touch this suite:
+
+- Every pass/fail pair reads the **same static fixture** with different `params` — nothing is mutated between assertions, so ordering and retries can't corrupt state.
+- Setup polls Postgres/Redis/Mongo until they actually accept connections before seeding (DB startup lag is the classic source of flaky integration tests).
+
 ## Known limitation: message language
 
 Engine messages (`message`, `expected`, `observed`) are produced in **English**, regardless of the roadmap's `language` field. A French roadmap currently gets English correction messages. This is a known v1 limitation, to be revisited with the full validator palette (V-3) — options include message keys translated by the frontend.


### PR DESCRIPTION
## Summary of Changes

Adds an integration test suite for the validation engine (`backend/src/modules/learning/engine/engine.itest.ts`). The unit tests next to each validator mock every Docker/DB call, so they prove the logic but never the contact with reality (container startup timing, DB readiness, real ASG label resolution). This suite stands up one disposable project with real Docker containers (Postgres/Redis/Mongo seeded with real data, a load balancer, a running auto-scaling group) and runs all 8 validators — pass **and** fail — through `runStepValidators` with its default (real) dependencies. Every pass/fail pair reads the same static fixture with different params, so nothing is mutated between assertions, keeping the suite non-flaky. It stays out of the default `npm test` run (existing `*.itest.ts` / `jest.integration.config.js` convention) and is wired into the existing dedicated `Integration` GitHub Actions job by extending its `paths` filters.

## Types of Changes

- [ ] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update
- [x] Test coverage addition

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass — 206/206, unchanged, no Docker dependency)

### Manual Verification

Ran `npm run test:integration` locally against a real Docker daemon 3 times in a row: all 16 new assertions pass every time, no flaky result. Ran the full integration suite (both `*.itest.ts` files): 21/21. Confirmed no leftover containers after teardown (`docker ps -a` filtered on the test project's label).

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing