### PR TITLE
feat(learning): roadmap player side panel

### DIFF
--- a/backend/src/modules/learning/controllers/learningController.test.ts
+++ b/backend/src/modules/learning/controllers/learningController.test.ts
@@ -75,7 +75,16 @@ describe('LearningController', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(roadmap);
-      expect(RoadmapService.getRoadmap).toHaveBeenCalledWith('example-roadmap');
+      expect(RoadmapService.getRoadmap).toHaveBeenCalledWith('example-roadmap', {});
+    });
+
+    it('forwards the language query to the service', async () => {
+      const res = await request(app).get('/api/learning/roadmaps/example-roadmap?language=fr');
+
+      expect(res.status).toBe(200);
+      expect(RoadmapService.getRoadmap).toHaveBeenCalledWith('example-roadmap', {
+        language: 'fr',
+      });
     });
 
     it('returns 404 for an unknown id', async () => {
@@ -125,6 +134,16 @@ describe('LearningController', () => {
         expect(res.body.error).toContain(`"${field}"`);
       }
     );
+
+    it('returns 400 (not 500) when the request has no JSON body', async () => {
+      const res = await request(app)
+        .post('/api/learning/validate')
+        .set('Content-Type', 'text/plain')
+        .send('not json');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('"projectId"');
+    });
 
     it('returns 404 when the project does not exist', async () => {
       (ProjectService.listProjects as jest.Mock).mockResolvedValue([]);

--- a/backend/src/modules/learning/controllers/learningController.ts
+++ b/backend/src/modules/learning/controllers/learningController.ts
@@ -25,7 +25,11 @@ export class LearningController {
 
   public static async getRoadmap(req: Request, res: Response): Promise<void> {
     try {
-      const roadmap = RoadmapService.getRoadmap(req.params.id as string);
+      const { language } = req.query;
+      const roadmap = RoadmapService.getRoadmap(
+        req.params.id as string,
+        typeof language === 'string' && language.length > 0 ? { language } : {}
+      );
       if (!roadmap) {
         res.status(404).json({
           error: `No roadmap found with id "${req.params.id}".`,
@@ -41,7 +45,9 @@ export class LearningController {
 
   public static async validate(req: Request, res: Response): Promise<void> {
     try {
-      const { projectId, roadmapId, stepId } = req.body as Record<string, unknown>;
+      // req.body is undefined when the request has no JSON Content-Type —
+      // fall through to the per-field 400s instead of throwing a 500.
+      const { projectId, roadmapId, stepId } = (req.body ?? {}) as Record<string, unknown>;
       for (const [name, value] of Object.entries({ projectId, roadmapId, stepId })) {
         if (typeof value !== 'string' || value.length === 0) {
           res.status(400).json({ error: `"${name}" is required and must be a string` });

--- a/backend/src/modules/learning/controllers/learningController.ts
+++ b/backend/src/modules/learning/controllers/learningController.ts
@@ -26,13 +26,17 @@ export class LearningController {
   public static async getRoadmap(req: Request, res: Response): Promise<void> {
     try {
       const { language } = req.query;
+      const wantedLanguage =
+        typeof language === 'string' && language.length > 0 ? language : undefined;
       const roadmap = RoadmapService.getRoadmap(
         req.params.id as string,
-        typeof language === 'string' && language.length > 0 ? { language } : {}
+        wantedLanguage ? { language: wantedLanguage } : {}
       );
       if (!roadmap) {
         res.status(404).json({
-          error: `No roadmap found with id "${req.params.id}".`,
+          error: wantedLanguage
+            ? `No roadmap found with id "${req.params.id}" in language "${wantedLanguage}".`
+            : `No roadmap found with id "${req.params.id}".`,
           code: 'ROADMAP_NOT_FOUND',
         });
         return;

--- a/backend/src/modules/learning/services/__fixtures__/roadmaps/valid-fr.json
+++ b/backend/src/modules/learning/services/__fixtures__/roadmaps/valid-fr.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "id": "fixture-roadmap",
+  "title": "Roadmap de test",
+  "description": "Traduction française de la roadmap de test — même id, langue différente.",
+  "language": "fr",
+  "estimatedMinutes": 10,
+  "difficulty": "beginner",
+  "steps": [
+    {
+      "id": "start-web",
+      "title": "Démarrer le serveur web",
+      "instruction": "Créez un nœud nommé `web` et démarrez-le.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "web" }
+        }
+      ]
+    },
+    {
+      "id": "start-db",
+      "title": "Démarrer la base de données",
+      "instruction": "Créez un nœud nommé `db` et démarrez-le.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "db" }
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/modules/learning/services/roadmapService.test.ts
+++ b/backend/src/modules/learning/services/roadmapService.test.ts
@@ -11,10 +11,20 @@ describe('RoadmapService', () => {
   });
 
   describe('listRoadmaps', () => {
-    it('lists valid roadmaps with their summary fields', () => {
+    it('lists one summary per file — translations appear as separate entries', () => {
       const summaries = RoadmapService.listRoadmaps(FIXTURES_DIR);
 
       expect(summaries).toEqual([
+        {
+          id: 'fixture-roadmap',
+          title: 'Roadmap de test',
+          description:
+            'Traduction française de la roadmap de test — même id, langue différente.',
+          language: 'fr',
+          difficulty: 'beginner',
+          estimatedMinutes: 10,
+          stepCount: 2,
+        },
         {
           id: 'fixture-roadmap',
           title: 'Fixture roadmap',
@@ -43,18 +53,42 @@ describe('RoadmapService', () => {
 
   describe('getRoadmap', () => {
     it('returns the full roadmap for a known id', () => {
-      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', FIXTURES_DIR);
+      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', { dir: FIXTURES_DIR });
 
       expect(roadmap).not.toBeNull();
       expect(roadmap?.steps.map(s => s.id)).toEqual(['start-web', 'start-db']);
     });
 
+    it('picks deterministically (sorted by language) when no language is given', () => {
+      const first = RoadmapService.getRoadmap('fixture-roadmap', { dir: FIXTURES_DIR });
+      const second = RoadmapService.getRoadmap('fixture-roadmap', { dir: FIXTURES_DIR });
+
+      expect(first?.language).toBe('en');
+      expect(second?.language).toBe('en');
+    });
+
+    it('returns the exact translation when a language is given', () => {
+      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', {
+        language: 'fr',
+        dir: FIXTURES_DIR,
+      });
+
+      expect(roadmap?.language).toBe('fr');
+      expect(roadmap?.title).toBe('Roadmap de test');
+    });
+
+    it('returns null for a language with no translation — no fallback', () => {
+      expect(
+        RoadmapService.getRoadmap('fixture-roadmap', { language: 'de', dir: FIXTURES_DIR })
+      ).toBeNull();
+    });
+
     it('returns null for an unknown id', () => {
-      expect(RoadmapService.getRoadmap('does-not-exist', FIXTURES_DIR)).toBeNull();
+      expect(RoadmapService.getRoadmap('does-not-exist', { dir: FIXTURES_DIR })).toBeNull();
     });
 
     it('never serves a roadmap from an invalid file', () => {
-      expect(RoadmapService.getRoadmap('broken-roadmap', FIXTURES_DIR)).toBeNull();
+      expect(RoadmapService.getRoadmap('broken-roadmap', { dir: FIXTURES_DIR })).toBeNull();
     });
   });
 });

--- a/backend/src/modules/learning/services/roadmapService.ts
+++ b/backend/src/modules/learning/services/roadmapService.ts
@@ -40,8 +40,22 @@ export class RoadmapService {
     }));
   }
 
-  public static getRoadmap(id: string, dir: string = ROADMAPS_DIR): Roadmap | null {
-    return this.readAll(dir).find(roadmap => roadmap.id === id) ?? null;
+  /**
+   * Translations share an id and differ by `language` (format v1 contract),
+   * so (id, language) is the real key. With `language`, the match is exact —
+   * no fallback: the caller only asks for pairs the catalogue advertised.
+   * Without it, the pick is deterministic (sorted by language) — used by
+   * /validate, where steps and validators are language-neutral.
+   */
+  public static getRoadmap(
+    id: string,
+    opts: { language?: string; dir?: string } = {}
+  ): Roadmap | null {
+    const candidates = this.readAll(opts.dir ?? ROADMAPS_DIR).filter(roadmap => roadmap.id === id);
+    if (opts.language) {
+      return candidates.find(roadmap => roadmap.language === opts.language) ?? null;
+    }
+    return candidates.sort((a, b) => a.language.localeCompare(b.language))[0] ?? null;
   }
 
   private static readAll(dir: string): Roadmap[] {
@@ -51,7 +65,9 @@ export class RoadmapService {
     }
 
     const roadmaps: Roadmap[] = [];
-    for (const file of fs.readdirSync(dir)) {
+    // Sorted: readdir order is filesystem-dependent, and both the catalogue
+    // order and the language-less getRoadmap pick must be stable.
+    for (const file of fs.readdirSync(dir).sort()) {
       if (!file.endsWith('.json')) {
         continue;
       }

--- a/docs/learning-api.md
+++ b/docs/learning-api.md
@@ -11,7 +11,7 @@ This document is the contract for API consumers (the roadmap player in the front
 
 ### `GET /api/learning/roadmaps`
 
-Lists the available roadmaps as summaries.
+Lists the available roadmaps as summaries — **one entry per file**. Translations of the same roadmap share an `id` and differ by `language` (see the format's language model), so they appear as separate catalogue entries; a selection UI should surface the `language` field.
 
 ```json
 [
@@ -31,7 +31,11 @@ Lists the available roadmaps as summaries.
 
 Returns the full roadmap file (format v1, see [`roadmap-format.md`](./roadmap-format.md)) — steps, instructions, hints, solutions, validators.
 
-- `404 { "error": "...", "code": "ROADMAP_NOT_FOUND" }` if no valid roadmap has this id.
+Because translations share an `id`, the real key is `(id, language)`:
+
+- `?language=<code>` (optional) — return exactly the translation with that `language`, or `404`. **No fallback**: the player only requests pairs the catalogue advertised.
+- Without `language`, the pick among translations is deterministic (sorted by language code), so repeated calls always return the same file.
+- `404 { "error": "...", "code": "ROADMAP_NOT_FOUND" }` if no valid roadmap matches.
 
 ### `POST /api/learning/validate`
 
@@ -48,6 +52,8 @@ Request body:
 ```
 
 `stepId` is the step's stable slug id, never its position — step ids are unique within a roadmap, which is why `roadmapId` is also required.
+
+There is no `language` field: step ids and validators are language-neutral by format contract, so validating against any translation of the roadmap is equivalent (the server uses the deterministic language-less pick).
 
 Error responses (request problems only, see [status semantics](#http-status-semantics)):
 

--- a/frontend/src/features/learning/components/LearningPanel.test.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.test.tsx
@@ -1,0 +1,197 @@
+import '../../../i18n';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LearningPanel from './LearningPanel';
+import type {
+  Roadmap,
+  RoadmapSummary,
+  StepValidationResponse,
+} from '../../../shared/types/roadmap';
+
+const summaries: RoadmapSummary[] = [
+  {
+    id: 'example-first-architecture',
+    title: 'Your first architecture',
+    description: 'Build a minimal two-tier architecture.',
+    language: 'en',
+    difficulty: 'beginner',
+    estimatedMinutes: 30,
+    stepCount: 2,
+  },
+];
+
+const roadmap: Roadmap = {
+  schemaVersion: 1,
+  id: 'example-first-architecture',
+  title: 'Your first architecture',
+  description: 'Build a minimal two-tier architecture.',
+  language: 'en',
+  steps: [
+    {
+      id: 'create-web-server',
+      title: 'Create the web server',
+      instruction: 'Drag an Ubuntu node named `web` onto the canvas and start it.',
+      validators: [{ type: 'container_running', params: { node: 'web' } }],
+    },
+    {
+      id: 'add-database',
+      title: 'Add the database',
+      instruction: 'Add a Postgres node named `db`.',
+      validators: [{ type: 'container_running', params: { node: 'db' } }],
+    },
+  ],
+};
+
+const failResponse: StepValidationResponse = {
+  roadmapId: roadmap.id,
+  stepId: 'create-web-server',
+  stepPassed: false,
+  results: [
+    {
+      index: 0,
+      type: 'container_running',
+      status: 'fail',
+      message: 'No container named "web" exists in this project yet.',
+      expected: 'a running container named "web"',
+      observed: 'no container with that name',
+    },
+  ],
+  checkedAt: '2026-07-15T10:00:00.000Z',
+};
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as Response;
+}
+
+/** Routes fetch calls by URL so the catalogue, roadmap and validate endpoints can be scripted independently. */
+function buildFetchMock(handlers: {
+  roadmaps?: () => Response;
+  roadmap?: () => Response;
+  validate?: () => Response;
+}) {
+  return vi.fn((url: string) => {
+    if (url.includes('/api/learning/validate')) {
+      return Promise.resolve(handlers.validate?.() ?? jsonResponse(true, failResponse));
+    }
+    if (url.includes('/api/learning/roadmaps/')) {
+      return Promise.resolve(handlers.roadmap?.() ?? jsonResponse(true, roadmap));
+    }
+    if (url.includes('/api/learning/roadmaps')) {
+      return Promise.resolve(handlers.roadmaps?.() ?? jsonResponse(true, summaries));
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+}
+
+async function openRoadmapFromCatalog() {
+  fireEvent.click(await screen.findByText('Your first architecture'));
+  // The current step's title appears twice: in the step list and in the detail block.
+  await screen.findAllByText('Create the web server');
+}
+
+describe('LearningPanel', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    errorSpy.mockRestore();
+  });
+
+  it('lists the roadmap catalogue on open', async () => {
+    vi.stubGlobal('fetch', buildFetchMock({}));
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+
+    expect(await screen.findByText('Your first architecture')).toBeInTheDocument();
+    expect(screen.getByText('Build a minimal two-tier architecture.')).toBeInTheDocument();
+    expect(screen.getByText('EN')).toBeInTheDocument();
+  });
+
+  it('shows a retry path when the catalogue cannot be loaded', async () => {
+    const fetchMock = buildFetchMock({});
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('Your first architecture')).toBeInTheDocument();
+  });
+
+  it('opens a roadmap: all steps listed, current step highlighted, instruction shown', async () => {
+    vi.stubGlobal('fetch', buildFetchMock({}));
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+
+    await openRoadmapFromCatalog();
+
+    expect(screen.getByText('Add the database')).toBeInTheDocument();
+    expect(screen.getByText('Step 1 of 2')).toBeInTheDocument();
+    expect(
+      screen.getByText('Drag an Ubuntu node named `web` onto the canvas and start it.')
+    ).toBeInTheDocument();
+  });
+
+  it('navigates between steps with next/previous', async () => {
+    vi.stubGlobal('fetch', buildFetchMock({}));
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+    await openRoadmapFromCatalog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(screen.getByText('Step 2 of 2')).toBeInTheDocument();
+    expect(screen.getByText('Add a Postgres node named `db`.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous' }));
+    expect(screen.getByText('Step 1 of 2')).toBeInTheDocument();
+  });
+
+  it('validates the current step and renders the raw results', async () => {
+    vi.stubGlobal('fetch', buildFetchMock({}));
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+    await openRoadmapFromCatalog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Not yet — see the results below')).toBeInTheDocument();
+    expect(
+      screen.getByText('No container named "web" exists in this project yet.')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/a running container named "web"/)).toBeInTheDocument();
+  });
+
+  it('shows an understandable error with retry when the backend is unreachable during validation', async () => {
+    let validateFails = true;
+    vi.stubGlobal(
+      'fetch',
+      buildFetchMock({
+        validate: () => {
+          if (validateFails) throw new Error('network down');
+          return jsonResponse(true, failResponse);
+        },
+      })
+    );
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+    await openRoadmapFromCatalog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
+    expect(
+      await screen.findByText('Could not reach the server. Your work is untouched — try again.')
+    ).toBeInTheDocument();
+
+    validateFails = false;
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(await screen.findByText('Not yet — see the results below')).toBeInTheDocument();
+  });
+
+  it('calls onClose from the header button', async () => {
+    vi.stubGlobal('fetch', buildFetchMock({}));
+    const onClose = vi.fn();
+    render(<LearningPanel projectId="p1" onClose={onClose} />);
+
+    fireEvent.click(screen.getByTitle('Close panel'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/learning/components/LearningPanel.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.tsx
@@ -1,0 +1,103 @@
+import { useTranslation } from 'react-i18next';
+import { GraduationCap, X } from 'lucide-react';
+import { useLearningPlayer } from '../hooks/useLearningPlayer';
+import RoadmapCatalog from './RoadmapCatalog';
+import RoadmapPlayer from './RoadmapPlayer';
+
+interface LearningPanelProps {
+  projectId: string;
+  onClose: () => void;
+}
+
+/**
+ * The roadmap player sidebar. Sits to the LEFT of the canvas (NodeLibrary
+ * owns the right) and is only mounted while open, so the free-canvas
+ * experience is untouched when the learner is not in a roadmap.
+ */
+export default function LearningPanel({ projectId, onClose }: LearningPanelProps) {
+  const { t } = useTranslation();
+  const player = useLearningPlayer({ projectId });
+
+  return (
+    <div style={styles.sidebar}>
+      <div style={styles.header}>
+        <div style={styles.headerTitle}>
+          <GraduationCap size={16} color="var(--color-accent)" style={{ marginRight: 8 }} />
+          <span>{t('learning.panelTitle')}</span>
+        </div>
+        <button onClick={onClose} style={styles.closeBtn} title={t('learning.close')}>
+          <X size={16} />
+        </button>
+      </div>
+
+      <div style={styles.content}>
+        {player.roadmap ? (
+          <RoadmapPlayer player={player} />
+        ) : player.roadmapLoading ? (
+          <div style={styles.status}>{t('learning.player.loading')}</div>
+        ) : player.roadmapError !== null ? (
+          <div style={styles.status}>
+            <span>{player.roadmapError || t('learning.player.loadError')}</span>
+            <RoadmapCatalog onOpen={player.openRoadmap} />
+          </div>
+        ) : (
+          <RoadmapCatalog onOpen={player.openRoadmap} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  sidebar: {
+    width: '300px',
+    backgroundColor: 'var(--bg-surface-solid)',
+    borderRight: '1px solid var(--border-color)',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    flexShrink: 0,
+    zIndex: 5,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '16px',
+    borderBottom: '1px solid var(--border-color)',
+    height: '57px',
+    boxSizing: 'border-box',
+  },
+  headerTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    fontWeight: 700,
+    fontSize: '14px',
+    color: 'var(--color-text-primary)',
+    letterSpacing: '-0.2px',
+  },
+  closeBtn: {
+    background: 'none',
+    border: 'none',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    padding: '4px',
+    borderRadius: '4px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: '16px',
+  },
+  status: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    fontSize: '12px',
+    color: 'var(--color-danger)',
+    lineHeight: 1.5,
+  },
+};

--- a/frontend/src/features/learning/components/LearningPanel.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.tsx
@@ -34,14 +34,17 @@ export default function LearningPanel({ projectId, onClose }: LearningPanelProps
         {player.roadmap ? (
           <RoadmapPlayer player={player} />
         ) : player.roadmapLoading ? (
-          <div style={styles.status}>{t('learning.player.loading')}</div>
-        ) : player.roadmapError !== null ? (
-          <div style={styles.status}>
-            <span>{player.roadmapError || t('learning.player.loadError')}</span>
-            <RoadmapCatalog onOpen={player.openRoadmap} />
-          </div>
+          <div style={styles.loading}>{t('learning.player.loading')}</div>
         ) : (
-          <RoadmapCatalog onOpen={player.openRoadmap} />
+          <>
+            {player.roadmapError !== null && (
+              <div style={styles.status}>
+                {player.roadmapError || t('learning.player.loadError')}
+              </div>
+            )}
+            {/* Single JSX position: the catalog must not remount (and refetch) when a load error appears. */}
+            <RoadmapCatalog onOpen={player.openRoadmap} />
+          </>
         )}
       </div>
     </div>
@@ -92,12 +95,16 @@ const styles: Record<string, React.CSSProperties> = {
     overflowY: 'auto',
     padding: '16px',
   },
+  loading: {
+    fontSize: '12px',
+    color: 'var(--color-text-muted)',
+    textAlign: 'center',
+    padding: '24px 16px',
+  },
   status: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '12px',
     fontSize: '12px',
     color: 'var(--color-danger)',
     lineHeight: 1.5,
+    marginBottom: '12px',
   },
 };

--- a/frontend/src/features/learning/components/RoadmapCatalog.tsx
+++ b/frontend/src/features/learning/components/RoadmapCatalog.tsx
@@ -52,7 +52,7 @@ export default function RoadmapCatalog({ onOpen }: RoadmapCatalogProps) {
               <span>{t(`learning.catalog.difficulty.${summary.difficulty}`)}</span>
             )}
             <span>{t('learning.catalog.steps', { count: summary.stepCount })}</span>
-            {summary.estimatedMinutes && (
+            {summary.estimatedMinutes != null && (
               <span>{t('learning.catalog.minutes', { count: summary.estimatedMinutes })}</span>
             )}
           </div>

--- a/frontend/src/features/learning/components/RoadmapCatalog.tsx
+++ b/frontend/src/features/learning/components/RoadmapCatalog.tsx
@@ -1,0 +1,135 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRoadmaps } from '../hooks/useRoadmaps';
+import type { RoadmapSummary } from '../../../shared/types/roadmap';
+
+interface RoadmapCatalogProps {
+  onOpen: (summary: RoadmapSummary) => void;
+}
+
+export default function RoadmapCatalog({ onOpen }: RoadmapCatalogProps) {
+  const { t } = useTranslation();
+  const { summaries, loading, error, fetchRoadmaps } = useRoadmaps();
+
+  useEffect(() => {
+    fetchRoadmaps();
+  }, [fetchRoadmaps]);
+
+  if (loading) {
+    return <div style={styles.status}>{t('learning.catalog.loading')}</div>;
+  }
+
+  if (error) {
+    return (
+      <div style={styles.status}>
+        <span>{t('learning.catalog.error')}</span>
+        <button onClick={fetchRoadmaps} style={styles.retryBtn}>
+          {t('learning.catalog.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  if (summaries.length === 0) {
+    return <div style={styles.status}>{t('learning.catalog.empty')}</div>;
+  }
+
+  return (
+    <div style={styles.list}>
+      {summaries.map(summary => (
+        <button
+          key={`${summary.id}-${summary.language}`}
+          onClick={() => onOpen(summary)}
+          style={styles.card}
+        >
+          <div style={styles.cardHeader}>
+            <span style={styles.cardTitle}>{summary.title}</span>
+            <span style={styles.languageBadge}>{summary.language.toUpperCase()}</span>
+          </div>
+          <span style={styles.cardDescription}>{summary.description}</span>
+          <div style={styles.cardMeta}>
+            {summary.difficulty && (
+              <span>{t(`learning.catalog.difficulty.${summary.difficulty}`)}</span>
+            )}
+            <span>{t('learning.catalog.steps', { count: summary.stepCount })}</span>
+            {summary.estimatedMinutes && (
+              <span>{t('learning.catalog.minutes', { count: summary.estimatedMinutes })}</span>
+            )}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  status: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '12px',
+    padding: '24px 16px',
+    fontSize: '12px',
+    color: 'var(--color-text-muted)',
+    textAlign: 'center',
+  },
+  retryBtn: {
+    padding: '6px 14px',
+    border: '1px solid var(--border-color)',
+    borderRadius: '6px',
+    background: 'none',
+    color: 'var(--color-text-primary)',
+    fontSize: '12px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    padding: '12px',
+    border: '1px solid var(--border-color)',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+    cursor: 'pointer',
+    textAlign: 'left',
+    fontFamily: 'var(--font-sans)',
+  },
+  cardHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '8px',
+  },
+  cardTitle: {
+    fontSize: '13px',
+    fontWeight: 600,
+    color: 'var(--color-text-primary)',
+  },
+  languageBadge: {
+    fontSize: '10px',
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+    border: '1px solid var(--border-color)',
+    borderRadius: '4px',
+    padding: '1px 5px',
+    flexShrink: 0,
+  },
+  cardDescription: {
+    fontSize: '11px',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.5,
+  },
+  cardMeta: {
+    display: 'flex',
+    gap: '10px',
+    fontSize: '11px',
+    color: 'var(--color-text-muted)',
+  },
+};

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -1,0 +1,262 @@
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react';
+import StepValidationResults from './StepValidationResults';
+import type { useLearningPlayer } from '../hooks/useLearningPlayer';
+
+interface RoadmapPlayerProps {
+  player: ReturnType<typeof useLearningPlayer>;
+}
+
+export default function RoadmapPlayer({ player }: RoadmapPlayerProps) {
+  const { t } = useTranslation();
+  const {
+    roadmap,
+    currentStepIndex,
+    currentStep,
+    goToStep,
+    validating,
+    validationError,
+    resultsByStepId,
+    validateCurrentStep,
+    closeRoadmap,
+  } = player;
+
+  if (!roadmap || !currentStep) return null;
+
+  return (
+    <div style={styles.container}>
+      <button onClick={closeRoadmap} style={styles.backLink}>
+        <ArrowLeft size={13} style={{ marginRight: 5 }} />
+        {t('learning.player.backToCatalog')}
+      </button>
+      <span style={styles.roadmapTitle}>{roadmap.title}</span>
+
+      <div style={styles.stepList}>
+        {roadmap.steps.map((step, index) => {
+          const result = resultsByStepId[step.id];
+          const isCurrent = index === currentStepIndex;
+          return (
+            <button
+              key={step.id}
+              onClick={() => goToStep(index)}
+              style={{
+                ...styles.stepItem,
+                ...(isCurrent ? styles.stepItemCurrent : {}),
+              }}
+            >
+              <span style={styles.stepIndex}>{index + 1}.</span>
+              <span style={styles.stepItemTitle}>{step.title}</span>
+              {result && (
+                <span
+                  style={{
+                    ...styles.stepMarker,
+                    color: result.stepPassed ? 'var(--color-success)' : 'var(--color-danger)',
+                  }}
+                >
+                  {result.stepPassed ? '✓' : '✗'}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={styles.currentStep}>
+        <span style={styles.stepCounter}>
+          {t('learning.player.stepCounter', {
+            current: currentStepIndex + 1,
+            total: roadmap.steps.length,
+          })}
+        </span>
+        <span style={styles.stepTitle}>{currentStep.title}</span>
+        <p style={styles.instruction}>{currentStep.instruction}</p>
+      </div>
+
+      <div style={styles.navRow}>
+        <button
+          onClick={() => goToStep(currentStepIndex - 1)}
+          disabled={currentStepIndex === 0}
+          style={{ ...styles.navBtn, opacity: currentStepIndex === 0 ? 0.4 : 1 }}
+        >
+          <ChevronLeft size={13} />
+          {t('learning.player.previous')}
+        </button>
+        <button
+          onClick={() => goToStep(currentStepIndex + 1)}
+          disabled={currentStepIndex === roadmap.steps.length - 1}
+          style={{
+            ...styles.navBtn,
+            opacity: currentStepIndex === roadmap.steps.length - 1 ? 0.4 : 1,
+          }}
+        >
+          {t('learning.player.next')}
+          <ChevronRight size={13} />
+        </button>
+      </div>
+
+      <button
+        onClick={validateCurrentStep}
+        disabled={validating}
+        style={{ ...styles.validateBtn, opacity: validating ? 0.6 : 1 }}
+      >
+        {validating ? t('learning.player.validating') : t('learning.player.validate')}
+      </button>
+
+      {validationError !== null && (
+        <div style={styles.errorBox}>
+          <span>{validationError || t('learning.player.validationError')}</span>
+          <button onClick={validateCurrentStep} style={styles.retryBtn}>
+            {t('learning.player.retry')}
+          </button>
+        </div>
+      )}
+
+      {resultsByStepId[currentStep.id] && (
+        <StepValidationResults response={resultsByStepId[currentStep.id]} />
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '14px',
+  },
+  backLink: {
+    display: 'flex',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    padding: 0,
+    border: 'none',
+    background: 'none',
+    color: 'var(--color-text-muted)',
+    fontSize: '11px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+  },
+  roadmapTitle: {
+    fontSize: '14px',
+    fontWeight: 700,
+    color: 'var(--color-text-primary)',
+    lineHeight: 1.4,
+  },
+  stepList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  stepItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '7px 10px',
+    border: '1px solid transparent',
+    borderRadius: '6px',
+    background: 'none',
+    cursor: 'pointer',
+    textAlign: 'left',
+    fontFamily: 'var(--font-sans)',
+    color: 'var(--color-text-secondary)',
+  },
+  stepItemCurrent: {
+    border: '1px solid var(--color-accent)',
+    backgroundColor: 'rgba(59, 130, 246, 0.06)',
+    color: 'var(--color-text-primary)',
+  },
+  stepIndex: {
+    fontSize: '11px',
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+  },
+  stepItemTitle: {
+    fontSize: '12px',
+    fontWeight: 500,
+    flex: 1,
+  },
+  stepMarker: {
+    fontSize: '12px',
+    fontWeight: 700,
+  },
+  currentStep: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    borderTop: '1px solid var(--border-color)',
+    paddingTop: '12px',
+  },
+  stepCounter: {
+    fontSize: '10px',
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+  },
+  stepTitle: {
+    fontSize: '13px',
+    fontWeight: 600,
+    color: 'var(--color-text-primary)',
+  },
+  instruction: {
+    margin: 0,
+    fontSize: '12px',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.6,
+    whiteSpace: 'pre-wrap',
+  },
+  navRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '8px',
+  },
+  navBtn: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '2px',
+    padding: '5px 10px',
+    border: '1px solid var(--border-color)',
+    borderRadius: '6px',
+    background: 'none',
+    color: 'var(--color-text-primary)',
+    fontSize: '11px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+  },
+  validateBtn: {
+    padding: '9px 12px',
+    border: 'none',
+    borderRadius: '6px',
+    backgroundColor: 'var(--color-accent)',
+    color: '#FFFFFF',
+    fontSize: '13px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+  },
+  errorBox: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    padding: '10px',
+    border: '1px solid var(--color-danger)',
+    borderRadius: '6px',
+    fontSize: '12px',
+    color: 'var(--color-danger)',
+    lineHeight: 1.5,
+  },
+  retryBtn: {
+    alignSelf: 'flex-start',
+    padding: '5px 12px',
+    border: '1px solid var(--border-color)',
+    borderRadius: '6px',
+    background: 'none',
+    color: 'var(--color-text-primary)',
+    fontSize: '11px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+  },
+};

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -23,6 +23,9 @@ export default function RoadmapPlayer({ player }: RoadmapPlayerProps) {
 
   if (!roadmap || !currentStep) return null;
 
+  const atFirstStep = currentStepIndex === 0;
+  const atLastStep = currentStepIndex === roadmap.steps.length - 1;
+
   return (
     <div style={styles.container}>
       <button onClick={closeRoadmap} style={styles.backLink}>
@@ -75,19 +78,16 @@ export default function RoadmapPlayer({ player }: RoadmapPlayerProps) {
       <div style={styles.navRow}>
         <button
           onClick={() => goToStep(currentStepIndex - 1)}
-          disabled={currentStepIndex === 0}
-          style={{ ...styles.navBtn, opacity: currentStepIndex === 0 ? 0.4 : 1 }}
+          disabled={atFirstStep}
+          style={{ ...styles.navBtn, opacity: atFirstStep ? 0.4 : 1 }}
         >
           <ChevronLeft size={13} />
           {t('learning.player.previous')}
         </button>
         <button
           onClick={() => goToStep(currentStepIndex + 1)}
-          disabled={currentStepIndex === roadmap.steps.length - 1}
-          style={{
-            ...styles.navBtn,
-            opacity: currentStepIndex === roadmap.steps.length - 1 ? 0.4 : 1,
-          }}
+          disabled={atLastStep}
+          style={{ ...styles.navBtn, opacity: atLastStep ? 0.4 : 1 }}
         >
           {t('learning.player.next')}
           <ChevronRight size={13} />

--- a/frontend/src/features/learning/components/StepValidationResults.tsx
+++ b/frontend/src/features/learning/components/StepValidationResults.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from 'react-i18next';
+import type { StepValidationResponse, ValidatorResult } from '../../../shared/types/roadmap';
+
+interface StepValidationResultsProps {
+  response: StepValidationResponse;
+}
+
+// P-1 scope: a deliberately raw rendering of the engine's report.
+// P-2 turns this into the real ✓/✗/⚠ pedagogical feedback.
+export default function StepValidationResults({ response }: StepValidationResultsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div style={styles.container}>
+      <div
+        style={{
+          ...styles.banner,
+          color: response.stepPassed ? 'var(--color-success)' : 'var(--color-danger)',
+        }}
+      >
+        {response.stepPassed ? t('learning.player.stepPassed') : t('learning.player.stepFailed')}
+      </div>
+      {response.results.map(result => (
+        <ResultBlock key={result.index} result={result} />
+      ))}
+    </div>
+  );
+}
+
+function ResultBlock({ result }: { result: ValidatorResult }) {
+  const { t } = useTranslation();
+  const statusColor =
+    result.status === 'pass'
+      ? 'var(--color-success)'
+      : result.status === 'fail'
+        ? 'var(--color-danger)'
+        : 'var(--color-text-muted)';
+
+  return (
+    <div style={styles.result}>
+      <div style={styles.resultHeader}>
+        <span style={{ ...styles.resultStatus, color: statusColor }}>[{result.status}]</span>
+        <span style={styles.resultType}>{result.type}</span>
+        {result.errorCode && <span style={styles.errorCode}>{result.errorCode}</span>}
+      </div>
+      <div style={styles.resultMessage}>{result.message}</div>
+      {result.expected && (
+        <div style={styles.detailLine}>
+          <span style={styles.detailLabel}>{t('learning.player.expected')}:</span> {result.expected}
+        </div>
+      )}
+      {result.observed && (
+        <div style={styles.detailLine}>
+          <span style={styles.detailLabel}>{t('learning.player.observed')}:</span> {result.observed}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  banner: {
+    fontSize: '13px',
+    fontWeight: 700,
+  },
+  result: {
+    border: '1px solid var(--border-color)',
+    borderRadius: '6px',
+    padding: '8px 10px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  resultHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    fontFamily: 'var(--font-mono)',
+    fontSize: '11px',
+  },
+  resultStatus: {
+    fontWeight: 700,
+  },
+  resultType: {
+    color: 'var(--color-text-secondary)',
+  },
+  errorCode: {
+    color: 'var(--color-text-muted)',
+    marginLeft: 'auto',
+  },
+  resultMessage: {
+    fontSize: '12px',
+    color: 'var(--color-text-primary)',
+    lineHeight: 1.5,
+  },
+  detailLine: {
+    fontSize: '11px',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.4,
+  },
+  detailLabel: {
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+  },
+};

--- a/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLearningPlayer } from './useLearningPlayer';
+import type { Roadmap, StepValidationResponse } from '../../../shared/types/roadmap';
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as Response;
+}
+
+const roadmap: Roadmap = {
+  schemaVersion: 1,
+  id: 'example-first-architecture',
+  title: 'Your first architecture',
+  description: 'Build a minimal two-tier architecture.',
+  language: 'en',
+  steps: [
+    {
+      id: 'create-web-server',
+      title: 'Create the web server',
+      instruction: 'Drag an Ubuntu node named `web` onto the canvas and start it.',
+      validators: [{ type: 'container_running', params: { node: 'web' } }],
+    },
+    {
+      id: 'add-database',
+      title: 'Add the database',
+      instruction: 'Add a Postgres node named `db`.',
+      validators: [{ type: 'container_running', params: { node: 'db' } }],
+    },
+  ],
+};
+
+const passResponse: StepValidationResponse = {
+  roadmapId: roadmap.id,
+  stepId: 'create-web-server',
+  stepPassed: true,
+  results: [{ index: 0, type: 'container_running', status: 'pass', message: 'Running.' }],
+  checkedAt: '2026-07-15T10:00:00.000Z',
+};
+
+async function openExampleRoadmap(
+  result: { current: ReturnType<typeof useLearningPlayer> },
+  fetchMock: ReturnType<typeof vi.fn>
+) {
+  fetchMock.mockResolvedValueOnce(jsonResponse(true, roadmap));
+  await act(async () => {
+    await result.current.openRoadmap({ id: roadmap.id, language: 'en' });
+  });
+}
+
+describe('useLearningPlayer', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    errorSpy.mockRestore();
+  });
+
+  describe('openRoadmap', () => {
+    it('loads the roadmap for the (id, language) pair and starts on step 1', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/learning/roadmaps/example-first-architecture?language=en')
+      );
+      expect(result.current.roadmap).toEqual(roadmap);
+      expect(result.current.currentStepIndex).toBe(0);
+      expect(result.current.currentStep?.id).toBe('create-web-server');
+    });
+
+    it('surfaces the server error message on a non-ok response', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(false, { error: 'No roadmap found with id "nope".', code: 'ROADMAP_NOT_FOUND' })
+      );
+
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await act(async () => {
+        await result.current.openRoadmap({ id: 'nope', language: 'en' });
+      });
+
+      expect(result.current.roadmap).toBeNull();
+      expect(result.current.roadmapError).toBe('No roadmap found with id "nope".');
+    });
+
+    it('sets a generic error when the backend is unreachable, and retry succeeds', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await act(async () => {
+        await result.current.openRoadmap({ id: roadmap.id, language: 'en' });
+      });
+      expect(result.current.roadmapError).toBe('');
+
+      await openExampleRoadmap(result, fetchMock);
+      expect(result.current.roadmapError).toBeNull();
+      expect(result.current.roadmap).toEqual(roadmap);
+    });
+  });
+
+  describe('goToStep', () => {
+    it('navigates and clamps to the step range', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      act(() => result.current.goToStep(1));
+      expect(result.current.currentStep?.id).toBe('add-database');
+
+      act(() => result.current.goToStep(99));
+      expect(result.current.currentStepIndex).toBe(1);
+
+      act(() => result.current.goToStep(-5));
+      expect(result.current.currentStepIndex).toBe(0);
+    });
+  });
+
+  describe('validateCurrentStep', () => {
+    it('posts the current step and stores the response under its step id', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, passResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        expect.stringContaining('/api/learning/validate'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            projectId: 'p1',
+            roadmapId: roadmap.id,
+            stepId: 'create-web-server',
+          }),
+        })
+      );
+      expect(result.current.resultsByStepId['create-web-server']).toEqual(passResponse);
+    });
+
+    it('keeps a step result when navigating away and back', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, passResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+
+      act(() => result.current.goToStep(1));
+      act(() => result.current.goToStep(0));
+
+      expect(result.current.resultsByStepId['create-web-server']).toEqual(passResponse);
+    });
+
+    it('sends a single request when validate is triggered twice synchronously', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+      const callsAfterOpen = fetchMock.mock.calls.length;
+
+      fetchMock.mockResolvedValue(jsonResponse(true, passResponse));
+      await act(async () => {
+        const first = result.current.validateCurrentStep();
+        const second = result.current.validateCurrentStep();
+        await Promise.all([first, second]);
+      });
+
+      expect(fetchMock.mock.calls.length).toBe(callsAfterOpen + 1);
+    });
+
+    it('sets a generic validation error when the backend is unreachable, without storing a result', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockRejectedValueOnce(new Error('network down'));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+
+      expect(result.current.validationError).toBe('');
+      expect(result.current.resultsByStepId).toEqual({});
+      expect(result.current.validating).toBe(false);
+    });
+
+    it('surfaces the server error on a non-ok response and recovers on retry', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(false, { error: 'No project found with id "p1".', code: 'PROJECT_NOT_FOUND' })
+      );
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(result.current.validationError).toBe('No project found with id "p1".');
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, passResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(result.current.validationError).toBeNull();
+      expect(result.current.resultsByStepId['create-web-server']).toEqual(passResponse);
+    });
+
+    it('clears the validation error when navigating between steps', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockRejectedValueOnce(new Error('network down'));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(result.current.validationError).not.toBeNull();
+
+      act(() => result.current.goToStep(1));
+      expect(result.current.validationError).toBeNull();
+    });
+  });
+
+  describe('closeRoadmap', () => {
+    it('returns to the catalogue state and drops in-memory results', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, passResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+
+      act(() => result.current.closeRoadmap());
+
+      expect(result.current.roadmap).toBeNull();
+      expect(result.current.resultsByStepId).toEqual({});
+      expect(result.current.currentStepIndex).toBe(0);
+    });
+  });
+});

--- a/frontend/src/features/learning/hooks/useLearningPlayer.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.ts
@@ -1,0 +1,132 @@
+import { useState, useCallback, useRef } from 'react';
+import { API_BASE } from '../../../shared/types';
+import type {
+  Roadmap,
+  RoadmapStep,
+  RoadmapSummary,
+  StepValidationResponse,
+} from '../../../shared/types/roadmap';
+
+interface UseLearningPlayerOptions {
+  projectId: string;
+}
+
+async function readErrorMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = await res.json();
+    return body?.error || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * State of one roadmap play-through: the opened roadmap, the current step,
+ * and the validation results per step. Everything lives in memory — losing
+ * it on reload is the accepted P-1 scope; persistence is P-4.
+ *
+ * Error fields hold the server-provided message when there is one, or ''
+ * for a generic failure (network down) — the component falls back to an
+ * i18n label so the hook stays translation-free.
+ */
+export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
+  const [roadmap, setRoadmap] = useState<Roadmap | null>(null);
+  const [roadmapLoading, setRoadmapLoading] = useState(false);
+  const [roadmapError, setRoadmapError] = useState<string | null>(null);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [validating, setValidating] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [resultsByStepId, setResultsByStepId] = useState<Record<string, StepValidationResponse>>({});
+  // React state updates are async, so `validating` alone cannot stop two
+  // synchronous clicks — the ref is the actual double-submit guard.
+  const validatingRef = useRef(false);
+
+  const currentStep: RoadmapStep | null = roadmap?.steps[currentStepIndex] ?? null;
+
+  const openRoadmap = useCallback(
+    async ({ id, language }: Pick<RoadmapSummary, 'id' | 'language'>) => {
+      try {
+        setRoadmapLoading(true);
+        setRoadmapError(null);
+        const res = await fetch(
+          `${API_BASE}/api/learning/roadmaps/${encodeURIComponent(id)}?language=${encodeURIComponent(language)}`
+        );
+        if (!res.ok) {
+          setRoadmapError(await readErrorMessage(res, ''));
+          return;
+        }
+        setRoadmap(await res.json());
+        setCurrentStepIndex(0);
+        setResultsByStepId({});
+        setValidationError(null);
+      } catch (err) {
+        console.error('Failed to load roadmap:', err);
+        setRoadmapError('');
+      } finally {
+        setRoadmapLoading(false);
+      }
+    },
+    []
+  );
+
+  const closeRoadmap = useCallback(() => {
+    setRoadmap(null);
+    setRoadmapError(null);
+    setCurrentStepIndex(0);
+    setResultsByStepId({});
+    setValidationError(null);
+  }, []);
+
+  const goToStep = useCallback(
+    (index: number) => {
+      if (!roadmap) return;
+      setCurrentStepIndex(Math.max(0, Math.min(index, roadmap.steps.length - 1)));
+      // A transport error is about the attempt, not the step; results stay.
+      setValidationError(null);
+    },
+    [roadmap]
+  );
+
+  const validateCurrentStep = useCallback(async () => {
+    if (validatingRef.current || !roadmap || !currentStep) return;
+    validatingRef.current = true;
+    try {
+      setValidating(true);
+      setValidationError(null);
+      const res = await fetch(`${API_BASE}/api/learning/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId, roadmapId: roadmap.id, stepId: currentStep.id }),
+      });
+      if (!res.ok) {
+        // Per the learning API contract, 4xx/5xx mean the request was wrong
+        // or the server crashed — never "the learner hasn't finished".
+        setValidationError(await readErrorMessage(res, ''));
+        return;
+      }
+      const response: StepValidationResponse = await res.json();
+      setResultsByStepId(prev => ({ ...prev, [currentStep.id]: response }));
+    } catch (err) {
+      console.error('Failed to validate step:', err);
+      setValidationError('');
+    } finally {
+      validatingRef.current = false;
+      setValidating(false);
+    }
+  }, [projectId, roadmap, currentStep]);
+
+  return {
+    roadmap,
+    roadmapLoading,
+    roadmapError,
+    openRoadmap,
+    closeRoadmap,
+    currentStepIndex,
+    currentStep,
+    goToStep,
+    validating,
+    validationError,
+    resultsByStepId,
+    validateCurrentStep,
+  };
+}

--- a/frontend/src/features/learning/hooks/useLearningPlayer.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { API_BASE } from '../../../shared/types';
+import { readErrorMessage } from '../../../shared/utils/readErrorMessage';
 import type {
   Roadmap,
   RoadmapStep,
@@ -9,15 +10,6 @@ import type {
 
 interface UseLearningPlayerOptions {
   projectId: string;
-}
-
-async function readErrorMessage(res: Response, fallback: string): Promise<string> {
-  try {
-    const body = await res.json();
-    return body?.error || fallback;
-  } catch {
-    return fallback;
-  }
 }
 
 /**
@@ -40,30 +32,41 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
   // React state updates are async, so `validating` alone cannot stop two
   // synchronous clicks — the ref is the actual double-submit guard.
   const validatingRef = useRef(false);
+  // Two quick openRoadmap clicks race on fetch resolution order; only the
+  // latest request is allowed to commit its result.
+  const openSeqRef = useRef(0);
 
   const currentStep: RoadmapStep | null = roadmap?.steps[currentStepIndex] ?? null;
 
   const openRoadmap = useCallback(
     async ({ id, language }: Pick<RoadmapSummary, 'id' | 'language'>) => {
+      const seq = ++openSeqRef.current;
       try {
         setRoadmapLoading(true);
         setRoadmapError(null);
         const res = await fetch(
           `${API_BASE}/api/learning/roadmaps/${encodeURIComponent(id)}?language=${encodeURIComponent(language)}`
         );
+        if (seq !== openSeqRef.current) return;
         if (!res.ok) {
           setRoadmapError(await readErrorMessage(res, ''));
           return;
         }
-        setRoadmap(await res.json());
+        const data = await res.json();
+        if (seq !== openSeqRef.current) return;
+        if (!Array.isArray(data?.steps) || data.steps.length === 0) {
+          setRoadmapError('');
+          return;
+        }
+        setRoadmap(data);
         setCurrentStepIndex(0);
         setResultsByStepId({});
         setValidationError(null);
       } catch (err) {
         console.error('Failed to load roadmap:', err);
-        setRoadmapError('');
+        if (seq === openSeqRef.current) setRoadmapError('');
       } finally {
-        setRoadmapLoading(false);
+        if (seq === openSeqRef.current) setRoadmapLoading(false);
       }
     },
     []

--- a/frontend/src/features/learning/hooks/useRoadmaps.test.ts
+++ b/frontend/src/features/learning/hooks/useRoadmaps.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRoadmaps } from './useRoadmaps';
+import type { RoadmapSummary } from '../../../shared/types/roadmap';
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as Response;
+}
+
+const summaries: RoadmapSummary[] = [
+  {
+    id: 'example-first-architecture',
+    title: 'Your first architecture',
+    description: 'Build a minimal two-tier architecture.',
+    language: 'en',
+    difficulty: 'beginner',
+    estimatedMinutes: 30,
+    stepCount: 4,
+  },
+];
+
+describe('useRoadmaps', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('populates summaries from a successful fetch', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(true, summaries));
+
+    const { result } = renderHook(() => useRoadmaps());
+    await act(async () => {
+      await result.current.fetchRoadmaps();
+    });
+
+    expect(result.current.summaries).toEqual(summaries);
+    expect(result.current.error).toBe(false);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/learning/roadmaps'));
+  });
+
+  it('flags an error on a non-array response body', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(true, { unexpected: 'shape' }));
+
+    const { result } = renderHook(() => useRoadmaps());
+    await act(async () => {
+      await result.current.fetchRoadmaps();
+    });
+
+    expect(result.current.summaries).toEqual([]);
+    expect(result.current.error).toBe(true);
+  });
+
+  it('flags an error when the backend is unreachable, and retry clears it', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(jsonResponse(true, summaries));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useRoadmaps());
+    await act(async () => {
+      await result.current.fetchRoadmaps();
+    });
+    expect(result.current.error).toBe(true);
+
+    await act(async () => {
+      await result.current.fetchRoadmaps();
+    });
+    expect(result.current.error).toBe(false);
+    expect(result.current.summaries).toEqual(summaries);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/frontend/src/features/learning/hooks/useRoadmaps.ts
+++ b/frontend/src/features/learning/hooks/useRoadmaps.ts
@@ -1,0 +1,35 @@
+import { useState, useCallback } from 'react';
+import { API_BASE } from '../../../shared/types';
+import type { RoadmapSummary } from '../../../shared/types/roadmap';
+
+/**
+ * Loads the roadmap catalogue (GET /api/learning/roadmaps).
+ * The caller triggers the initial fetch (mount effect) and retries by
+ * calling `fetchRoadmaps` again — same pattern as useContainers.
+ */
+export function useRoadmaps() {
+  const [summaries, setSummaries] = useState<RoadmapSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const fetchRoadmaps = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(false);
+      const res = await fetch(`${API_BASE}/api/learning/roadmaps`);
+      const data = await res.json();
+      if (res.ok && Array.isArray(data)) {
+        setSummaries(data);
+      } else {
+        setError(true);
+      }
+    } catch (err) {
+      console.error('Failed to fetch roadmaps:', err);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { summaries, loading, error, fetchRoadmaps };
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4,7 +4,41 @@
     "trafficSimulator": "Traffic Simulator",
     "saveGraph": "Save Graph",
     "backToProjects": "Back to Projects",
-    "refreshNodes": "Refresh Nodes"
+    "refreshNodes": "Refresh Nodes",
+    "learning": "Learning"
+  },
+  "learning": {
+    "panelTitle": "Learning",
+    "close": "Close panel",
+    "catalog": {
+      "loading": "Loading roadmaps...",
+      "error": "Could not load roadmaps. Is the backend running?",
+      "retry": "Retry",
+      "empty": "No roadmaps available.",
+      "steps": "{{count}} steps",
+      "minutes": "~{{count}} min",
+      "difficulty": {
+        "beginner": "Beginner",
+        "intermediate": "Intermediate",
+        "advanced": "Advanced"
+      }
+    },
+    "player": {
+      "backToCatalog": "All roadmaps",
+      "loading": "Loading roadmap...",
+      "loadError": "Could not load this roadmap. Pick one below to try again.",
+      "stepCounter": "Step {{current}} of {{total}}",
+      "previous": "Previous",
+      "next": "Next",
+      "validate": "Validate",
+      "validating": "Checking...",
+      "validationError": "Could not reach the server. Your work is untouched — try again.",
+      "retry": "Retry",
+      "stepPassed": "Step passed",
+      "stepFailed": "Not yet — see the results below",
+      "expected": "Expected",
+      "observed": "Observed"
+    }
   },
   "projects": {
     "title": "Torollo Projects",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -15,7 +15,8 @@
       "error": "Could not load roadmaps. Is the backend running?",
       "retry": "Retry",
       "empty": "No roadmaps available.",
-      "steps": "{{count}} steps",
+      "steps_one": "{{count}} step",
+      "steps_other": "{{count}} steps",
       "minutes": "~{{count}} min",
       "difficulty": {
         "beginner": "Beginner",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -4,7 +4,41 @@
     "trafficSimulator": "Simulateur de Trafic",
     "saveGraph": "Enregistrer le Graphe",
     "backToProjects": "Retour aux Projets",
-    "refreshNodes": "Actualiser les Nœuds"
+    "refreshNodes": "Actualiser les Nœuds",
+    "learning": "Apprentissage"
+  },
+  "learning": {
+    "panelTitle": "Apprentissage",
+    "close": "Fermer le panneau",
+    "catalog": {
+      "loading": "Chargement des roadmaps...",
+      "error": "Impossible de charger les roadmaps. Le backend est-il démarré ?",
+      "retry": "Réessayer",
+      "empty": "Aucune roadmap disponible.",
+      "steps": "{{count}} étapes",
+      "minutes": "~{{count}} min",
+      "difficulty": {
+        "beginner": "Débutant",
+        "intermediate": "Intermédiaire",
+        "advanced": "Avancé"
+      }
+    },
+    "player": {
+      "backToCatalog": "Toutes les roadmaps",
+      "loading": "Chargement de la roadmap...",
+      "loadError": "Impossible de charger cette roadmap. Choisissez-en une ci-dessous pour réessayer.",
+      "stepCounter": "Étape {{current}} sur {{total}}",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "validate": "Valider",
+      "validating": "Vérification...",
+      "validationError": "Impossible de joindre le serveur. Votre travail est intact — réessayez.",
+      "retry": "Réessayer",
+      "stepPassed": "Étape validée",
+      "stepFailed": "Pas encore — voir les résultats ci-dessous",
+      "expected": "Attendu",
+      "observed": "Observé"
+    }
   },
   "projects": {
     "title": "Projets Torollo",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -15,7 +15,8 @@
       "error": "Impossible de charger les roadmaps. Le backend est-il démarré ?",
       "retry": "Réessayer",
       "empty": "Aucune roadmap disponible.",
-      "steps": "{{count}} étapes",
+      "steps_one": "{{count}} étape",
+      "steps_other": "{{count}} étapes",
       "minutes": "~{{count}} min",
       "difficulty": {
         "beginner": "Débutant",

--- a/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.test.tsx
@@ -560,4 +560,22 @@ describe('CanvasPage', () => {
     await waitFor(() => expect(screen.getByText('A node named "web-1" already exists in this project.')).toBeInTheDocument());
     expect(fetchMock.mock.calls.some(c => (c[0] as string).endsWith('/containers') && (c[1] as RequestInit | undefined)?.method === 'POST')).toBe(false);
   });
+
+  it('mounts the learning panel from the topbar button and unmounts it on close, touching /api/learning only while open', async () => {
+    const fetchMock = buildFetchMock({ containers: [], networkConfig: { vpcConfig: validVpcConfig, subnets: [], nodeSubnetMap: {}, nodeSecurityGroups: {}, nodeIpMap: {} } });
+    await renderCanvasPage(fetchMock);
+
+    // Closed panel = strictly unchanged canvas: not mounted, zero learning fetches.
+    expect(screen.queryByTitle('Close panel')).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls.some(c => (c[0] as string).includes('/api/learning'))).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: /Learning/ }));
+    expect(screen.getByTitle('Close panel')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(c => (c[0] as string).includes('/api/learning/roadmaps'))).toBe(true)
+    );
+
+    fireEvent.click(screen.getByTitle('Close panel'));
+    expect(screen.queryByTitle('Close panel')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -13,6 +13,7 @@ import AsgNode from '../../features/nodes/AsgNode/AsgNode';
 import VpcNode from '../../features/nodes/VpcNode/VpcNode';
 import SubnetNode from '../../features/nodes/SubnetNode/SubnetNode';
 import NodeLibrary from './components/NodeLibrary';
+import LearningPanel from '../../features/learning/components/LearningPanel';
 import { useContainers } from '../../shared/hooks/useContainers';
 import { useToast } from '../../shared/hooks/useToast';
 import { ToastNotification } from '../../shared/components/Toast';
@@ -118,6 +119,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
   const [showVpcSettings, setShowVpcSettings] = useState(false);
   const [showTrafficSimulator, setShowTrafficSimulator] = useState(false);
+  const [showLearning, setShowLearning] = useState(false);
 
   const nodeTypes = useMemo(() => ({
     ubuntu: UbuntuNode,
@@ -568,9 +570,14 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         onSave={saveGraphLocally}
         onConfigureVpc={() => setShowVpcSettings(true)}
         onSimulateTraffic={() => setShowTrafficSimulator(true)}
+        onToggleLearning={() => setShowLearning(v => !v)}
       />
 
       <div style={styles.bodyWrapper}>
+        {showLearning && (
+          <LearningPanel projectId={projectId} onClose={() => setShowLearning(false)} />
+        )}
+
         {/* Main React Flow Workspace */}
         <div
           style={styles.canvasContainer}

--- a/frontend/src/pages/CanvasPage/components/CanvasTopbar.tsx
+++ b/frontend/src/pages/CanvasPage/components/CanvasTopbar.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, RefreshCw, Save, Network, Play } from 'lucide-react';
+import { ArrowLeft, RefreshCw, Save, Network, Play, GraduationCap } from 'lucide-react';
 import logo from '../../../assets/logo.png';
 import { useTranslation } from 'react-i18next';
 
@@ -11,6 +11,7 @@ interface CanvasTopbarProps {
   onSave: () => void;
   onConfigureVpc: () => void;
   onSimulateTraffic: () => void;
+  onToggleLearning: () => void;
 }
 
 declare const __APP_VERSION__: string;
@@ -23,6 +24,7 @@ export default function CanvasTopbar({
   onSave,
   onConfigureVpc,
   onSimulateTraffic,
+  onToggleLearning,
 }: CanvasTopbarProps) {
   const { t, i18n } = useTranslation();
 
@@ -61,6 +63,11 @@ export default function CanvasTopbar({
           title={t('topbar.refreshNodes')}
         >
           <RefreshCw size={16} className={loading ? 'spin' : ''} />
+        </button>
+
+        <button onClick={onToggleLearning} style={styles.saveBtn} title={t('topbar.learning')}>
+          <GraduationCap size={16} style={{ marginRight: 6 }} />
+          {t('topbar.learning')}
         </button>
 
         <button onClick={onConfigureVpc} style={styles.saveBtn} title={t('topbar.vpcSettings')}>

--- a/frontend/src/shared/hooks/useContainers.ts
+++ b/frontend/src/shared/hooks/useContainers.ts
@@ -2,19 +2,11 @@ import { useState, useCallback, useRef } from 'react';
 import { API_BASE } from '../types';
 import type { ContainerData } from '../types';
 import type { NotificationData } from './useToast';
+import { readErrorMessage } from '../utils/readErrorMessage';
 
 interface UseContainersOptions {
   projectId: string;
   onNotify?: (notification: NotificationData) => void;
-}
-
-async function readErrorMessage(res: Response, fallback: string): Promise<string> {
-  try {
-    const body = await res.json();
-    return body?.error || fallback;
-  } catch {
-    return fallback;
-  }
 }
 
 /**

--- a/frontend/src/shared/types/roadmap.ts
+++ b/frontend/src/shared/types/roadmap.ts
@@ -1,11 +1,16 @@
 /**
  * TypeScript types for the Torollo roadmap format, version 1.
  *
- * KEEP IN SYNC with backend/src/modules/learning/format/roadmapTypes.ts —
- * the duplication is deliberate: backend and frontend are separate npm
+ * KEEP IN SYNC with the backend sources —
+ * format types:  backend/src/modules/learning/format/roadmapTypes.ts
+ * API types:     backend/src/modules/learning/engine/types.ts (ValidatorResult),
+ *                controllers/learningController.ts (StepValidationResponse),
+ *                services/roadmapService.ts (RoadmapSummary).
+ * The duplication is deliberate: backend and frontend are separate npm
  * packages (same policy as the Project type in shared/types/index.ts).
  * Source of truth for the format is the JSON Schema:
  * backend/src/modules/learning/format/roadmap.schema.json
+ * API contract: docs/learning-api.md
  *
  * Format documentation: docs/roadmap-format.md
  */
@@ -45,4 +50,45 @@ export interface Roadmap {
   difficulty?: RoadmapDifficulty;
   prerequisites?: string[];
   steps: RoadmapStep[];
+}
+
+/** One catalogue entry of GET /api/learning/roadmaps — one per file, so translations are separate entries. */
+export interface RoadmapSummary {
+  id: string;
+  title: string;
+  description: string;
+  language: string;
+  difficulty?: RoadmapDifficulty;
+  estimatedMinutes?: number;
+  stepCount: number;
+}
+
+export type ValidatorStatus = 'pass' | 'fail' | 'error';
+
+/**
+ * Result of one validator, as returned by POST /api/learning/validate.
+ * `fail` is a pedagogical failure (normal state — the learner isn't done);
+ * `error` means the check itself could not run (never the learner's fault).
+ */
+export interface ValidatorResult {
+  /** Position in step.validators — the stable key of the result. */
+  index: number;
+  type: string;
+  status: ValidatorStatus;
+  message: string;
+  /** Set iff status is 'error'. Wider than the backend union: the frontend only displays it. */
+  errorCode?: string;
+  expected?: string;
+  observed?: string;
+}
+
+/** Response of POST /api/learning/validate. */
+export interface StepValidationResponse {
+  roadmapId: string;
+  stepId: string;
+  /** true iff every result is 'pass' — an 'error' never validates a step. */
+  stepPassed: boolean;
+  results: ValidatorResult[];
+  /** ISO timestamp of the evaluation. */
+  checkedAt: string;
 }

--- a/frontend/src/shared/utils/readErrorMessage.ts
+++ b/frontend/src/shared/utils/readErrorMessage.ts
@@ -1,0 +1,9 @@
+/** Extracts the backend's `{ error }` message from a failed response, or the fallback. */
+export async function readErrorMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = await res.json();
+    return body?.error || fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/roadmaps/example-first-architecture.json
+++ b/roadmaps/example-first-architecture.json
@@ -17,7 +17,7 @@
       "title": "Create the web server",
       "instruction": "From the node library, drag an **Ubuntu** node onto the canvas and name it `web`. Start it and wait until it is running.",
       "hints": [
-        "Nodes are created by dragging them from the library panel on the left side of the canvas."
+        "Nodes are created by dragging them from the library panel on the right side of the canvas."
       ],
       "validators": [
         {


### PR DESCRIPTION
## Summary of Changes

Adds the roadmap player: a sidebar next to the canvas that opens a roadmap, lists its steps with the current one highlighted, shows the instruction, and validates the current step against the **real** containers via `POST /api/learning/validate`. This closes the full loop: frontend → learning API → Docker → frontend, and gives new users a guided path instead of an empty canvas.

Deliberately deferred to follow-ups: rich ✓/✗ result presentation (this PR renders the raw validation report), a hints UI, and progression persistence (player state is in-memory).

**How it's built:**

- **New `frontend/src/features/learning/`** — `useRoadmaps` (catalogue) + `useLearningPlayer` (open/navigate/validate; per-step results kept when navigating; ref-based guard so double-clicking Validate sends one request; latest-open-wins guard) and 4 components (`LearningPanel`, `RoadmapCatalog`, `RoadmapPlayer`, `StepValidationResults`).
- **Minimal CanvasPage surface**: one `showLearning` state, one topbar button, one conditional sibling in the body row. Closed panel = nothing mounted, no learning endpoint touched (tested).
- **Error handling per the learning API contract** (`docs/learning-api.md`): non-2xx is a request/server problem — shown inline with retry, never as a learner failure.
- **Backend preamble** (first commit):
  - `POST /validate` without a JSON body now returns **400** instead of 500.
  - Roadmap selection key is now **(id, language)**: `GET /roadmaps/:id?language=` (exact match or 404), deterministic sorted pick without the param, `/validate` stays language-neutral. Documented in `docs/learning-api.md`.
- i18n (en/fr), styling on the shared CSS variables.

Also fixes the example roadmap's first hint (the node library is on the right side of the canvas, not the left).

## Types of Changes

- [x] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: 211 passing (new: 400-not-500 on non-JSON body, language forwarding, deterministic/exact/missing-translation selection, fr fixture). Frontend: 195 passing (new: 22 — both hooks, LearningPanel behavior incl. network-down + retry, CanvasPage mount/unmount with zero learning fetches while closed).

### Manual Verification

Verified against real Docker with curl: step 1 of the example roadmap fails on an empty project, passes after creating and starting the `web` node; `?language=de` → 404; garbage body → 400; the disposable test project was deleted with no container residue.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
