### PR TITLE
feat(security): bind API to loopback by default and restrict CORS to local origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ npx torollo start
 
 ---
 
+## Self-Hosting & Network Exposure
+
+By default, the Torollo API binds to `127.0.0.1` and only accepts cross-origin requests from local origins (`localhost`, `127.0.0.1`, `[::1]`). Other machines on your network cannot reach it, and no configuration is needed for normal use.
+
+To access Torollo from another machine (e.g. a home lab server), opt in explicitly:
+
+```bash
+TOROLLO_HOST=0.0.0.0 TOROLLO_ALLOWED_ORIGINS=http://<your-lan-ip>:23232 npx torollo start
+```
+
+- `TOROLLO_HOST` — address the API binds to (default `127.0.0.1`; set to `0.0.0.0` to listen on all interfaces).
+- `TOROLLO_ALLOWED_ORIGINS` — comma-separated list of exact extra origins allowed to call the API from a browser (the address you type into the browser, e.g. `http://192.168.1.5:23232`).
+
+> ⚠️ **Warning:** Torollo has no authentication. Exposing it gives everyone on the network terminal access to its containers and control over Docker on your machine. Only do this on a trusted network, or put it behind an authenticating reverse proxy.
+
+---
+
 ## Supported Infrastructure Nodes
 
 You can drag and drop a wide range of infrastructure components onto the canvas. Everything is backed by **real Docker containers** running locally on your machine.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,10 @@ Only the latest `main` branch and the most recent release receive security updat
 | 1.0.x   | :white_check_mark: |
 | < 1.0   | :x:                |
 
