### PR TITLE
Feat/http validator and links

### DIFF
--- a/backend/src/infrastructure/docker/providers/containerProvider.ts
+++ b/backend/src/infrastructure/docker/providers/containerProvider.ts
@@ -32,6 +32,7 @@ export interface ContainerProvider {
   executePsqlCommand(containerId: string, database: string, sqlQuery: string, extraArgs?: string[]): Promise<string>;
   executeRedisCommand(containerId: string, args: string[]): Promise<string>;
   executeMongoCommand(containerId: string, evalExpression: string): Promise<string>;
+  executeCustomCommand(containerId: string, cmd: string[]): Promise<string>;
   markAsCrashed(instanceId: string): void;
   clearCrashed(instanceId: string): void;
   clearAllCrashed(): void;

--- a/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
+++ b/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
@@ -341,6 +341,10 @@ export class DockerContainerProvider implements ContainerProvider {
     return output;
   }
 
+  public async executeCustomCommand(containerId: string, cmd: string[]): Promise<string> {
+    return this.execCapture(containerId, cmd);
+  }
+
   public async commitContainer(id: string, repoName: string, tag: string = 'latest'): Promise<string> {
     try {
       const container = docker.getContainer(id);

--- a/backend/src/modules/learning/engine/engine.itest.ts
+++ b/backend/src/modules/learning/engine/engine.itest.ts
@@ -118,8 +118,8 @@ describe('learning engine — real containers (V-4)', () => {
         [nosql.id]: 'private',
       },
       nodeSecurityGroups: {
-        [web.id]: [
-          { id: 'sg-web-to-db', type: 'outbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: db.id },
+        [db.id]: [
+          { id: 'sg-web-to-db', type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: web.id },
         ],
       },
       loadBalancerTargets: {

--- a/backend/src/modules/learning/engine/engine.test.ts
+++ b/backend/src/modules/learning/engine/engine.test.ts
@@ -24,6 +24,7 @@ function makeDeps(impl?: EngineDeps['listContainersByProject']): EngineDeps & {
     executePsqlCommand: () => Promise.resolve(''),
     executeRedisCommand: () => Promise.resolve(''),
     executeMongoCommand: () => Promise.resolve(''),
+    executeCustomCommand: () => Promise.resolve(''),
   };
 }
 

--- a/backend/src/modules/learning/engine/engine.ts
+++ b/backend/src/modules/learning/engine/engine.ts
@@ -23,6 +23,8 @@ export const defaultEngineDeps: EngineDeps = {
   executeRedisCommand: (containerId, args) => containerProvider.executeRedisCommand(containerId, args),
   executeMongoCommand: (containerId, evalExpression) =>
     containerProvider.executeMongoCommand(containerId, evalExpression),
+  executeCustomCommand: (containerId, cmd) =>
+    containerProvider.executeCustomCommand(containerId, cmd),
 };
 
 /**
@@ -67,6 +69,8 @@ export async function runStepValidators(
     executeRedisCommand: (containerId, args) => deps.executeRedisCommand(containerId, args),
     executeMongoCommand: (containerId, evalExpression) =>
       deps.executeMongoCommand(containerId, evalExpression),
+    executeCustomCommand: (containerId, cmd) =>
+      deps.executeCustomCommand(containerId, cmd),
   };
 
   const results: ValidatorResult[] = [];

--- a/backend/src/modules/learning/engine/registry.ts
+++ b/backend/src/modules/learning/engine/registry.ts
@@ -7,6 +7,7 @@ import { edgeExists } from './validators/edgeExists';
 import { lbUpstreams } from './validators/lbUpstreams';
 import { portDenied } from './validators/portDenied';
 import { asgReplicas } from './validators/asgReplicas';
+import { httpGetContains } from './validators/httpGetContains';
 
 /**
  * The single extension point for validator types: adding a type to the
@@ -22,4 +23,5 @@ export const validatorRegistry: Readonly<Record<string, ValidatorHandler>> = {
   lb_upstreams: lbUpstreams,
   port_denied: portDenied,
   asg_replicas: asgReplicas,
+  http_get_contains: httpGetContains,
 };

--- a/backend/src/modules/learning/engine/types.ts
+++ b/backend/src/modules/learning/engine/types.ts
@@ -74,6 +74,7 @@ export interface ValidatorContext {
   ): Promise<string>;
   executeRedisCommand(containerId: string, args: string[]): Promise<string>;
   executeMongoCommand(containerId: string, evalExpression: string): Promise<string>;
+  executeCustomCommand(containerId: string, cmd: string[]): Promise<string>;
 }
 
 export type ValidatorHandler = (
@@ -93,4 +94,5 @@ export interface EngineDeps {
   ): Promise<string>;
   executeRedisCommand(containerId: string, args: string[]): Promise<string>;
   executeMongoCommand(containerId: string, evalExpression: string): Promise<string>;
+  executeCustomCommand(containerId: string, cmd: string[]): Promise<string>;
 }

--- a/backend/src/modules/learning/engine/validators/edgeExists.ts
+++ b/backend/src/modules/learning/engine/validators/edgeExists.ts
@@ -22,6 +22,7 @@ export const edgeExists: ValidatorHandler = async (params, ctx) => {
   const allowed = rules.some(
     (rule) =>
       rule.action === 'ALLOW' &&
+      rule.direction === 'inbound' &&
       rule.sourceNodeId === resolved.sourceContainer.id &&
       rule.targetNodeId === resolved.targetContainer.id &&
       (port === undefined || rule.port === 'ALL' || rule.port === String(port))

--- a/backend/src/modules/learning/engine/validators/httpGetContains.test.ts
+++ b/backend/src/modules/learning/engine/validators/httpGetContains.test.ts
@@ -1,0 +1,79 @@
+import { httpGetContains } from './httpGetContains';
+import { InvalidParamsError } from '../types';
+import { makeContainer, makeContext } from './testSupport';
+
+const web = makeContainer({ id: 'web-1', name: 'web' });
+
+describe('httpGetContains', () => {
+  it('passes when the server responds with expected text', async () => {
+    const mockExec = jest.fn().mockResolvedValue('<html><body>Users List</body></html>');
+    const outcome = await httpGetContains(
+      { node: 'web', port: 80, path: '/', expectedText: 'Users List' },
+      makeContext({
+        containers: [web],
+        executeCustomCommand: mockExec,
+      })
+    );
+
+    expect(outcome.status).toBe('pass');
+    expect(mockExec).toHaveBeenCalledWith('web-1', ['curl', '-s', 'http://localhost:80/']);
+  });
+
+  it('fails when no container has the given name', async () => {
+    const outcome = await httpGetContains(
+      { node: 'web', port: 80, path: '/', expectedText: 'Users List' },
+      makeContext({ containers: [] })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('No container named "web" exists');
+  });
+
+  it('fails when container is not running', async () => {
+    const outcome = await httpGetContains(
+      { node: 'web', port: 80, path: '/', expectedText: 'Users List' },
+      makeContext({
+        containers: [makeContainer({ name: 'web', state: 'exited' })],
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('is not running');
+  });
+
+  it('fails when server is down / connection refused', async () => {
+    const mockExec = jest.fn().mockResolvedValue('curl: (7) Failed to connect to localhost port 80');
+    const outcome = await httpGetContains(
+      { node: 'web', port: 80, path: '/', expectedText: 'Users List' },
+      makeContext({
+        containers: [web],
+        executeCustomCommand: mockExec,
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('Could not connect to the web server');
+    expect(outcome.observed).toContain('Failed to connect');
+  });
+
+  it('fails when response does not contain the expected text', async () => {
+    const mockExec = jest.fn().mockResolvedValue('Hello World');
+    const outcome = await httpGetContains(
+      { node: 'web', port: 80, path: '/', expectedText: 'Users List' },
+      makeContext({
+        containers: [web],
+        executeCustomCommand: mockExec,
+      })
+    );
+
+    expect(outcome.status).toBe('fail');
+    expect(outcome.message).toContain('did not return the expected content');
+    expect(outcome.observed).toBe('Hello World');
+  });
+
+  it('throws InvalidParamsError when params are missing', async () => {
+    await expect(
+      httpGetContains({ node: 'web', port: 80 }, makeContext())
+    ).rejects.toThrow(InvalidParamsError);
+  });
+});

--- a/backend/src/modules/learning/engine/validators/httpGetContains.ts
+++ b/backend/src/modules/learning/engine/validators/httpGetContains.ts
@@ -1,0 +1,71 @@
+import { ValidatorHandler } from '../types';
+import { requireStringParam, requireNumberParam } from '../params';
+
+/**
+ * `http_get_contains` — sends an HTTP GET request to localhost inside a container
+ * and checks if the response body contains a specific string.
+ * Params: `{ node: string, port: number, path: string, expectedText: string }`
+ */
+export const httpGetContains: ValidatorHandler = async (params, ctx) => {
+  const node = requireStringParam(params, 'node');
+  const port = requireNumberParam(params, 'port');
+  const path = requireStringParam(params, 'path');
+  const expectedText = requireStringParam(params, 'expectedText');
+
+  const containers = await ctx.getContainers();
+  const container = containers.find(c => c.name === node);
+
+  if (!container) {
+    return {
+      status: 'fail',
+      message: `No container named "${node}" exists in this project yet.`,
+      expected: `a running container named "${node}"`,
+      observed: 'no container with that name',
+    };
+  }
+
+  if (container.state !== 'running') {
+    return {
+      status: 'fail',
+      message: `The container "${node}" is not running.`,
+      expected: 'running',
+      observed: container.state,
+    };
+  }
+
+  try {
+    // Run curl inside the target container to retrieve the page content
+    const url = `http://localhost:${port}${path}`;
+    const output = await ctx.executeCustomCommand(container.id, ['curl', '-s', url]);
+
+    if (!output || output.includes('Failed to connect') || output.includes('Connection refused')) {
+      return {
+        status: 'fail',
+        message: `Could not connect to the web server on port ${port} inside container "${node}". Make sure your server is started and listening.`,
+        expected: `a successful response from ${url}`,
+        observed: output || 'no response (connection refused)',
+      };
+    }
+
+    if (!output.includes(expectedText)) {
+      return {
+        status: 'fail',
+        message: `The web server at ${url} did not return the expected content.`,
+        expected: `response body containing "${expectedText}"`,
+        observed: output.length > 200 ? output.substring(0, 200) + '...' : output,
+      };
+    }
+
+    return {
+      status: 'pass',
+      message: `Successfully connected to ${url} and verified the response contains "${expectedText}".`,
+    };
+  } catch (err: unknown) {
+    return {
+      status: 'fail',
+      message: `Failed to communicate with the web server: ${(err as Error).message}`,
+      expected: `response containing "${expectedText}"`,
+      observed: `error: ${(err as Error).message}`,
+    };
+  }
+};

--- a/backend/src/modules/learning/engine/validators/portDenied.ts
+++ b/backend/src/modules/learning/engine/validators/portDenied.ts
@@ -23,6 +23,7 @@ export const portDenied: ValidatorHandler = async (params, ctx) => {
   const openRule = rules.find(
     (rule) =>
       rule.action === 'ALLOW' &&
+      rule.direction === 'inbound' &&
       rule.sourceNodeId === resolved.sourceContainer.id &&
       rule.targetNodeId === resolved.targetContainer.id &&
       (rule.port === 'ALL' || rule.port === String(port))

--- a/backend/src/modules/learning/engine/validators/testSupport.ts
+++ b/backend/src/modules/learning/engine/validators/testSupport.ts
@@ -21,6 +21,7 @@ interface ContextOverrides {
   executePsqlCommand?: ValidatorContext['executePsqlCommand'];
   executeRedisCommand?: ValidatorContext['executeRedisCommand'];
   executeMongoCommand?: ValidatorContext['executeMongoCommand'];
+  executeCustomCommand?: ValidatorContext['executeCustomCommand'];
 }
 
 export function makeContext(overrides: ContextOverrides = {}): ValidatorContext {
@@ -32,6 +33,7 @@ export function makeContext(overrides: ContextOverrides = {}): ValidatorContext 
     executePsqlCommand: overrides.executePsqlCommand ?? (() => Promise.resolve('')),
     executeRedisCommand: overrides.executeRedisCommand ?? (() => Promise.resolve('')),
     executeMongoCommand: overrides.executeMongoCommand ?? (() => Promise.resolve('')),
+    executeCustomCommand: overrides.executeCustomCommand ?? (() => Promise.resolve('')),
   };
 }
 

--- a/backend/src/modules/learning/engine/validators/testSupport.ts
+++ b/backend/src/modules/learning/engine/validators/testSupport.ts
@@ -42,7 +42,7 @@ export function makeSemanticRule(overrides: Partial<SemanticRule>): SemanticRule
     protocol: 'tcp',
     port: 'ALL',
     action: 'ALLOW',
-    direction: 'outbound',
+    direction: 'inbound',
     ownerNodeId: 'src',
     ...overrides,
   };

--- a/frontend/src/features/learning/components/LearningPanel.test.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.test.tsx
@@ -130,7 +130,7 @@ describe('LearningPanel', () => {
     expect(screen.getByText('Add the database')).toBeInTheDocument();
     expect(screen.getByText('Step 1 of 2')).toBeInTheDocument();
     expect(
-      screen.getByText('Drag an Ubuntu node named `web` onto the canvas and start it.')
+      screen.getByText((_, el) => el?.tagName === 'P' && el.textContent === 'Drag an Ubuntu node named web onto the canvas and start it.')
     ).toBeInTheDocument();
   });
 
@@ -141,7 +141,9 @@ describe('LearningPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     expect(screen.getByText('Step 2 of 2')).toBeInTheDocument();
-    expect(screen.getByText('Add a Postgres node named `db`.')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, el) => el?.tagName === 'P' && el.textContent === 'Add a Postgres node named db.')
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Previous' }));
     expect(screen.getByText('Step 1 of 2')).toBeInTheDocument();

--- a/frontend/src/features/learning/components/LearningPanel.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.tsx
@@ -27,7 +27,7 @@ export default function LearningPanel({
     subnets: [],
     nodeSubnetMap: {},
     nodeSecurityGroups: {}
-  }
+  } as unknown as NetworkConfig
 }: LearningPanelProps) {
   const { t } = useTranslation();
   const player = useLearningPlayer({ projectId });

--- a/frontend/src/features/learning/components/LearningPanel.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.tsx
@@ -3,10 +3,14 @@ import { GraduationCap, X } from 'lucide-react';
 import { useLearningPlayer } from '../hooks/useLearningPlayer';
 import RoadmapCatalog from './RoadmapCatalog';
 import RoadmapPlayer from './RoadmapPlayer';
+import type { ContainerData } from '../../../shared/types';
+import type { NetworkConfig } from '../../../shared/types/network';
 
 interface LearningPanelProps {
   projectId: string;
   onClose: () => void;
+  containers?: ContainerData[];
+  networkConfig?: NetworkConfig;
 }
 
 /**
@@ -14,7 +18,17 @@ interface LearningPanelProps {
  * owns the right) and is only mounted while open, so the free-canvas
  * experience is untouched when the learner is not in a roadmap.
  */
-export default function LearningPanel({ projectId, onClose }: LearningPanelProps) {
+export default function LearningPanel({
+  projectId,
+  onClose,
+  containers = [],
+  networkConfig = {
+    vpcConfig: { name: '', cidr: '' },
+    subnets: [],
+    nodeSubnetMap: {},
+    nodeSecurityGroups: {}
+  }
+}: LearningPanelProps) {
   const { t } = useTranslation();
   const player = useLearningPlayer({ projectId });
 
@@ -32,7 +46,11 @@ export default function LearningPanel({ projectId, onClose }: LearningPanelProps
 
       <div style={styles.content}>
         {player.roadmap ? (
-          <RoadmapPlayer player={player} />
+          <RoadmapPlayer
+            player={player}
+            containers={containers}
+            networkConfig={networkConfig}
+          />
         ) : player.roadmapLoading ? (
           <div style={styles.loading}>{t('learning.player.loading')}</div>
         ) : (

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -140,7 +140,7 @@ export default function RoadmapPlayer({
     subnets: [],
     nodeSubnetMap: {},
     nodeSecurityGroups: {}
-  }
+  } as unknown as NetworkConfig
 }: RoadmapPlayerProps) {
   const { t } = useTranslation();
   const {

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -1,13 +1,147 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ArrowLeft, ChevronLeft, ChevronRight, Globe, Copy, Check } from 'lucide-react';
 import StepValidationResults from './StepValidationResults';
 import type { useLearningPlayer } from '../hooks/useLearningPlayer';
+import type { ContainerData } from '../../../shared/types';
+import type { NetworkConfig } from '../../../shared/types/network';
 
 interface RoadmapPlayerProps {
   player: ReturnType<typeof useLearningPlayer>;
+  containers: ContainerData[];
+  networkConfig: NetworkConfig;
 }
 
-export default function RoadmapPlayer({ player }: RoadmapPlayerProps) {
+function CodeBlock({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div style={styles.codeBlockContainer}>
+      <div style={styles.codeBlockHeader}>
+        <button
+          onClick={handleCopy}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          style={{
+            ...styles.copyBtn,
+            backgroundColor: isHovered ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+          }}
+          title="Copy code"
+        >
+          {copied ? <Check size={12} color="#10B981" /> : <Copy size={12} color="#94A3B8" />}
+        </button>
+      </div>
+      <pre style={styles.pre}>
+        <code style={styles.codeBlock}>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+function renderInstruction(text: string) {
+  if (!text) return null;
+
+  const blocks: React.ReactNode[] = [];
+  const lines = text.split('\n');
+  let inCodeBlock = false;
+  let codeBlockLines: string[] = [];
+
+  const parseInline = (inlineText: string): React.ReactNode => {
+    const inlineRegex = /(\*\*.*?\*\*|`.*?`)/g;
+    const parts = inlineText.split(inlineRegex);
+    return parts.map((part, index) => {
+      if (part.startsWith('**') && part.endsWith('**')) {
+        return <strong key={index} style={{ fontWeight: 700, color: 'var(--color-text-primary)' }}>{part.slice(2, -2)}</strong>;
+      }
+      if (part.startsWith('`') && part.endsWith('`')) {
+        return (
+          <code
+            key={index}
+            style={{
+              fontFamily: 'monospace',
+              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+              padding: '2px 4px',
+              borderRadius: '4px',
+              fontSize: '11px',
+              color: 'var(--color-text-primary)',
+            }}
+          >
+            {part.slice(1, -1)}
+          </code>
+        );
+      }
+      return part;
+    });
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.startsWith('```')) {
+      if (inCodeBlock) {
+        const codeContent = codeBlockLines.join('\n');
+        blocks.push(<CodeBlock key={`code-${i}`} code={codeContent} />);
+        inCodeBlock = false;
+        codeBlockLines = [];
+      } else {
+        inCodeBlock = true;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBlockLines.push(line);
+      continue;
+    }
+
+    if (line.trim() === '') {
+      blocks.push(<div key={`empty-${i}`} style={{ height: '8px' }} />);
+      continue;
+    }
+
+    const listMatch = line.match(/^(\d+\.|\-|\*)\s+(.*)$/);
+    if (listMatch) {
+      const marker = listMatch[1];
+      const content = listMatch[2];
+      blocks.push(
+        <div key={`list-${i}`} style={styles.listItem}>
+          <span style={styles.listMarker}>{marker}</span>
+          <span style={styles.listContent}>{parseInline(content)}</span>
+        </div>
+      );
+    } else {
+      blocks.push(
+        <p key={`p-${i}`} style={styles.instructionLine}>
+          {parseInline(line)}
+        </p>
+      );
+    }
+  }
+
+  return <div style={styles.markdownWrapper}>{blocks}</div>;
+}
+
+export default function RoadmapPlayer({
+  player,
+  containers = [],
+  networkConfig = {
+    vpcConfig: { name: '', cidr: '' },
+    subnets: [],
+    nodeSubnetMap: {},
+    nodeSecurityGroups: {}
+  }
+}: RoadmapPlayerProps) {
   const { t } = useTranslation();
   const {
     roadmap,
@@ -64,16 +198,61 @@ export default function RoadmapPlayer({ player }: RoadmapPlayerProps) {
         })}
       </div>
 
-      <div style={styles.currentStep}>
-        <span style={styles.stepCounter}>
-          {t('learning.player.stepCounter', {
-            current: currentStepIndex + 1,
-            total: roadmap.steps.length,
-          })}
-        </span>
-        <span style={styles.stepTitle}>{currentStep.title}</span>
-        <p style={styles.instruction}>{currentStep.instruction}</p>
-      </div>
+      {/* Determine if we should show a localhost link to the container. */}
+      {(() => {
+        let localhostLink: string | null = null;
+        const firstValidator = currentStep.validators[0];
+        if (firstValidator && firstValidator.params) {
+          const nodeName = (firstValidator.params.node || firstValidator.params.source) as string | undefined;
+          if (nodeName) {
+            const container = containers.find(c => c.name === nodeName);
+            if (container && container.state === 'running') {
+              const subnetId = networkConfig.nodeSubnetMap?.[container.id];
+              const subnet = networkConfig.subnets?.find(s => s.id === subnetId);
+              const isPublicSubnet = subnet?.type === 'public';
+
+              const sgRules = networkConfig.nodeSecurityGroups?.[container.id] || [];
+              const allowsPort80 = sgRules.some(
+                (r: any) =>
+                  r.type === 'inbound' &&
+                  r.action === 'ALLOW' &&
+                  (r.port === '80' || r.port === 'ALL') &&
+                  r.source === '0.0.0.0/0'
+              );
+
+              if (isPublicSubnet && allowsPort80 && container.port) {
+                localhostLink = `http://localhost:${container.port}`;
+              }
+            }
+          }
+        }
+
+        return (
+          <div style={styles.currentStep}>
+            <span style={styles.stepCounter}>
+              {t('learning.player.stepCounter', {
+                current: currentStepIndex + 1,
+                total: roadmap.steps.length,
+              })}
+            </span>
+            <span style={styles.stepTitle}>{currentStep.title}</span>
+            <div style={styles.instructionContainer}>
+              {renderInstruction(currentStep.instruction)}
+            </div>
+            {localhostLink && (
+              <div style={styles.linkBox}>
+                <Globe size={14} color="#10B981" style={{ marginRight: 6, flexShrink: 0 }} />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                  <span style={styles.linkLabel}>Visit your web server:</span>
+                  <a href={localhostLink} target="_blank" rel="noopener noreferrer" style={styles.link}>
+                    {localhostLink}
+                  </a>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       <div style={styles.navRow}>
         <button
@@ -258,5 +437,92 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 600,
     cursor: 'pointer',
     fontFamily: 'var(--font-sans)',
+  },
+  linkBox: {
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: '10px',
+    padding: '8px 12px',
+    backgroundColor: 'rgba(16, 185, 129, 0.08)',
+    border: '1px solid rgba(16, 185, 129, 0.2)',
+    borderRadius: '6px',
+  },
+  linkLabel: {
+    fontSize: '11px',
+    fontWeight: 600,
+    color: 'var(--color-text-secondary)',
+  },
+  link: {
+    fontSize: '11px',
+    fontWeight: 700,
+    color: 'var(--color-accent)',
+    textDecoration: 'underline',
+    wordBreak: 'break-all',
+  },
+  instructionContainer: {
+    marginTop: '4px',
+  },
+  markdownWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  },
+  instructionLine: {
+    margin: 0,
+    fontSize: '12px',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.6,
+  },
+  codeBlockContainer: {
+    margin: '8px 0',
+    backgroundColor: '#0F172A',
+    borderRadius: '6px',
+    border: '1px solid rgba(255, 255, 255, 0.05)',
+    overflow: 'hidden',
+  },
+  pre: {
+    margin: 0,
+    padding: '12px',
+    overflowX: 'auto',
+  },
+  codeBlock: {
+    fontFamily: 'monospace',
+    fontSize: '11px',
+    color: '#E2E8F0',
+    lineHeight: 1.5,
+    whiteSpace: 'pre',
+  },
+  listItem: {
+    display: 'flex',
+    gap: '6px',
+    fontSize: '12px',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.6,
+    paddingLeft: '4px',
+  },
+  listMarker: {
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+    flexShrink: 0,
+  },
+  listContent: {
+    flex: 1,
+  },
+  codeBlockHeader: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: '6px 8px 0 8px',
+    backgroundColor: '#0F172A',
+  },
+  copyBtn: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    padding: '4px',
+    borderRadius: '4px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: 'background-color 0.2s',
   },
 };

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -575,7 +575,12 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
       <div style={styles.bodyWrapper}>
         {showLearning && (
-          <LearningPanel projectId={projectId} onClose={() => setShowLearning(false)} />
+          <LearningPanel
+            projectId={projectId}
+            onClose={() => setShowLearning(false)}
+            containers={containers}
+            networkConfig={networkConfig}
+          />
         )}
 
         {/* Main React Flow Workspace */}

--- a/roadmaps/example-first-architecture.json
+++ b/roadmaps/example-first-architecture.json
@@ -15,9 +15,9 @@
     {
       "id": "create-web-server",
       "title": "Create the web server",
-      "instruction": "From the node library, drag an **Ubuntu** node onto the canvas and name it `web`. Start it and wait until it is running.",
+      "instruction": "From the node library, drag a **Server** node (Ubuntu) onto the canvas and name it `web`. Start it and wait until it is running.",
       "hints": [
-        "Nodes are created by dragging them from the library panel on the right side of the canvas."
+        "Nodes are created by dragging them from the library panel on the left side of the canvas."
       ],
       "validators": [
         {
@@ -29,7 +29,7 @@
     {
       "id": "add-database",
       "title": "Add a PostgreSQL database with a users table",
-      "instruction": "Add a **PostgreSQL** node named `db` and start it. Then open its explorer and create a table named `users` (any columns you like).",
+      "instruction": "Add a **SQL Database** node (PostgreSQL) named `db` and start it. Then open its explorer and create a table named `users` (any columns you like).",
       "hints": [
         "Double-click the PostgreSQL node to open its modal — the explorer tab lets you run SQL against the real container.",
         "A table needs at least one column, for example: `CREATE TABLE users (id SERIAL PRIMARY KEY);`"

--- a/roadmaps/example-first-architecture.json
+++ b/roadmaps/example-first-architecture.json
@@ -29,10 +29,10 @@
     {
       "id": "add-database",
       "title": "Add a PostgreSQL database with a users table",
-      "instruction": "Add a **SQL Database** node (PostgreSQL) named `db` and start it. Then open its explorer and create a table named `users` (any columns you like).",
+      "instruction": "Add a **SQL Database** node (PostgreSQL) named `db` and start it. Then check by clicking inspector in db explorer if there is a `users` table.",
       "hints": [
-        "Double-click the PostgreSQL node to open its modal — the explorer tab lets you run SQL against the real container.",
-        "A table needs at least one column, for example: `CREATE TABLE users (id SERIAL PRIMARY KEY);`"
+        "Double-click the SQL Database node to open its modal — check by clicking inspector in db explorer if there is a `users` table.",
+        "If the table is missing, create it in the Query tab, for example: `CREATE TABLE users (id SERIAL PRIMARY KEY, email TEXT NOT NULL);`"
       ],
       "solution": "Create the node, start it, open its modal and run:\n\n```sql\nCREATE TABLE users (\n  id SERIAL PRIMARY KEY,\n  email TEXT NOT NULL\n);\n```",
       "validators": [
@@ -71,6 +71,28 @@
         {
           "type": "port_denied",
           "params": { "source": "web", "target": "db", "port": 80 }
+        }
+      ]
+    },
+    {
+      "id": "run-web-server",
+      "title": "Run a web server querying the database",
+      "instruction": "Connect to the terminal of your `web` node and run the following commands:\n\n1. Install PostgreSQL drivers:\n```bash\napt-get update && apt-get install -y python3-psycopg2\n```\n\n2. Write the server script (`server.py`):\n```bash\ncat << 'EOF' > server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport psycopg2\nclass DBHandler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        try:\n            conn = psycopg2.connect(host='db', database='postgres', user='postgres', password='postgres')\n            cur = conn.cursor()\n            cur.execute('SELECT id, email FROM users;')\n            rows = cur.fetchall()\n            html = '<html><body><h1>Users List</h1><table border=1><tr><th>ID</th><th>Email</th></tr>'\n            for row in rows:\n                html += f'<tr><td>{row[0]}</td><td>{row[1]}</td></tr>'\n            html += '</table></body></html>'\n            cur.close(); conn.close()\n        except Exception as e:\n            html = f'<html><body><h1>Error</h1><p>{str(e)}</p></body></html>'\n        self.wfile.write(bytes(html, 'utf8'))\nHTTPServer(('', 80), DBHandler).serve_forever()\nEOF\n```\n\n3. Start the server in the background:\n```bash\npython3 server.py &\n```\n\n4. Finally, open port 80 in inbound rules for the `web` node security group allowing traffic from `0.0.0.0/0` (Anywhere).",
+      "hints": [
+        "Double-click 'web' and use the Terminal tab to run commands.",
+        "Write your Python web server script using Python's http.server and psycopg2. Connect using host='db', database='postgres', user='postgres', password='postgres'. Example script:\n\n```python\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport psycopg2\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        conn = psycopg2.connect(host='db', database='postgres', user='postgres', password='postgres')\n        cur = conn.cursor()\n        cur.execute('SELECT id, email FROM users;')\n        rows = cur.fetchall()\n        html = '<html><body><h1>Users List</h1><table border=1>'\n        for r in rows:\n            html += f'<tr><td>{r[0]}</td><td>{r[1]}</td></tr>'\n        html += '</table></body></html>'\n        self.wfile.write(bytes(html, 'utf8'))\n        cur.close(); conn.close()\nHTTPServer(('', 80), Handler).serve_forever()\n```",
+        "Don't forget to open port 80 in inbound rules for the 'web' security group!"
+      ],
+      "solution": "Write the Python script server.py, run 'python3 server.py &', and add an inbound security group rule on 'web' allowing TCP port 80 from 0.0.0.0/0.",
+      "validators": [
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/",
+            "expectedText": "Users List"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary of Changes

This PR introduces HTTP web server verification in the learning validation engine and improves the Roadmap UI with dynamic access links, markdown formatting, and copy buttons.

Key additions:
- **`http_get_contains` Validator**: Adds a backend learning engine validator that executes localized `curl` requests inside docker containers to verify page content (e.g. database rows rendered in HTML).
- **Step 5 (Run Web Server)**: Adds a 5th step to the `example-first-architecture` roadmap instructing learners to build and start a Python web server connected to the PostgreSQL database, and open port 80.
- **Dynamic Localhost Links**: Automatically displays a clickable `http://localhost:<mapped_port>` link under step instructions if the target container is running, placed in a public subnet, and has port 80 allowed inbound.
- **Enhanced Markdown & Code Blocks**: Implements native parsing for lists, bolding, inline code, and multi-line console code blocks in the roadmap sidebar.
- **Copy Buttons**: Adds a top-right copy icon on all terminal code blocks in the UI for easy copy-pasting, showing a checkmark indicator upon success.
- **DB Inspector Alignment**: Updates Step 2 to guide the user to verify the `users` table via the database explorer inspector rather than simply instructing them to write SQL.
- **Ingress Port Isolation Fix**: Restricts port validation to inbound-only rules, preventing outbound wildcard rules (`ALLOW ALL` outbound) from leaking into ingress checks.

## Types of Changes

- [x] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification
- Ran backend unit tests validating the connection success/failure modes in `httpGetContains.test.ts` (passed).
- Ran CLI validator (`npm run roadmap:validate`) against `example-first-architecture.json` to verify schema validation (passed).
- Ran all frontend learning panel tests (`LearningPanel.test.tsx`, `useLearningPlayer.test.ts`, `useRoadmaps.test.ts`) to verify component behavior, styling fallbacks, and navigation logic (all 21 passed).
- Simulated and verified copying code blocks to the clipboard and dynamic public port links in the UI.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
