### PR TITLE
feat(learning): pedagogical validation feedback with pass/fail/error states

### DIFF
--- a/frontend/src/features/learning/components/LearningPanel.test.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.test.tsx
@@ -176,7 +176,7 @@ describe('LearningPanel', () => {
       screen.getByText('No container named "web" exists in this project yet.')
     ).toBeInTheDocument();
     expect(screen.getByText(/a running container named "web"/)).toBeInTheDocument();
-    // The step list reflects the failure, and the raw P-1 rendering is gone.
+    // The step list reflects the failure, and the raw status/type strings are gone.
     expect(screen.getByTitle('Failed')).toBeInTheDocument();
     expect(screen.queryByText('[fail]')).not.toBeInTheDocument();
     expect(screen.queryByText('container_running')).not.toBeInTheDocument();

--- a/frontend/src/features/learning/components/LearningPanel.test.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.test.tsx
@@ -59,6 +59,21 @@ const failResponse: StepValidationResponse = {
   checkedAt: '2026-07-15T10:00:00.000Z',
 };
 
+const passResponse: StepValidationResponse = {
+  roadmapId: roadmap.id,
+  stepId: 'create-web-server',
+  stepPassed: true,
+  results: [
+    {
+      index: 0,
+      type: 'container_running',
+      status: 'pass',
+      message: 'The container "web" is running.',
+    },
+  ],
+  checkedAt: '2026-07-15T10:01:00.000Z',
+};
+
 function jsonResponse(ok: boolean, body: unknown): Response {
   return { ok, json: () => Promise.resolve(body) } as Response;
 }
@@ -149,7 +164,7 @@ describe('LearningPanel', () => {
     expect(screen.getByText('Step 1 of 2')).toBeInTheDocument();
   });
 
-  it('validates the current step and renders the raw results', async () => {
+  it('validates the current step and renders pedagogical feedback', async () => {
     vi.stubGlobal('fetch', buildFetchMock({}));
     render(<LearningPanel projectId="p1" onClose={() => {}} />);
     await openRoadmapFromCatalog();
@@ -161,6 +176,50 @@ describe('LearningPanel', () => {
       screen.getByText('No container named "web" exists in this project yet.')
     ).toBeInTheDocument();
     expect(screen.getByText(/a running container named "web"/)).toBeInTheDocument();
+    // The step list reflects the failure, and the raw P-1 rendering is gone.
+    expect(screen.getByTitle('Failed')).toBeInTheDocument();
+    expect(screen.queryByText('[fail]')).not.toBeInTheDocument();
+    expect(screen.queryByText('container_running')).not.toBeInTheDocument();
+  });
+
+  it('replaces failure feedback cleanly when a revalidation passes', async () => {
+    let firstAttempt = true;
+    vi.stubGlobal(
+      'fetch',
+      buildFetchMock({
+        validate: () => {
+          const body = firstAttempt ? failResponse : passResponse;
+          firstAttempt = false;
+          return jsonResponse(true, body);
+        },
+      })
+    );
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+    await openRoadmapFromCatalog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
+    expect(await screen.findByText('Not yet — see the results below')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
+    expect(await screen.findByText('Step passed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next step' })).toBeInTheDocument();
+    expect(screen.getByTitle('Passed')).toBeInTheDocument();
+    // No artifacts from the failed attempt survive.
+    expect(screen.queryByText('Not yet — see the results below')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('No container named "web" exists in this project yet.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('advances to the next step from the success banner', async () => {
+    vi.stubGlobal('fetch', buildFetchMock({ validate: () => jsonResponse(true, passResponse) }));
+    render(<LearningPanel projectId="p1" onClose={() => {}} />);
+    await openRoadmapFromCatalog();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Next step' }));
+
+    expect(screen.getByText('Step 2 of 2')).toBeInTheDocument();
   });
 
   it('shows an understandable error with retry when the backend is unreachable during validation', async () => {

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, ChevronLeft, ChevronRight, Globe, Copy, Check } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, CheckCircle2, ChevronLeft, ChevronRight, Globe, Copy, Check, XCircle } from 'lucide-react';
 import StepValidationResults from './StepValidationResults';
+import { stepOutcome, type StepOutcome } from '../validationStatus';
+import type { StepValidationResponse } from '../../../shared/types/roadmap';
 import type { useLearningPlayer } from '../hooks/useLearningPlayer';
 import type { ContainerData } from '../../../shared/types';
 import type { NetworkConfig } from '../../../shared/types/network';
@@ -46,6 +48,22 @@ function CodeBlock({ code }: { code: string }) {
         <code style={styles.codeBlock}>{code}</code>
       </pre>
     </div>
+  );
+}
+
+const MARKER_PRESETS: Record<StepOutcome, { icon: typeof CheckCircle2; color: string; labelKey: string }> = {
+  passed: { icon: CheckCircle2, color: 'var(--color-success)', labelKey: 'learning.player.markerPassed' },
+  failed: { icon: XCircle, color: 'var(--color-danger)', labelKey: 'learning.player.markerFailed' },
+  error: { icon: AlertTriangle, color: 'var(--color-warning)', labelKey: 'learning.player.markerError' },
+};
+
+function StepMarker({ response }: { response: StepValidationResponse }) {
+  const { t } = useTranslation();
+  const { icon: Icon, color, labelKey } = MARKER_PRESETS[stepOutcome(response)];
+  return (
+    <span style={styles.stepMarker} title={t(labelKey)} aria-label={t(labelKey)}>
+      <Icon size={13} color={color} />
+    </span>
   );
 }
 
@@ -183,16 +201,7 @@ export default function RoadmapPlayer({
             >
               <span style={styles.stepIndex}>{index + 1}.</span>
               <span style={styles.stepItemTitle}>{step.title}</span>
-              {result && (
-                <span
-                  style={{
-                    ...styles.stepMarker,
-                    color: result.stepPassed ? 'var(--color-success)' : 'var(--color-danger)',
-                  }}
-                >
-                  {result.stepPassed ? '✓' : '✗'}
-                </span>
-              )}
+              {result && <StepMarker response={result} />}
             </button>
           );
         })}
@@ -291,7 +300,11 @@ export default function RoadmapPlayer({
       )}
 
       {resultsByStepId[currentStep.id] && (
-        <StepValidationResults response={resultsByStepId[currentStep.id]} />
+        <StepValidationResults
+          response={resultsByStepId[currentStep.id]}
+          isLastStep={atLastStep}
+          onNextStep={() => goToStep(currentStepIndex + 1)}
+        />
       )}
     </div>
   );
@@ -356,8 +369,8 @@ const styles: Record<string, React.CSSProperties> = {
     flex: 1,
   },
   stepMarker: {
-    fontSize: '12px',
-    fontWeight: 700,
+    display: 'flex',
+    alignItems: 'center',
   },
   currentStep: {
     display: 'flex',

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, ArrowLeft, CheckCircle2, ChevronLeft, ChevronRight, Globe, Copy, Check, XCircle } from 'lucide-react';
+import { ArrowLeft, ChevronLeft, ChevronRight, Globe, Copy, Check } from 'lucide-react';
 import StepValidationResults from './StepValidationResults';
-import { stepOutcome, type StepOutcome } from '../validationStatus';
+import { outcomePreset } from '../validationStatus';
 import type { StepValidationResponse } from '../../../shared/types/roadmap';
 import type { useLearningPlayer } from '../hooks/useLearningPlayer';
 import type { ContainerData } from '../../../shared/types';
@@ -51,18 +51,12 @@ function CodeBlock({ code }: { code: string }) {
   );
 }
 
-const MARKER_PRESETS: Record<StepOutcome, { icon: typeof CheckCircle2; color: string; labelKey: string }> = {
-  passed: { icon: CheckCircle2, color: 'var(--color-success)', labelKey: 'learning.player.markerPassed' },
-  failed: { icon: XCircle, color: 'var(--color-danger)', labelKey: 'learning.player.markerFailed' },
-  error: { icon: AlertTriangle, color: 'var(--color-warning)', labelKey: 'learning.player.markerError' },
-};
-
 function StepMarker({ response }: { response: StepValidationResponse }) {
   const { t } = useTranslation();
-  const { icon: Icon, color, labelKey } = MARKER_PRESETS[stepOutcome(response)];
+  const { icon: Icon, color, labelKey } = outcomePreset(response);
   return (
-    <span style={styles.stepMarker} title={t(labelKey)} aria-label={t(labelKey)}>
-      <Icon size={13} color={color} />
+    <span style={styles.stepMarker} title={t(labelKey)}>
+      <Icon size={13} color={color} role="img" aria-label={t(labelKey)} />
     </span>
   );
 }

--- a/frontend/src/features/learning/components/StepValidationResults.test.tsx
+++ b/frontend/src/features/learning/components/StepValidationResults.test.tsx
@@ -1,0 +1,109 @@
+import '../../../i18n';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import StepValidationResults from './StepValidationResults';
+import type { StepValidationResponse, ValidatorResult } from '../../../shared/types/roadmap';
+
+const passResult: ValidatorResult = {
+  index: 0,
+  type: 'container_running',
+  status: 'pass',
+  message: 'The container "web" is running.',
+};
+
+const failResult: ValidatorResult = {
+  index: 0,
+  type: 'container_running',
+  status: 'fail',
+  message: 'No container named "web" exists in this project yet.',
+  expected: 'a running container named "web"',
+  observed: 'no container with that name',
+};
+
+const errorResult: ValidatorResult = {
+  index: 1,
+  type: 'table_exists',
+  status: 'error',
+  message: 'Something went wrong while talking to Docker.',
+  errorCode: 'DOCKER_ERROR',
+};
+
+function buildResponse(results: ValidatorResult[]): StepValidationResponse {
+  return {
+    roadmapId: 'example-first-architecture',
+    stepId: 'create-web-server',
+    stepPassed: results.every(result => result.status === 'pass'),
+    results,
+    checkedAt: '2026-07-15T10:00:00.000Z',
+  };
+}
+
+function renderResults(
+  response: StepValidationResponse,
+  { isLastStep = false, onNextStep = vi.fn() } = {}
+) {
+  render(<StepValidationResults response={response} isLastStep={isLastStep} onNextStep={onNextStep} />);
+  return { onNextStep };
+}
+
+describe('StepValidationResults', () => {
+  it('renders the success banner with a Next step button that advances', () => {
+    const { onNextStep } = renderResults(buildResponse([passResult]));
+
+    expect(screen.getByText('Step passed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Next step' }));
+    expect(onNextStep).toHaveBeenCalledOnce();
+  });
+
+  it('celebrates the roadmap on the last step and offers no Next step button', () => {
+    renderResults(buildResponse([passResult]), { isLastStep: true });
+
+    expect(
+      screen.getByText('Step passed — that was the last one. Roadmap complete!')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next step' })).not.toBeInTheDocument();
+  });
+
+  it('renders a pedagogical failure: banner, message, expected and observed', () => {
+    renderResults(buildResponse([failResult]));
+
+    expect(screen.getByText('Not yet — see the results below')).toBeInTheDocument();
+    expect(
+      screen.getByText('No container named "web" exists in this project yet.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('a running container named "web"')).toBeInTheDocument();
+    expect(screen.getByText('no container with that name')).toBeInTheDocument();
+  });
+
+  it('renders an infrastructure error distinctly, without the raw error code', () => {
+    renderResults(buildResponse([errorResult]));
+
+    expect(
+      screen.getByText("Some checks couldn't run — that's on us, not you. Fix the issue below or just try again.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Check couldn't run")).toBeInTheDocument();
+    expect(screen.queryByText('DOCKER_ERROR')).not.toBeInTheDocument();
+  });
+
+  it('lets an error win over a failure in the banner while still listing the failure', () => {
+    renderResults(buildResponse([failResult, errorResult]));
+
+    expect(
+      screen.getByText("Some checks couldn't run — that's on us, not you. Fix the issue below or just try again.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Not yet — see the results below')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('No container named "web" exists in this project yet.')
+    ).toBeInTheDocument();
+  });
+
+  it('uses the Docker-specific wording when the daemon is unreachable', () => {
+    renderResults(
+      buildResponse([{ ...errorResult, errorCode: 'DOCKER_UNAVAILABLE' }])
+    );
+
+    expect(
+      screen.getByText("Docker isn't running, so the checks couldn't run. Start Docker and validate again.")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/learning/components/StepValidationResults.test.tsx
+++ b/frontend/src/features/learning/components/StepValidationResults.test.tsx
@@ -103,7 +103,7 @@ describe('StepValidationResults', () => {
     );
 
     expect(
-      screen.getByText("Docker isn't running, so the checks couldn't run. Start Docker and validate again.")
+      screen.getByText("Docker wasn't running, so the checks couldn't run. Start Docker and validate again.")
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/learning/components/StepValidationResults.tsx
+++ b/frontend/src/features/learning/components/StepValidationResults.tsx
@@ -1,57 +1,111 @@
 import { useTranslation } from 'react-i18next';
-import type { StepValidationResponse, ValidatorResult } from '../../../shared/types/roadmap';
+import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react';
+import { stepOutcome, STATUS_COLORS } from '../validationStatus';
+import type { StepValidationResponse, ValidatorResult, ValidatorStatus } from '../../../shared/types/roadmap';
 
 interface StepValidationResultsProps {
   response: StepValidationResponse;
+  isLastStep: boolean;
+  onNextStep: () => void;
 }
 
-// P-1 scope: a deliberately raw rendering of the engine's report.
-// P-2 turns this into the real ✓/✗/⚠ pedagogical feedback.
-export default function StepValidationResults({ response }: StepValidationResultsProps) {
-  const { t } = useTranslation();
+const STATUS_ICONS: Record<ValidatorStatus, typeof CheckCircle2> = {
+  pass: CheckCircle2,
+  fail: XCircle,
+  error: AlertTriangle,
+};
 
+const MARKER_LABEL_KEYS: Record<ValidatorStatus, string> = {
+  pass: 'learning.player.markerPassed',
+  fail: 'learning.player.markerFailed',
+  error: 'learning.player.markerError',
+};
+
+export default function StepValidationResults({
+  response,
+  isLastStep,
+  onNextStep,
+}: StepValidationResultsProps) {
   return (
     <div style={styles.container}>
-      <div
-        style={{
-          ...styles.banner,
-          color: response.stepPassed ? 'var(--color-success)' : 'var(--color-danger)',
-        }}
-      >
-        {response.stepPassed ? t('learning.player.stepPassed') : t('learning.player.stepFailed')}
-      </div>
+      <OutcomeBanner response={response} isLastStep={isLastStep} onNextStep={onNextStep} />
       {response.results.map(result => (
-        <ResultBlock key={result.index} result={result} />
+        <ValidatorResultCard key={result.index} result={result} />
       ))}
     </div>
   );
 }
 
-function ResultBlock({ result }: { result: ValidatorResult }) {
+function OutcomeBanner({ response, isLastStep, onNextStep }: StepValidationResultsProps) {
   const { t } = useTranslation();
-  const statusColor =
-    result.status === 'pass'
-      ? 'var(--color-success)'
-      : result.status === 'fail'
-        ? 'var(--color-danger)'
-        : 'var(--color-text-muted)';
+  const outcome = stepOutcome(response);
+
+  if (outcome === 'passed') {
+    return (
+      <div style={{ ...styles.banner, ...styles.bannerPassed }}>
+        <div style={styles.bannerHeader}>
+          <CheckCircle2 size={15} style={styles.bannerIcon} color="var(--color-success)" />
+          <span style={{ color: 'var(--color-success)' }}>
+            {isLastStep ? t('learning.player.roadmapComplete') : t('learning.player.stepPassed')}
+          </span>
+        </div>
+        {!isLastStep && (
+          <button onClick={onNextStep} style={styles.nextStepBtn}>
+            {t('learning.player.nextStep')}
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (outcome === 'error') {
+    const dockerDown = response.results.some(result => result.errorCode === 'DOCKER_UNAVAILABLE');
+    return (
+      <div style={{ ...styles.banner, ...styles.bannerError }}>
+        <div style={styles.bannerHeader}>
+          <AlertTriangle size={15} style={styles.bannerIcon} color="var(--color-warning)" />
+          <span style={{ color: 'var(--color-warning-strong)' }}>
+            {dockerDown ? t('learning.player.stepErrorDocker') : t('learning.player.stepError')}
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div style={styles.result}>
-      <div style={styles.resultHeader}>
-        <span style={{ ...styles.resultStatus, color: statusColor }}>[{result.status}]</span>
-        <span style={styles.resultType}>{result.type}</span>
-        {result.errorCode && <span style={styles.errorCode}>{result.errorCode}</span>}
+    <div style={{ ...styles.banner, ...styles.bannerFailed }}>
+      <div style={styles.bannerHeader}>
+        <XCircle size={15} style={styles.bannerIcon} color="var(--color-danger)" />
+        <span style={{ color: 'var(--color-danger)' }}>{t('learning.player.stepFailed')}</span>
       </div>
-      <div style={styles.resultMessage}>{result.message}</div>
+    </div>
+  );
+}
+
+function ValidatorResultCard({ result }: { result: ValidatorResult }) {
+  const { t } = useTranslation();
+  const Icon = STATUS_ICONS[result.status];
+  const color = STATUS_COLORS[result.status];
+
+  return (
+    <div style={{ ...styles.card, borderLeft: `3px solid ${color}` }}>
+      <div style={styles.cardHeader}>
+        <Icon size={14} color={color} style={styles.cardIcon} aria-label={t(MARKER_LABEL_KEYS[result.status])} />
+        <span style={styles.cardMessage}>{result.message}</span>
+      </div>
+      {result.status === 'error' && (
+        <span style={styles.checkNotRun}>{t('learning.player.checkNotRun')}</span>
+      )}
       {result.expected && (
         <div style={styles.detailLine}>
-          <span style={styles.detailLabel}>{t('learning.player.expected')}:</span> {result.expected}
+          <span style={styles.detailLabel}>{t('learning.player.expected')}:</span>{' '}
+          <span style={styles.detailValue}>{result.expected}</span>
         </div>
       )}
       {result.observed && (
         <div style={styles.detailLine}>
-          <span style={styles.detailLabel}>{t('learning.player.observed')}:</span> {result.observed}
+          <span style={styles.detailLabel}>{t('learning.player.observed')}:</span>{' '}
+          <span style={styles.detailValue}>{result.observed}</span>
         </div>
       )}
     </div>
@@ -65,10 +119,49 @@ const styles: Record<string, React.CSSProperties> = {
     gap: '8px',
   },
   banner: {
-    fontSize: '13px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    padding: '10px 12px',
+    borderRadius: '6px',
+    fontSize: '12px',
     fontWeight: 700,
+    lineHeight: 1.5,
   },
-  result: {
+  bannerPassed: {
+    border: '1px solid var(--color-success)',
+    backgroundColor: 'var(--color-success-glow)',
+  },
+  bannerFailed: {
+    border: '1px solid var(--color-danger)',
+    backgroundColor: 'var(--color-danger-glow)',
+  },
+  bannerError: {
+    border: '1px solid var(--color-warning)',
+    backgroundColor: 'var(--color-warning-glow)',
+  },
+  bannerHeader: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '6px',
+  },
+  bannerIcon: {
+    flexShrink: 0,
+    marginTop: '2px',
+  },
+  nextStepBtn: {
+    alignSelf: 'flex-start',
+    padding: '6px 14px',
+    border: 'none',
+    borderRadius: '6px',
+    backgroundColor: 'var(--color-success)',
+    color: '#FFFFFF',
+    fontSize: '12px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+  },
+  card: {
     border: '1px solid var(--border-color)',
     borderRadius: '6px',
     padding: '8px 10px',
@@ -76,27 +169,24 @@ const styles: Record<string, React.CSSProperties> = {
     flexDirection: 'column',
     gap: '4px',
   },
-  resultHeader: {
+  cardHeader: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     gap: '6px',
-    fontFamily: 'var(--font-mono)',
-    fontSize: '11px',
   },
-  resultStatus: {
-    fontWeight: 700,
+  cardIcon: {
+    flexShrink: 0,
+    marginTop: '2px',
   },
-  resultType: {
-    color: 'var(--color-text-secondary)',
-  },
-  errorCode: {
-    color: 'var(--color-text-muted)',
-    marginLeft: 'auto',
-  },
-  resultMessage: {
+  cardMessage: {
     fontSize: '12px',
     color: 'var(--color-text-primary)',
     lineHeight: 1.5,
+  },
+  checkNotRun: {
+    fontSize: '11px',
+    fontWeight: 600,
+    color: 'var(--color-warning-strong)',
   },
   detailLine: {
     fontSize: '11px',
@@ -106,5 +196,8 @@ const styles: Record<string, React.CSSProperties> = {
   detailLabel: {
     fontWeight: 600,
     color: 'var(--color-text-muted)',
+  },
+  detailValue: {
+    fontFamily: 'var(--font-mono)',
   },
 };

--- a/frontend/src/features/learning/components/StepValidationResults.tsx
+++ b/frontend/src/features/learning/components/StepValidationResults.tsx
@@ -1,25 +1,13 @@
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react';
-import { stepOutcome, STATUS_COLORS } from '../validationStatus';
-import type { StepValidationResponse, ValidatorResult, ValidatorStatus } from '../../../shared/types/roadmap';
+import { stepOutcome, isDockerUnavailable, STATUS_PRESETS } from '../validationStatus';
+import type { StepValidationResponse, ValidatorResult } from '../../../shared/types/roadmap';
 
 interface StepValidationResultsProps {
   response: StepValidationResponse;
   isLastStep: boolean;
   onNextStep: () => void;
 }
-
-const STATUS_ICONS: Record<ValidatorStatus, typeof CheckCircle2> = {
-  pass: CheckCircle2,
-  fail: XCircle,
-  error: AlertTriangle,
-};
-
-const MARKER_LABEL_KEYS: Record<ValidatorStatus, string> = {
-  pass: 'learning.player.markerPassed',
-  fail: 'learning.player.markerFailed',
-  error: 'learning.player.markerError',
-};
 
 export default function StepValidationResults({
   response,
@@ -59,7 +47,7 @@ function OutcomeBanner({ response, isLastStep, onNextStep }: StepValidationResul
   }
 
   if (outcome === 'error') {
-    const dockerDown = response.results.some(result => result.errorCode === 'DOCKER_UNAVAILABLE');
+    const dockerDown = isDockerUnavailable(response);
     return (
       <div style={{ ...styles.banner, ...styles.bannerError }}>
         <div style={styles.bannerHeader}>
@@ -84,25 +72,24 @@ function OutcomeBanner({ response, isLastStep, onNextStep }: StepValidationResul
 
 function ValidatorResultCard({ result }: { result: ValidatorResult }) {
   const { t } = useTranslation();
-  const Icon = STATUS_ICONS[result.status];
-  const color = STATUS_COLORS[result.status];
+  const { icon: Icon, color, labelKey } = STATUS_PRESETS[result.status];
 
   return (
     <div style={{ ...styles.card, borderLeft: `3px solid ${color}` }}>
       <div style={styles.cardHeader}>
-        <Icon size={14} color={color} style={styles.cardIcon} aria-label={t(MARKER_LABEL_KEYS[result.status])} />
+        <Icon size={14} color={color} style={styles.cardIcon} role="img" aria-label={t(labelKey)} />
         <span style={styles.cardMessage}>{result.message}</span>
       </div>
       {result.status === 'error' && (
         <span style={styles.checkNotRun}>{t('learning.player.checkNotRun')}</span>
       )}
-      {result.expected && (
+      {result.expected != null && (
         <div style={styles.detailLine}>
           <span style={styles.detailLabel}>{t('learning.player.expected')}:</span>{' '}
           <span style={styles.detailValue}>{result.expected}</span>
         </div>
       )}
-      {result.observed && (
+      {result.observed != null && (
         <div style={styles.detailLine}>
           <span style={styles.detailLabel}>{t('learning.player.observed')}:</span>{' '}
           <span style={styles.detailValue}>{result.observed}</span>

--- a/frontend/src/features/learning/validationStatus.ts
+++ b/frontend/src/features/learning/validationStatus.ts
@@ -1,0 +1,22 @@
+import type { StepValidationResponse, ValidatorStatus } from '../../shared/types/roadmap';
+
+export type StepOutcome = 'passed' | 'failed' | 'error';
+
+/**
+ * Aggregates a step's validator results into a single outcome.
+ * `error` wins over `failed`: when a check could not run, the step's real
+ * state is unknowable — telling the learner "not yet, fix your work" would
+ * blame them for an infrastructure problem. Failed checks still render
+ * individually below the banner, so no pedagogical information is lost.
+ */
+export function stepOutcome(response: StepValidationResponse): StepOutcome {
+  if (response.stepPassed) return 'passed';
+  if (response.results.some(result => result.status === 'error')) return 'error';
+  return 'failed';
+}
+
+export const STATUS_COLORS: Record<ValidatorStatus, string> = {
+  pass: 'var(--color-success)',
+  fail: 'var(--color-danger)',
+  error: 'var(--color-warning)',
+};

--- a/frontend/src/features/learning/validationStatus.ts
+++ b/frontend/src/features/learning/validationStatus.ts
@@ -1,3 +1,4 @@
+import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react';
 import type { StepValidationResponse, ValidatorStatus } from '../../shared/types/roadmap';
 
 export type StepOutcome = 'passed' | 'failed' | 'error';
@@ -15,8 +16,30 @@ export function stepOutcome(response: StepValidationResponse): StepOutcome {
   return 'failed';
 }
 
-export const STATUS_COLORS: Record<ValidatorStatus, string> = {
-  pass: 'var(--color-success)',
-  fail: 'var(--color-danger)',
-  error: 'var(--color-warning)',
+// Matches the backend DockerErrorCode emitted when the daemon is unreachable
+// (backend infrastructure/docker/dockerErrors.ts).
+const DOCKER_UNAVAILABLE = 'DOCKER_UNAVAILABLE';
+
+/** True when a check of this attempt could not run because the Docker daemon was unreachable. */
+export function isDockerUnavailable(response: StepValidationResponse): boolean {
+  return response.results.some(result => result.errorCode === DOCKER_UNAVAILABLE);
+}
+
+interface StatusPreset {
+  icon: typeof CheckCircle2;
+  color: string;
+  labelKey: string;
+}
+
+/** Single source of each status's visual identity (icon, color, i18n label). */
+export const STATUS_PRESETS: Record<ValidatorStatus, StatusPreset> = {
+  pass: { icon: CheckCircle2, color: 'var(--color-success)', labelKey: 'learning.player.markerPassed' },
+  fail: { icon: XCircle, color: 'var(--color-danger)', labelKey: 'learning.player.markerFailed' },
+  error: { icon: AlertTriangle, color: 'var(--color-warning)', labelKey: 'learning.player.markerError' },
 };
+
+/** Preset for a step's aggregate outcome — the step-list marker shows one glyph per step. */
+export function outcomePreset(response: StepValidationResponse): StatusPreset {
+  const status: Record<StepOutcome, ValidatorStatus> = { passed: 'pass', failed: 'fail', error: 'error' };
+  return STATUS_PRESETS[status[stepOutcome(response)]];
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,7 +18,10 @@
   --color-success-glow: rgba(5, 150, 105, 0.1);
   --color-danger: #DC2626;
   --color-danger-glow: rgba(220, 38, 38, 0.1);
-  
+  --color-warning: #F59E0B;
+  --color-warning-glow: rgba(245, 158, 11, 0.1);
+  --color-warning-strong: #92400E;
+
   --font-sans: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', monospace;
   

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -40,7 +40,7 @@
       "expected": "Expected",
       "observed": "Observed",
       "stepError": "Some checks couldn't run — that's on us, not you. Fix the issue below or just try again.",
-      "stepErrorDocker": "Docker isn't running, so the checks couldn't run. Start Docker and validate again.",
+      "stepErrorDocker": "Docker wasn't running, so the checks couldn't run. Start Docker and validate again.",
       "nextStep": "Next step",
       "roadmapComplete": "Step passed — that was the last one. Roadmap complete!",
       "checkNotRun": "Check couldn't run",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -38,7 +38,15 @@
       "stepPassed": "Step passed",
       "stepFailed": "Not yet — see the results below",
       "expected": "Expected",
-      "observed": "Observed"
+      "observed": "Observed",
+      "stepError": "Some checks couldn't run — that's on us, not you. Fix the issue below or just try again.",
+      "stepErrorDocker": "Docker isn't running, so the checks couldn't run. Start Docker and validate again.",
+      "nextStep": "Next step",
+      "roadmapComplete": "Step passed — that was the last one. Roadmap complete!",
+      "checkNotRun": "Check couldn't run",
+      "markerPassed": "Passed",
+      "markerFailed": "Failed",
+      "markerError": "Check error"
     }
   },
   "projects": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -38,7 +38,15 @@
       "stepPassed": "Étape validée",
       "stepFailed": "Pas encore — voir les résultats ci-dessous",
       "expected": "Attendu",
-      "observed": "Observé"
+      "observed": "Observé",
+      "stepError": "Certaines vérifications n'ont pas pu s'exécuter — ce n'est pas de votre faute. Corrigez le problème ci-dessous ou réessayez simplement.",
+      "stepErrorDocker": "Docker n'est pas démarré, les vérifications n'ont pas pu s'exécuter. Démarrez Docker puis validez à nouveau.",
+      "nextStep": "Étape suivante",
+      "roadmapComplete": "Étape validée — c'était la dernière. Roadmap terminée !",
+      "checkNotRun": "Vérification impossible",
+      "markerPassed": "Validée",
+      "markerFailed": "Échouée",
+      "markerError": "Erreur de vérification"
     }
   },
   "projects": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -40,7 +40,7 @@
       "expected": "Attendu",
       "observed": "Observé",
       "stepError": "Certaines vérifications n'ont pas pu s'exécuter — ce n'est pas de votre faute. Corrigez le problème ci-dessous ou réessayez simplement.",
-      "stepErrorDocker": "Docker n'est pas démarré, les vérifications n'ont pas pu s'exécuter. Démarrez Docker puis validez à nouveau.",
+      "stepErrorDocker": "Docker n'était pas démarré, les vérifications n'ont pas pu s'exécuter. Démarrez Docker puis validez à nouveau.",
       "nextStep": "Étape suivante",
       "roadmapComplete": "Étape validée — c'était la dernière. Roadmap terminée !",
       "checkNotRun": "Vérification impossible",

--- a/frontend/src/shared/types/roadmap.ts
+++ b/frontend/src/shared/types/roadmap.ts
@@ -76,7 +76,11 @@ export interface ValidatorResult {
   type: string;
   status: ValidatorStatus;
   message: string;
-  /** Set iff status is 'error'. Wider than the backend union: the frontend only displays it. */
+  /**
+   * Set iff status is 'error'. Wider than the backend union: the frontend matches
+   * the codes it knows (see features/learning/validationStatus.ts) and treats the
+   * rest generically, so new backend codes never break rendering.
+   */
   errorCode?: string;
   expected?: string;
   observed?: string;


### PR DESCRIPTION
## Summary of Changes

The roadmap player previously rendered validation results raw (`[pass]`/`[fail]` text, validator type slugs, raw error codes). This PR turns them into real pedagogical feedback:

- **Per-validator cards** with a ✓/✗/⚠ icon, colored left border, the backend message as primary text, and `Expected`/`Observed` values in monospace.
- **Aggregate step banner** with three distinct families: green success (with an explicit **Next step** button, or a "roadmap complete" message on the last step), red pedagogical failure (encouraging tone), and amber infrastructure error — visually and verbally impossible to confuse with a learner mistake, with a Docker-specific wording when the daemon was unreachable.
- **Three-state step-list markers** (✓/✗/⚠) via a shared `stepOutcome` helper: an infra error never shows as a learner failure. Error wins over fail in the aggregate because the step's real state is unknowable when a check couldn't run (documented in `validationStatus.ts`).
- Shared status presets (icon/color/label) live once in `features/learning/validationStatus.ts`; icons carry `role="img"` + `aria-label` so status is announced by screen readers.
- New `--color-warning*` CSS variables aligned with the existing amber infrastructure-error language (daemon banner, node badge, toast).
- New i18n keys (en/fr) for the banner copy, CTA, and marker labels.

No backend changes; no changes to `useLearningPlayer` (revalidation already replaces the whole per-step response, so no stale artifacts by construction).

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

Drove the full flow in a real browser (Playwright + Chrome) against real Docker on the example roadmap:
1. **Pedagogical fail**: validated step 1 on an empty project → red banner, ✗ card with message + Expected/Observed, red marker in the step list.
2. **Success + revalidation**: created and started the `web` container, revalidated → green banner + **Next step** button, no artifacts from the failed attempt; CTA advances to step 2.
3. **Infrastructure error**: with the Docker daemon unreachable, validated → amber banner with the Docker-specific "not your fault" wording, ⚠ cards with "Check couldn't run", amber marker; coexists with the global daemon banner. After restoring Docker, revalidated in the same session → clean recovery, no amber leftovers.
4. Spot-checked all new strings in French.

Frontend suite: 203 tests green (8 new: three result families, aggregation precedence, fully-validated step, revalidation without artifacts, Next step CTA).

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing