### PR TITLE
fix(projects): make the projects.json store atomic and serialized

### DIFF
--- a/backend/src/infrastructure/docker/DockerInitializer.test.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.test.ts
@@ -68,6 +68,30 @@ describe('DockerInitializer.ensureSharedNetwork', () => {
     });
   });
 
+  it('accepts the versioned envelope format like the bare array', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    (mockedFs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({
+      version: 1,
+      projects: [{ id: 'project-1', networkConfig: { subnets: [{ id: 'subnet-1' }] } }]
+    }));
+
+    await ensureSharedNetwork();
+
+    expect(mockedDocker.getNetwork).toHaveBeenCalledTimes(1);
+    expect(mockedDocker.getNetwork).toHaveBeenCalledWith('n2');
+    expect(networkHandle.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips cleanup on an unknown store version, and never moves the file aside', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    (mockedFs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ version: 2, projects: [] }));
+
+    await ensureSharedNetwork();
+
+    expect(networkHandle.remove).not.toHaveBeenCalled();
+    expect(mockedFs.renameSync).not.toHaveBeenCalled();
+  });
+
   it('skips cleanup when projects.json is not an array', async () => {
     mockedFs.existsSync.mockReturnValue(true);
     (mockedFs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({}));

--- a/backend/src/infrastructure/docker/DockerInitializer.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import os from 'os';
 import docker from './DockerClient';
 import { NODE_TYPES } from './nodeTypes';
+import { parseProjectsRaw } from '../../modules/projects/services/projectStore';
 
 export class DockerInitializer {
   private static isInitializing = false;
@@ -32,19 +33,23 @@ export class DockerInitializer {
     const dbPath = path.join(os.homedir(), '.torollo', 'projects.json');
     const names = new Set<string>();
     if (!fs.existsSync(dbPath)) return names;
+    let projects;
     try {
-      const projects = JSON.parse(fs.readFileSync(dbPath, 'utf-8'));
-      if (!Array.isArray(projects)) throw new Error('projects.json is not an array');
-      for (const p of projects) {
-        for (const s of p.networkConfig?.subnets || []) {
-          names.add(`akal-subnet-${p.id}-${s.id}`);
-        }
-      }
-      return names;
+      projects = parseProjectsRaw(fs.readFileSync(dbPath, 'utf-8'));
     } catch (err) {
-      console.error('[DockerInitializer] Failed to parse projects.json for orphaned network cleanup:', err);
+      console.error('[DockerInitializer] Failed to read projects.json for orphaned network cleanup:', err);
       return null;
     }
+    if (projects === null) {
+      console.error('[DockerInitializer] Failed to parse projects.json for orphaned network cleanup');
+      return null;
+    }
+    for (const p of projects) {
+      for (const s of p.networkConfig?.subnets || []) {
+        names.add(`akal-subnet-${p.id}-${s.id}`);
+      }
+    }
+    return names;
   }
 
   private static async ensureSharedNetwork(): Promise<void> {

--- a/backend/src/modules/projects/controllers/projectController.test.ts
+++ b/backend/src/modules/projects/controllers/projectController.test.ts
@@ -28,12 +28,23 @@ describe('ProjectController', () => {
         { id: 'project-1', name: 'Project 1', createdAt: '2026-07-11T12:00:00.000Z' }
       ];
       (ProjectService.listProjects as jest.Mock).mockResolvedValue(mockProjects);
+      (ProjectService.consumeStoreRecovered as jest.Mock).mockReturnValue(false);
 
       const res = await request(app).get('/api/projects');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(mockProjects);
+      expect(res.body).toEqual({ projects: mockProjects });
       expect(ProjectService.listProjects).toHaveBeenCalled();
+    });
+
+    it('should surface the one-shot store recovery notice', async () => {
+      (ProjectService.listProjects as jest.Mock).mockResolvedValue([]);
+      (ProjectService.consumeStoreRecovered as jest.Mock).mockReturnValue(true);
+
+      const res = await request(app).get('/api/projects');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ projects: [], storeRecovered: true });
     });
 
     it('should handle errors and return 500 status', async () => {

--- a/backend/src/modules/projects/controllers/projectController.ts
+++ b/backend/src/modules/projects/controllers/projectController.ts
@@ -6,7 +6,12 @@ export class ProjectController {
   public static async list(req: Request, res: Response): Promise<void> {
     try {
       const list = await ProjectService.listProjects();
-      res.json(list);
+      // storeRecovered is one-shot: present (true) once after an unreadable
+      // store was moved aside, so the UI can tell the user.
+      res.json({
+        projects: list,
+        ...(ProjectService.consumeStoreRecovered() ? { storeRecovered: true } : {})
+      });
     } catch (err: any) {
       res.status(500).json({ error: err.message });
     }

--- a/backend/src/modules/projects/services/projectService.test.ts
+++ b/backend/src/modules/projects/services/projectService.test.ts
@@ -1,0 +1,235 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { ProjectService } from './projectService';
+import { ProjectStore } from './projectStore';
+import { NetworkService } from '../../network/services/networkService';
+import { ProgressService } from '../../learning/services/progressService';
+import { containerProvider } from '../../../infrastructure/docker/providers/dockerContainerProvider';
+
+jest.mock('../../network/services/networkService', () => ({
+  NetworkService: {
+    cleanupProjectNetwork: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+jest.mock('../../learning/services/progressService', () => ({
+  ProgressService: {
+    deleteProjectProgress: jest.fn()
+  }
+}));
+jest.mock('../../../infrastructure/docker/providers/dockerContainerProvider', () => ({
+  containerProvider: {
+    listContainersByProject: jest.fn().mockResolvedValue([]),
+    deleteContainer: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+const mutate = (fn: (store: ProjectStore) => unknown, file: string): Promise<unknown> =>
+  (ProjectService as unknown as {
+    mutate: (fn: (store: ProjectStore) => unknown, file: string) => Promise<unknown>;
+  }).mutate.call(ProjectService, fn, file);
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('ProjectService', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (NetworkService.cleanupProjectNetwork as jest.Mock).mockResolvedValue(undefined);
+    (containerProvider.listContainersByProject as jest.Mock).mockResolvedValue([]);
+    (containerProvider.deleteContainer as jest.Mock).mockResolvedValue(undefined);
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'torollo-projects-'));
+    file = path.join(dir, 'projects.json');
+    (ProjectService as unknown as { storeRecovered: boolean }).storeRecovered = false;
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns an empty list without creating the file when nothing was ever stored', async () => {
+    const projects = await ProjectService.listProjects(file);
+
+    expect(projects).toEqual([]);
+    expect(fs.existsSync(file)).toBe(false);
+    expect(ProjectService.consumeStoreRecovered()).toBe(false);
+  });
+
+  it('persists projects in the versioned envelope, atomically', async () => {
+    const created = await ProjectService.createProject('My Lab', file);
+
+    const stored = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(stored).toEqual({ version: 1, projects: [created] });
+    expect(created.name).toBe('My Lab');
+    expect(fs.existsSync(`${file}.tmp`)).toBe(false);
+  });
+
+  it('reads the legacy bare-array format and upgrades it on the next write', async () => {
+    const legacy = [{ id: 'project-1', name: 'Old', createdAt: '2026-07-01T00:00:00.000Z' }];
+    fs.writeFileSync(file, JSON.stringify(legacy));
+
+    const projects = await ProjectService.listProjects(file);
+    expect(projects).toEqual(legacy);
+    expect(fs.existsSync(`${file}.corrupt`)).toBe(false);
+    expect(ProjectService.consumeStoreRecovered()).toBe(false);
+
+    await ProjectService.saveNetworkConfig('project-1', { subnets: [] }, file);
+
+    const stored = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(stored.version).toBe(1);
+    expect(stored.projects).toHaveLength(1);
+    expect(stored.projects[0].id).toBe('project-1');
+    expect(stored.projects[0].networkConfig).toEqual({ subnets: [] });
+  });
+
+  it('moves an unparseable store aside and reports it once, never a silent empty list', async () => {
+    fs.writeFileSync(file, 'not json {');
+
+    const projects = await ProjectService.listProjects(file);
+
+    expect(projects).toEqual([]);
+    expect(fs.readFileSync(`${file}.corrupt`, 'utf-8')).toBe('not json {');
+    expect(ProjectService.consumeStoreRecovered()).toBe(true);
+    expect(ProjectService.consumeStoreRecovered()).toBe(false);
+  });
+
+  it('treats an unknown store version as unreadable, never guesses', async () => {
+    fs.writeFileSync(file, JSON.stringify({ version: 99, projects: [] }));
+
+    const projects = await ProjectService.listProjects(file);
+
+    expect(projects).toEqual([]);
+    expect(fs.existsSync(`${file}.corrupt`)).toBe(true);
+    expect(ProjectService.consumeStoreRecovered()).toBe(true);
+  });
+
+  it('ignores a leftover .tmp crash artifact and overwrites it on the next write', async () => {
+    await ProjectService.createProject('Survivor', file);
+    fs.writeFileSync(`${file}.tmp`, 'half-written garbage');
+
+    const projects = await ProjectService.listProjects(file);
+    expect(projects.map(p => p.name)).toEqual(['Survivor']);
+
+    await ProjectService.createProject('Second', file);
+    const stored = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(stored.projects.map((p: { name: string }) => p.name)).toEqual(['Survivor', 'Second']);
+    expect(fs.existsSync(`${file}.tmp`)).toBe(false);
+  });
+
+  it('keeps the previous valid store when the atomic rename fails mid-write', async () => {
+    const first = await ProjectService.createProject('Kept', file);
+
+    const renameSpy = jest.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+      throw new Error('simulated crash during rename');
+    });
+    await expect(ProjectService.createProject('Lost', file)).rejects.toThrow('simulated crash');
+    renameSpy.mockRestore();
+
+    const stored = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(stored).toEqual({ version: 1, projects: [first] });
+  });
+
+  it('serializes concurrent read-modify-write transactions (no lost update)', async () => {
+    await Promise.all([
+      mutate(async store => {
+        const count = store.projects.length;
+        await delay(20);
+        store.projects.push({ id: `slow-${count}`, name: `Slow ${count}`, createdAt: '' });
+      }, file),
+      mutate(async store => {
+        const count = store.projects.length;
+        await delay(5);
+        store.projects.push({ id: `fast-${count}`, name: `Fast ${count}`, createdAt: '' });
+      }, file)
+    ]);
+
+    // Without the queue, both transactions read length 0 and the second
+    // write clobbers the first — here both entries land, in FIFO order.
+    const projects = await ProjectService.listProjects(file);
+    expect(projects.map(p => p.id)).toEqual(['slow-0', 'fast-1']);
+  });
+
+  it('keeps every project from a burst of concurrent creations', async () => {
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) => ProjectService.createProject(`Project ${i}`, file))
+    );
+
+    const stored = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(stored.projects).toHaveLength(10);
+  });
+
+  it('does not poison the queue when a transaction throws', async () => {
+    await expect(
+      mutate(() => {
+        throw new Error('boom');
+      }, file)
+    ).rejects.toThrow('boom');
+
+    const created = await ProjectService.createProject('After failure', file);
+    expect((await ProjectService.listProjects(file)).map(p => p.id)).toEqual([created.id]);
+  });
+
+  it('deletes a project along with its network, progress and containers, leaving others intact', async () => {
+    // Explicit ids: createProject derives ids from Date.now(), which can
+    // collide for back-to-back creations and would make this test flaky.
+    fs.writeFileSync(file, JSON.stringify({
+      version: 1,
+      projects: [
+        { id: 'project-keep', name: 'Keep', createdAt: '' },
+        { id: 'project-target', name: 'Target', createdAt: '', networkConfig: { subnets: [{ id: 'subnet-1' }] } }
+      ]
+    }));
+    (containerProvider.listContainersByProject as jest.Mock).mockResolvedValue([{ id: 'c1' }]);
+
+    await ProjectService.deleteProject('project-target', file);
+
+    expect((await ProjectService.listProjects(file)).map(p => p.id)).toEqual(['project-keep']);
+    expect(NetworkService.cleanupProjectNetwork).toHaveBeenCalledWith(
+      'project-target',
+      { subnets: [{ id: 'subnet-1' }] }
+    );
+    expect(ProgressService.deleteProjectProgress).toHaveBeenCalledWith('project-target');
+    expect(containerProvider.deleteContainer).toHaveBeenCalledWith('c1');
+  });
+
+  it('does not clobber a project created while a slow deletion is doing Docker work', async () => {
+    fs.writeFileSync(file, JSON.stringify({
+      version: 1,
+      projects: [{ id: 'project-target', name: 'Target', createdAt: '', networkConfig: { subnets: [] } }]
+    }));
+    let releaseCleanup: () => void = () => undefined;
+    (NetworkService.cleanupProjectNetwork as jest.Mock).mockImplementation(
+      () => new Promise<void>(resolve => { releaseCleanup = resolve; })
+    );
+
+    const deletion = ProjectService.deleteProject('project-target', file);
+    await delay(5); // let the deletion reach the pending network cleanup
+    const created = await ProjectService.createProject('Concurrent', file);
+    releaseCleanup();
+    await deletion;
+
+    // The delete transaction re-reads the store, so the concurrent project
+    // survives instead of being overwritten by a stale snapshot.
+    expect((await ProjectService.listProjects(file)).map(p => p.id)).toEqual([created.id]);
+  });
+
+  it('saveNetworkConfig on an unknown project is a harmless no-op', async () => {
+    const existing = await ProjectService.createProject('Existing', file);
+
+    await ProjectService.saveNetworkConfig('project-unknown', { subnets: [] }, file);
+
+    expect(await ProjectService.getNetworkConfig('project-unknown', file)).toBeNull();
+    expect((await ProjectService.listProjects(file))).toEqual([existing]);
+  });
+
+  it('round-trips a network config through save and get', async () => {
+    const project = await ProjectService.createProject('Networked', file);
+    const config = { subnets: [{ id: 'subnet-1', cidr: '10.0.1.0/24' }], nodeSubnetMap: { n1: 'subnet-1' } };
+
+    await ProjectService.saveNetworkConfig(project.id, config, file);
+
+    expect(await ProjectService.getNetworkConfig(project.id, file)).toEqual(config);
+  });
+});

--- a/backend/src/modules/projects/services/projectService.ts
+++ b/backend/src/modules/projects/services/projectService.ts
@@ -4,56 +4,88 @@ import os from 'os';
 import { containerProvider } from '../../../infrastructure/docker/providers/dockerContainerProvider';
 import { NetworkService } from '../../network/services/networkService';
 import { ProgressService } from '../../learning/services/progressService';
+import { Project, ProjectStore, STORE_VERSION, parseProjectsRaw } from './projectStore';
 
-export interface Project {
-  id: string;
-  name: string;
-  createdAt: string;
-  networkConfig?: any;
-}
+export type { Project } from './projectStore';
 
 const TOROLLO_DIR = path.join(os.homedir(), '.torollo');
 const DB_PATH = path.join(TOROLLO_DIR, 'projects.json');
 
+/**
+ * Persistence of projects in ~/.torollo/projects.json. Same durability
+ * standard as the learning progress store — atomic write-then-rename,
+ * versioned envelope, non-destructive recovery of an unreadable file — plus
+ * one addition: every read-modify-write runs through a serialization queue,
+ * so concurrent operations can never lose each other's updates.
+ *
+ * The legacy format (a bare JSON array) is read transparently and upgraded
+ * to the envelope on the next write; no manual migration.
+ *
+ * The optional `filePath` parameters exist for tests only.
+ */
 export class ProjectService {
-  private static readDB(): Project[] {
-    if (!fs.existsSync(TOROLLO_DIR)) {
-      fs.mkdirSync(TOROLLO_DIR, { recursive: true });
-    }
-    if (!fs.existsSync(DB_PATH)) {
-      fs.writeFileSync(DB_PATH, JSON.stringify([]));
-    }
-    try {
-      const data = fs.readFileSync(DB_PATH, 'utf-8');
-      return JSON.parse(data);
-    } catch {
-      return [];
-    }
+  // Set when an unreadable store was moved aside; reported to the frontend by
+  // the next projects listing (once), so the user learns what happened.
+  private static storeRecovered = false;
+
+  // FIFO serialization of store transactions. A failed task must not poison
+  // the chain, hence the swallow when re-chaining.
+  private static queue: Promise<unknown> = Promise.resolve();
+
+  private static enqueue<T>(task: () => T | Promise<T>): Promise<T> {
+    const run = this.queue.then(task);
+    this.queue = run.then(() => undefined, () => undefined);
+    return run;
   }
 
-  private static writeDB(data: Project[]): void {
-    fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
+  /**
+   * Runs one serialized read-modify-write transaction. `fn` may mutate the
+   * store draft (including reassigning `store.projects`); the result is
+   * persisted atomically when it returns. The queue holds the store for the
+   * whole transaction — never do Docker or network I/O inside `fn`.
+   */
+  private static mutate<T>(
+    fn: (store: ProjectStore) => T | Promise<T>,
+    filePath: string
+  ): Promise<T> {
+    return this.enqueue(async () => {
+      const store = this.readStore(filePath);
+      const result = await fn(store);
+      this.writeStore(store, filePath);
+      return result;
+    });
   }
 
-  public static async listProjects(): Promise<Project[]> {
-    return this.readDB();
+  /** Serialized read-only access — waits for pending writes, writes nothing. */
+  private static withStore<T>(fn: (store: ProjectStore) => T, filePath: string): Promise<T> {
+    return this.enqueue(() => fn(this.readStore(filePath)));
   }
 
-  public static async createProject(name: string): Promise<Project> {
-    const db = this.readDB();
-    const newProject: Project = {
-      id: `project-${Date.now()}`,
-      name,
-      createdAt: new Date().toISOString()
-    };
-    db.push(newProject);
-    this.writeDB(db);
-    return newProject;
+  /** One-shot: reports whether an unreadable store was moved aside, then clears. */
+  public static consumeStoreRecovered(): boolean {
+    const recovered = this.storeRecovered;
+    this.storeRecovered = false;
+    return recovered;
   }
 
-  public static async deleteProject(id: string): Promise<void> {
-    const db = this.readDB();
-    const project = db.find(p => p.id === id);
+  public static async listProjects(filePath: string = DB_PATH): Promise<Project[]> {
+    return this.withStore(store => store.projects, filePath);
+  }
+
+  public static async createProject(name: string, filePath: string = DB_PATH): Promise<Project> {
+    return this.mutate(store => {
+      const newProject: Project = {
+        id: `project-${Date.now()}`,
+        name,
+        createdAt: new Date().toISOString()
+      };
+      store.projects.push(newProject);
+      return newProject;
+    }, filePath);
+  }
+
+  public static async deleteProject(id: string, filePath: string = DB_PATH): Promise<void> {
+    const project = await this.withStore(store => store.projects.find(p => p.id === id), filePath);
     if (project && project.networkConfig) {
       try {
         await NetworkService.cleanupProjectNetwork(id, project.networkConfig);
@@ -62,8 +94,9 @@ export class ProjectService {
       }
     }
 
-    const filtered = db.filter(p => p.id !== id);
-    this.writeDB(filtered);
+    await this.mutate(store => {
+      store.projects = store.projects.filter(p => p.id !== id);
+    }, filePath);
 
     // Learning progress is validated against this project's containers —
     // without them it is meaningless, so it goes with the project.
@@ -84,18 +117,60 @@ export class ProjectService {
     }
   }
 
-  public static async getNetworkConfig(projectId: string): Promise<any> {
-    const db = this.readDB();
-    const project = db.find(p => p.id === projectId);
-    return project?.networkConfig || null;
+  public static async getNetworkConfig(projectId: string, filePath: string = DB_PATH): Promise<any> {
+    return this.withStore(
+      store => store.projects.find(p => p.id === projectId)?.networkConfig || null,
+      filePath
+    );
   }
 
-  public static async saveNetworkConfig(projectId: string, networkConfig: any): Promise<void> {
-    const db = this.readDB();
-    const project = db.find(p => p.id === projectId);
-    if (project) {
-      project.networkConfig = networkConfig;
-      this.writeDB(db);
+  public static async saveNetworkConfig(
+    projectId: string,
+    networkConfig: any,
+    filePath: string = DB_PATH
+  ): Promise<void> {
+    await this.mutate(store => {
+      const project = store.projects.find(p => p.id === projectId);
+      if (project) {
+        project.networkConfig = networkConfig;
+      }
+    }, filePath);
+  }
+
+  private static readStore(filePath: string): ProjectStore {
+    if (!fs.existsSync(filePath)) {
+      return { version: STORE_VERSION, projects: [] };
     }
+    try {
+      // Accepts the legacy bare-array format too: not a corruption — read
+      // as-is, the next write persists the envelope.
+      const projects = parseProjectsRaw(fs.readFileSync(filePath, 'utf-8'));
+      if (projects !== null) {
+        return { version: STORE_VERSION, projects };
+      }
+    } catch {
+      // Unreadable file — recovered below, same as unparseable content.
+    }
+    // Never crash and never guess: move the unreadable file aside so nothing
+    // is silently destroyed, start fresh, and flag it for the next listing.
+    try {
+      fs.renameSync(filePath, `${filePath}.corrupt`);
+    } catch (err: unknown) {
+      console.error(`[projects] Failed to move unreadable project store aside:`, err);
+    }
+    console.error(
+      `[projects] Project store ${filePath} was unreadable or of an unknown version; ` +
+        `starting fresh (previous file kept as projects.json.corrupt).`
+    );
+    this.storeRecovered = true;
+    return { version: STORE_VERSION, projects: [] };
+  }
+
+  private static writeStore(store: ProjectStore, filePath: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    // Write-then-rename: a crash mid-write can never leave a truncated store.
+    const tmpPath = `${filePath}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(store, null, 2));
+    fs.renameSync(tmpPath, filePath);
   }
 }

--- a/backend/src/modules/projects/services/projectStore.ts
+++ b/backend/src/modules/projects/services/projectStore.ts
@@ -1,0 +1,48 @@
+export interface Project {
+  id: string;
+  name: string;
+  createdAt: string;
+  networkConfig?: any;
+}
+
+/**
+ * On-disk shape of ~/.torollo/projects.json. `version` is the migration
+ * contract: a reader that finds another version must treat the file as
+ * unknown, never guess. Same convention as the learning progress store.
+ */
+export interface ProjectStore {
+  version: typeof STORE_VERSION;
+  projects: Project[];
+}
+
+export const STORE_VERSION = 1;
+
+export function isProjectStore(data: unknown): data is ProjectStore {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as ProjectStore).version === STORE_VERSION &&
+    Array.isArray((data as ProjectStore).projects)
+  );
+}
+
+/**
+ * Pure parser of a projects file's raw contents — no fs, no side effects, so
+ * it is safe for readers (like startup network cleanup) that must never
+ * mutate the store. Accepts both the legacy bare-array format and the
+ * versioned envelope; anything else (broken JSON, unknown version) is null.
+ */
+export function parseProjectsRaw(raw: string): Project[] | null {
+  try {
+    const data: unknown = JSON.parse(raw);
+    if (Array.isArray(data)) {
+      return data;
+    }
+    if (isProjectStore(data)) {
+      return data.projects;
+    }
+  } catch {
+    // Unparseable — same as an unknown shape/version.
+  }
+  return null;
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -74,7 +74,9 @@
     "noProjects": "No projects found. Create a new one!",
     "lastUpdated": "Last updated:",
     "open": "Open",
-    "delete": "Delete"
+    "delete": "Delete",
+    "storeRecovered": "Your projects file could not be read and had to be reset. The unreadable file was kept as projects.json.corrupt in your .torollo folder.",
+    "dismissNotice": "Dismiss notice"
   },
   "vpc": {
     "titleInfo": "Project VPC Settings",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -74,7 +74,9 @@
     "noProjects": "Aucun projet trouvé. Créez-en un nouveau !",
     "lastUpdated": "Dernière mise à jour :",
     "open": "Ouvrir",
-    "delete": "Supprimer"
+    "delete": "Supprimer",
+    "storeRecovered": "Votre fichier de projets était illisible et a dû être réinitialisé. Le fichier illisible a été conservé sous projects.json.corrupt dans votre dossier .torollo.",
+    "dismissNotice": "Fermer l'avertissement"
   },
   "vpc": {
     "titleInfo": "Paramètres VPC du Projet",

--- a/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Plus } from 'lucide-react';
+import { AlertTriangle, Plus, X } from 'lucide-react';
 import InputModal from '../../shared/components/InputModal';
 import ConfirmModal from '../../shared/components/ConfirmModal';
 import ProjectCard from './components/ProjectCard';
@@ -22,6 +22,7 @@ export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<Project | null>(null);
   const [deletingIds, setDeletingIds] = useState<string[]>([]);
+  const [storeRecovered, setStoreRecovered] = useState(false);
 
   const toggleLanguage = () => {
     const nextLang = i18n.language === 'fr' ? 'en' : 'fr';
@@ -34,8 +35,13 @@ export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
       setLoading(true);
       const res = await fetch(`${API_BASE}/api/projects`);
       const data = await res.json();
-      if (Array.isArray(data)) {
-        setProjects(data);
+      if (Array.isArray(data?.projects)) {
+        setProjects(data.projects);
+      }
+      // One-shot notice from the backend: the projects file was unreadable
+      // and has been moved aside — keep the banner up until dismissed.
+      if (data?.storeRecovered === true) {
+        setStoreRecovered(true);
       }
     } catch (err) {
       console.error(err);
@@ -116,6 +122,20 @@ export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
           </button>
         </div>
       </div>
+
+      {storeRecovered && (
+        <div style={styles.noticeBox}>
+          <AlertTriangle size={13} color="var(--color-warning-strong)" style={{ flexShrink: 0 }} />
+          <span style={styles.noticeText}>{t('projects.storeRecovered')}</span>
+          <button
+            onClick={() => setStoreRecovered(false)}
+            style={styles.noticeDismiss}
+            aria-label={t('projects.dismissNotice')}
+          >
+            <X size={13} />
+          </button>
+        </div>
+      )}
 
       {loading && <p style={styles.loading}>{t('projects.loading')}</p>}
 
@@ -232,6 +252,32 @@ const styles: Record<string, React.CSSProperties> = {
   loading: {
     color: 'var(--color-text-secondary)',
     fontSize: '14px',
+  },
+  noticeBox: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '6px',
+    padding: '8px 10px',
+    border: '1px solid var(--color-warning)',
+    borderRadius: '6px',
+    backgroundColor: 'var(--color-warning-glow)',
+    marginBottom: '20px',
+  },
+  noticeText: {
+    flex: 1,
+    fontSize: '12px',
+    color: 'var(--color-warning-strong)',
+    lineHeight: 1.5,
+  },
+  noticeDismiss: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    cursor: 'pointer',
+    color: 'var(--color-warning-strong)',
   },
   grid: {
     display: 'grid',


### PR DESCRIPTION
## Summary of Changes

`~/.torollo/projects.json` is the only persistence for projects, and it could be lost in two ways: a crash during `writeFileSync` truncates the file (all projects gone), and an unparseable file was silently read as `[]` (all projects invisible, no trace). Concurrent read-modify-write operations could also silently lose each other's updates.

This PR brings the projects store up to the same durability standard as the learning progress store, plus write serialization:

- **Atomic writes**: write-then-rename (`projects.json.tmp` → `projects.json`), a crash can never leave a truncated store.
- **Versioned envelope**: on-disk format becomes `{ "version": 1, "projects": [...] }`. The legacy bare-array format is read transparently and upgraded on the next write — zero manual migration.
- **Non-destructive recovery**: an unreadable/unknown-version file is moved aside as `projects.json.corrupt` (never deleted, never silently ignored), the backend logs it, and `GET /api/projects` reports a one-shot `storeRecovered: true` that the projects page surfaces as a dismissible warning banner (en/fr).
- **Serialized transactions**: all store mutations run through a FIFO queue via a private `mutate(fn)` read-modify-write primitive — concurrent operations can no longer lose updates to the store file. Docker/network I/O deliberately stays outside the queue (`deleteProject` re-reads the store after its slow cleanup instead of writing a stale snapshot).
- `DockerInitializer`'s startup orphaned-network cleanup now parses both formats through a shared pure parser (`projectStore.ts`) and keeps its skip-on-unreadable semantics.
- `GET /api/projects` response shape changed from a bare array to `{ projects, storeRecovered? }` (frontend updated; app is shipped as one unit).

Notes (out of scope, flagged for follow-up): partial config updates still replace the whole `networkConfig` document (`asgService`/`saveNetworkConfig` merge semantics are a separate task that will build on `mutate`); `createProject` ids derive from `Date.now()` and can collide for same-millisecond creations; the duplicate-name check in `ProjectController.create` remains check-then-act outside the queue.

## Types of Changes

- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: 263/263 tests green (28 suites), incl. 15 new tests for the store (legacy migration, corrupt recovery + one-shot flag, unknown version, leftover `.tmp`, failed-rename crash, concurrent-transaction sequencing, burst of 10 concurrent creates, queue not poisoned by a throwing transaction, delete with slow Docker work not clobbering concurrent creates). Frontend: 225/225 green (`vitest run --maxWorkers=1`; a handful of pre-existing CanvasPage/LearningPanel 5s-timeout flakes appear under parallel load on a busy machine, also present on `main`). Lint: 0 errors both sides (6 pre-existing frontend warnings untouched).

### Manual Verification

All against the built backend (`node dist/server.js`) with an isolated `$HOME`, real Docker 29.6.0:

1. **Legacy migration**: seeded a bare-array `projects.json` → `GET /api/projects` lists both projects → first write upgrades the file to `{"version":1,"projects":[...]}` with all legacy entries preserved.
2. **Crash loop**: 8 iterations of `kill -9` on the backend mid-burst (40 concurrent `POST /api/projects` each) → after every restart the file is valid envelope JSON, project count only grows (12 → 29 → 53 → 76 → 91 → 115 → 120 → 138), no torn file, no leftover `.tmp`.
3. **Recovery**: `echo '{ definitely not json' > projects.json` → restart → startup log shows `[DockerInitializer] Failed to parse projects.json for orphaned network cleanup` (cleanup skipped, nothing deleted) → first `GET /api/projects` returns `{"projects":[],"storeRecovered":true}`, second returns `{"projects":[]}` (one-shot) → `projects.json.corrupt` holds the original bytes → creating a project writes a fresh envelope. Loaded the production UI (CLI `bin/cli.js start`, headless Chrome): the projects page shows the dismissible warning banner "Your projects file could not be read and had to be reset. The unreadable file was kept as projects.json.corrupt in your .torollo folder."
4. **Delete round-trip**: create then delete a project through the API against real Docker → `{"success":true}`, store back to a clean envelope, network/progress/container cleanup paths invoked as before.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