+## Network Exposure Defaults
+
+The backend binds to loopback (`127.0.0.1`) by default and restricts cross-origin requests to local origins. Torollo has no authentication; see the "Self-Hosting & Network Exposure" section of the README before exposing it to a network.
+
 ## Reporting a Vulnerability
 
 Please do not open a public issue for security vulnerabilities. Instead, report them privately by emailing **youssefmoinou@gmail.com**.

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -3,6 +3,7 @@ dotenv.config();
 
 export const ENV = {
   PORT: process.env.PORT || 23233,
+  HOST: process.env.TOROLLO_HOST || '127.0.0.1',
   NODE_ENV: process.env.NODE_ENV || 'development',
   DOCKER_SOCKET: process.env.DOCKER_SOCKET || (process.platform === 'win32' 
     ? '//./pipe/docker_engine' 

--- a/backend/src/config/httpSecurity.test.ts
+++ b/backend/src/config/httpSecurity.test.ts
@@ -1,0 +1,53 @@
+import { isAllowedOrigin, parseAllowedOrigins } from './httpSecurity';
+
+describe('isAllowedOrigin', () => {
+  it('allows requests without an Origin header', () => {
+    expect(isAllowedOrigin(undefined, [])).toBe(true);
+  });
+
+  it.each([
+    'http://localhost:23232',
+    'http://localhost:51234',
+    'http://127.0.0.1:23233',
+    'http://[::1]:23232',
+    'https://localhost:23232'
+  ])('allows local origin %s on any port', origin => {
+    expect(isAllowedOrigin(origin, [])).toBe(true);
+  });
+
+  it.each([
+    'https://evil.com',
+    'http://localhost.evil.com:23232',
+    'http://192.168.1.5:23232',
+    'ftp://localhost:21',
+    'null',
+    'not-a-url'
+  ])('rejects non-local origin %s', origin => {
+    expect(isAllowedOrigin(origin, [])).toBe(false);
+  });
+
+  it('allows origins from the explicit allowlist', () => {
+    expect(isAllowedOrigin('http://192.168.1.5:23232', ['http://192.168.1.5:23232'])).toBe(true);
+  });
+
+  it('requires an exact match against the allowlist', () => {
+    expect(isAllowedOrigin('http://192.168.1.5:9999', ['http://192.168.1.5:23232'])).toBe(false);
+  });
+});
+
+describe('parseAllowedOrigins', () => {
+  it('returns an empty list when unset', () => {
+    expect(parseAllowedOrigins(undefined)).toEqual([]);
+    expect(parseAllowedOrigins('')).toEqual([]);
+  });
+
+  it('splits on commas and trims whitespace', () => {
+    expect(parseAllowedOrigins(' http://192.168.1.5:23232 , http://10.0.0.2:23232'))
+      .toEqual(['http://192.168.1.5:23232', 'http://10.0.0.2:23232']);
+  });
+
+  it('strips trailing slashes and empty segments', () => {
+    expect(parseAllowedOrigins('http://192.168.1.5:23232/,,'))
+      .toEqual(['http://192.168.1.5:23232']);
+  });
+});

--- a/backend/src/config/httpSecurity.ts
+++ b/backend/src/config/httpSecurity.ts
@@ -1,0 +1,48 @@
+import { CorsOptions } from 'cors';
+
+/**
+ * Hostnames considered local. Origins pointing at any of these are allowed
+ * on any port: the frontend port is picked dynamically by the CLI, and a
+ * local process can already reach a loopback-bound API directly.
+ */
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/** Parse a comma-separated list of origins (TOROLLO_ALLOWED_ORIGINS). */
+export function parseAllowedOrigins(raw?: string): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map(origin => origin.trim().replace(/\/$/, ''))
+    .filter(Boolean);
+}
+
+/**
+ * An origin is allowed if it is absent (same-origin, curl, health probes),
+ * explicitly allowlisted, or a local http(s) origin on any port.
+ */
+export function isAllowedOrigin(origin: string | undefined, extraOrigins: string[]): boolean {
+  if (!origin) return true;
+  if (extraOrigins.includes(origin)) return true;
+  try {
+    const url = new URL(origin);
+    return (url.protocol === 'http:' || url.protocol === 'https:')
+      && LOCAL_HOSTNAMES.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+const extraOrigins = parseAllowedOrigins(process.env.TOROLLO_ALLOWED_ORIGINS);
+
+/**
+ * Origin check for the Socket.IO handshake (allowRequest). CORS alone does
+ * not cover direct WebSocket connections, which browsers exempt from CORS.
+ */
+export function isRequestOriginAllowed(origin?: string): boolean {
+  return isAllowedOrigin(origin, extraOrigins);
+}
+
+/** Shared CORS options for the HTTP middleware and Socket.IO. */
+export const corsConfig: CorsOptions = {
+  origin: (origin, callback) => callback(null, isAllowedOrigin(origin, extraOrigins)),
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import http from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
 import { ENV } from './config/env';
+import { corsConfig, isRequestOriginAllowed } from './config/httpSecurity';
 import projectRouter from './modules/projects/routes/projectRoutes';
 import containerRouter from './modules/containers/routes/containerRoutes';
 import healthRouter from './modules/health/routes/healthRoutes';
@@ -13,10 +14,7 @@ import { DockerInitializer } from './infrastructure/docker/DockerInitializer';
 const app = express();
 const server = http.createServer(app);
 
-app.use(cors({
-  origin: '*',
-  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
-}));
+app.use(cors(corsConfig));
 app.use(express.json());
 
 // Health probe
@@ -29,16 +27,14 @@ app.use('/api/learning', learningRouter);
 
 // Socket.IO Setup
 const io = new Server(server, {
-  cors: {
-    origin: '*',
-    methods: ['GET', 'POST']
-  }
+  cors: corsConfig,
+  allowRequest: (req, callback) => callback(null, isRequestOriginAllowed(req.headers.origin))
 });
 
 TerminalGateway.handleConnections(io);
 
-server.listen(ENV.PORT, () => {
-  console.log(`Backend server running in ${ENV.NODE_ENV} mode on port ${ENV.PORT}`);
+server.listen(Number(ENV.PORT), ENV.HOST, () => {
+  console.log(`Backend server running in ${ENV.NODE_ENV} mode on ${ENV.HOST}:${ENV.PORT}`);
   // Run background Docker check & pull
   DockerInitializer.initialize();
 });

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -33,4 +33,4 @@ export interface TerminalInfo {
 /** API base URL for the backend */
 export const API_BASE = import.meta.env.DEV
   ? 'http://localhost:23233'
-  : `http://localhost:${(window as any).TOROLLO_BACKEND_PORT || 23233}`;
+  : `http://${window.location.hostname}:${(window as any).TOROLLO_BACKEND_PORT || 23233}`;


### PR DESCRIPTION
## Summary of Changes

The backend previously listened on all interfaces (`server.listen` without a host → `0.0.0.0`) with `origin: '*'` CORS on both the HTTP API and Socket.IO, making the API — including container terminals — reachable from any machine on the local network. This PR:

- Binds the API to `127.0.0.1` by default, with an explicit opt-in via `TOROLLO_HOST` (e.g. `0.0.0.0`).
- Replaces the wildcard CORS with a shared config (`backend/src/config/httpSecurity.ts`) used by both the HTTP middleware and Socket.IO: local origins (`localhost`, `127.0.0.1`, `[::1]`, any port — the CLI picks the frontend port dynamically) plus exact extra origins from `TOROLLO_ALLOWED_ORIGINS` (comma-separated) for the LAN opt-in.
- Adds an origin check on the Socket.IO handshake (`allowRequest`) — direct WebSocket connections are exempt from browser CORS, so CORS alone would not have protected the terminal gateway.
- Makes the production frontend derive the backend host from `window.location.hostname` instead of hardcoded `localhost`, so the LAN opt-in actually works end-to-end (identical behavior for local use).
- Documents the defaults and the opt-in (with a warning) in a new README "Self-Hosting & Network Exposure" section and in SECURITY.md.

No CLI changes needed: `bin/cli.js` already spreads `process.env` when spawning the backend.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: 28 suites / 263 tests green (includes new `httpSecurity.test.ts`). Frontend: 19 files / 225 tests green, build green.

### Manual Verification

**Default posture** (`node backend/dist/server.js`):

```
$ ss -tlnp | grep 23233
LISTEN 0      511        127.0.0.1:23233      0.0.0.0:*

$ curl -si http://127.0.0.1:23233/health | head -3
HTTP/1.1 200 OK                                    # no Origin (curl/same-origin) still works

$ curl -si -H 'Origin: https://evil.com' http://127.0.0.1:23233/health | grep -ci access-control-allow-origin
0                                                  # foreign origin gets no ACAO

$ curl -si -H 'Origin: http://localhost:23232' http://127.0.0.1:23233/health | grep -i access-control-allow-origin
Access-Control-Allow-Origin: http://localhost:23232

$ curl -si -H 'Origin: http://localhost.evil.com:23232' http://127.0.0.1:23233/health | grep -ci access-control-allow-origin
0                                                  # hostname is compared exactly

$ curl -si -H 'Origin: https://evil.com' 'http://127.0.0.1:23233/socket.io/?EIO=4&transport=polling' | head -1
HTTP/1.1 403 Forbidden                             # Socket.IO handshake rejected

$ curl -s -H 'Origin: http://localhost:23232' 'http://127.0.0.1:23233/socket.io/?EIO=4&transport=polling' | head -c 60
0{"sid":"sM6Jke-cgBVHWO5LAAAD","upgrades":["websocket"] ...

$ curl -s --max-time 3 http://192.168.0.69:23233/health ; echo exit=$?   # host's own LAN address
exit=7                                             # connection refused from the LAN
```

Direct WebSocket transport (browser CORS does not apply there), via `socket.io-client` with a forged `Origin` header:

```
websocket evil origin     : REFUSED (websocket error)
websocket localhost origin: CONNECTED (id=1ga-VSnHf5i3qUgqAAAC)
```

**Opt-in posture** (`TOROLLO_HOST=0.0.0.0 TOROLLO_ALLOWED_ORIGINS=http://192.168.0.69:23232`):

```
$ ss -tlnp | grep 23233
LISTEN 0      511          0.0.0.0:23233      0.0.0.0:*

$ curl -s http://192.168.0.69:23233/health
{"status":"ok","checks":{"docker":{"status":"ok"}}}

$ curl -si -H 'Origin: http://192.168.0.69:23232' http://192.168.0.69:23233/health | grep -i access-control-allow-origin
Access-Control-Allow-Origin: http://192.168.0.69:23232

$ curl -si -H 'Origin: https://evil.com' http://192.168.0.69:23233/health | grep -ci access-control-allow-origin
0                                                  # exposure does not open CORS wide
```

**Full-app smoke** through the real CLI (`node bin/cli.js start`, production build, Playwright + headless Chrome): created a project, container node visible and ONLINE on the canvas, opened the terminal modal and ran `echo S1-OK-$((40+2))` → `S1-OK-42` rendered in xterm (proves the Socket.IO terminal under the new CORS + `allowRequest`), opened the learning player showing the roadmap catalogue. Zero browser console errors.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
