### PR TITLE
fix(security): enforce project ownership on all container operations and terminal sessions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,11 @@ on:
     paths:
       - 'backend/src/infrastructure/docker/nodeTypes.ts'
       - 'backend/src/infrastructure/docker/imageRequirements.itest.ts'
+      - 'backend/src/infrastructure/docker/providers/**'
+      - 'backend/src/infrastructure/docker/dockerErrors.ts'
       - 'backend/src/modules/learning/**'
+      - 'backend/src/modules/containers/**'
+      - 'backend/src/modules/terminal/**'
       - 'backend/jest.integration.config.js'
       - 'backend/package.json'
       - 'backend/package-lock.json'
@@ -23,7 +27,11 @@ on:
     paths:
       - 'backend/src/infrastructure/docker/nodeTypes.ts'
       - 'backend/src/infrastructure/docker/imageRequirements.itest.ts'
+      - 'backend/src/infrastructure/docker/providers/**'
+      - 'backend/src/infrastructure/docker/dockerErrors.ts'
       - 'backend/src/modules/learning/**'
+      - 'backend/src/modules/containers/**'
+      - 'backend/src/modules/terminal/**'
       - 'backend/jest.integration.config.js'
       - 'backend/package.json'
       - 'backend/package-lock.json'

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,7 @@
         "globals": "^17.6.0",
         "jest": "^30.4.2",
         "nodemon": "^3.1.14",
+        "socket.io-client": "^4.8.3",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
@@ -4124,6 +4125,20 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -7402,6 +7417,22 @@
         "ws": "~8.21.0"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
@@ -8436,6 +8467,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "globals": "^17.6.0",
     "jest": "^30.4.2",
     "nodemon": "^3.1.14",
+    "socket.io-client": "^4.8.3",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",

--- a/backend/src/infrastructure/docker/dockerErrors.test.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.test.ts
@@ -1,4 +1,4 @@
-import { classifyDockerError, sendDockerError } from './dockerErrors';
+import { classifyDockerError, sendDockerError, ContainerNotFoundError } from './dockerErrors';
 
 describe('classifyDockerError', () => {
   it.each([
@@ -52,6 +52,13 @@ describe('classifyDockerError', () => {
   it('classifies 404 "no such container" as CONTAINER_NOT_FOUND', () => {
     const result = classifyDockerError({ statusCode: 404, message: '(HTTP code 404) no such container - No such container: abc123' });
     expect(result).toMatchObject({ code: 'CONTAINER_NOT_FOUND', httpStatus: 404 });
+  });
+
+  it('classifies ContainerNotFoundError identically to a missing container (no existence leak)', () => {
+    const denied = classifyDockerError(new ContainerNotFoundError('abc123'));
+    const missing = classifyDockerError({ statusCode: 404, message: '(HTTP code 404) no such container - No such container: abc123' });
+    expect(denied).toEqual(missing);
+    expect(denied).toMatchObject({ code: 'CONTAINER_NOT_FOUND', httpStatus: 404 });
   });
 
   it('hides the raw engine message behind a generic one when the error has a statusCode', () => {

--- a/backend/src/infrastructure/docker/dockerErrors.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.ts
@@ -22,6 +22,18 @@ interface DockerErrorLike {
 }
 
 /**
+ * Thrown when a container id/name does not exist OR belongs to another
+ * project. Both cases map to the exact same 404 payload as
+ * CONTAINER_NOT_FOUND so a caller cannot probe for a container's existence.
+ */
+export class ContainerNotFoundError extends Error {
+  constructor(containerId: string) {
+    super(`No such container: ${containerId}`);
+    this.name = 'ContainerNotFoundError';
+  }
+}
+
+/**
  * Maps a raw error from dockerode (or a service layer above it) to a stable
  * error code, an HTTP status and a user-facing message.
  *
@@ -30,6 +42,14 @@ interface DockerErrorLike {
  * conflicts are reported by the Docker Engine as a generic 500.
  */
 export function classifyDockerError(err: unknown, context?: string): ClassifiedDockerError {
+  if (err instanceof ContainerNotFoundError) {
+    return {
+      code: 'CONTAINER_NOT_FOUND',
+      httpStatus: 404,
+      userMessage: 'This container no longer exists in Docker. Refresh the canvas.',
+    };
+  }
+
   const e = (err ?? {}) as DockerErrorLike;
   const message = e.message ?? '';
 

--- a/backend/src/infrastructure/docker/providers/containerProvider.ts
+++ b/backend/src/infrastructure/docker/providers/containerProvider.ts
@@ -15,6 +15,7 @@ export interface ContainerInfo {
 
 export interface ContainerProvider {
   listContainersByProject(projectId: string): Promise<ContainerInfo[]>;
+  assertContainerInProject(containerId: string, projectId: string): Promise<void>;
   createContainer(
     projectId: string,
     nodeName: string,

--- a/backend/src/infrastructure/docker/providers/dockerContainerProvider.test.ts
+++ b/backend/src/infrastructure/docker/providers/dockerContainerProvider.test.ts
@@ -1,0 +1,59 @@
+import docker from '../DockerClient';
+import { ContainerNotFoundError } from '../dockerErrors';
+import { DockerContainerProvider } from './dockerContainerProvider';
+
+jest.mock('../DockerClient', () => ({
+  __esModule: true,
+  default: {
+    getContainer: jest.fn()
+  }
+}));
+
+describe('DockerContainerProvider.assertContainerInProject', () => {
+  const provider = new DockerContainerProvider();
+
+  function mockInspect(result: { labels?: Record<string, string> } | { rejectWith: unknown }) {
+    const inspect =
+      'rejectWith' in result
+        ? jest.fn().mockRejectedValue(result.rejectWith)
+        : jest.fn().mockResolvedValue({ Config: { Labels: result.labels } });
+    (docker.getContainer as jest.Mock).mockReturnValue({ inspect });
+    return inspect;
+  }
+
+  it('resolves when the container carries the requested project label', async () => {
+    mockInspect({ labels: { 'akal.project.id': 'project-a' } });
+    await expect(provider.assertContainerInProject('c1', 'project-a')).resolves.toBeUndefined();
+  });
+
+  it('throws ContainerNotFoundError when the container belongs to another project', async () => {
+    mockInspect({ labels: { 'akal.project.id': 'project-b' } });
+    await expect(provider.assertContainerInProject('c1', 'project-a')).rejects.toBeInstanceOf(ContainerNotFoundError);
+  });
+
+  it('throws ContainerNotFoundError when the container has no akal labels at all', async () => {
+    mockInspect({ labels: { 'com.example.other': 'x' } });
+    await expect(provider.assertContainerInProject('c1', 'project-a')).rejects.toBeInstanceOf(ContainerNotFoundError);
+  });
+
+  it('throws ContainerNotFoundError when Labels is undefined', async () => {
+    mockInspect({ labels: undefined });
+    await expect(provider.assertContainerInProject('c1', 'project-a')).rejects.toBeInstanceOf(ContainerNotFoundError);
+  });
+
+  it('throws ContainerNotFoundError when the container does not exist (inspect 404)', async () => {
+    mockInspect({ rejectWith: { statusCode: 404, message: '(HTTP code 404) no such container' } });
+    await expect(provider.assertContainerInProject('ghost', 'project-a')).rejects.toBeInstanceOf(ContainerNotFoundError);
+  });
+
+  it('refuses an empty projectId even if the container has a label (fail closed)', async () => {
+    mockInspect({ labels: { 'akal.project.id': 'project-a' } });
+    await expect(provider.assertContainerInProject('c1', '')).rejects.toBeInstanceOf(ContainerNotFoundError);
+  });
+
+  it('rethrows non-404 errors untouched (daemon down must not read as a 404)', async () => {
+    const daemonDown = Object.assign(new Error('connect ECONNREFUSED /var/run/docker.sock'), { code: 'ECONNREFUSED' });
+    mockInspect({ rejectWith: daemonDown });
+    await expect(provider.assertContainerInProject('c1', 'project-a')).rejects.toBe(daemonDown);
+  });
+});

--- a/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
+++ b/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
@@ -1,4 +1,5 @@
 import docker from '../DockerClient';
+import { ContainerNotFoundError } from '../dockerErrors';
 import { NodeType, NodeTypeDescriptor, resolveNodeType } from '../nodeTypes';
 import { ContainerInfo, ContainerProvider } from './containerProvider';
 
@@ -69,6 +70,28 @@ export class DockerContainerProvider implements ContainerProvider {
       } else {
         throw pullErr;
       }
+    }
+  }
+
+  /**
+   * Verifies that `containerId` (id or name) carries the label
+   * `akal.project.id === projectId`. Throws ContainerNotFoundError otherwise —
+   * including when the container simply does not exist, so callers cannot
+   * distinguish "not yours" from "not there".
+   */
+  public async assertContainerInProject(containerId: string, projectId: string): Promise<void> {
+    let labels: Record<string, string> | undefined;
+    try {
+      const info = await docker.getContainer(containerId).inspect();
+      labels = info.Config?.Labels;
+    } catch (err: any) {
+      if (err?.statusCode === 404) {
+        throw new ContainerNotFoundError(containerId);
+      }
+      throw err;
+    }
+    if (!projectId || labels?.['akal.project.id'] !== projectId) {
+      throw new ContainerNotFoundError(containerId);
     }
   }
 

--- a/backend/src/modules/containers/containerOwnership.itest.ts
+++ b/backend/src/modules/containers/containerOwnership.itest.ts
@@ -1,0 +1,235 @@
+import { createServer } from 'http';
+import { AddressInfo } from 'net';
+import express from 'express';
+import request from 'supertest';
+import { Server } from 'socket.io';
+import { io as ioClient, Socket as ClientSocket } from 'socket.io-client';
+import docker from '../../infrastructure/docker/DockerClient';
+import { containerProvider } from '../../infrastructure/docker/providers/dockerContainerProvider';
+import { resolveNodeType } from '../../infrastructure/docker/nodeTypes';
+import { ProjectService } from '../projects/services/projectService';
+import containerRouter from './routes/containerRoutes';
+import { TerminalGateway } from '../terminal/gateway/terminalGateway';
+
+/**
+ * Integration tests (run with `npm run test:integration`, requires a Docker daemon).
+ *
+ * Proves the container-ownership rule against reality: a container is only
+ * reachable through the API and the terminal gateway when it carries the
+ * `akal.project.id` label of the project in the request. Three fixtures:
+ * - project A with its own containers (must stay fully operable),
+ * - project B (its containers must be invisible through A's URLs),
+ * - a "rogue" container created outside the app, without any akal label
+ *   (must be invisible everywhere, and untouched by refused operations).
+ */
+
+/**
+ * `containerProvider.createContainer` attaches every container to this network
+ * (`HostConfig.NetworkMode: 'akal-lab-network'`). In the running app it's created
+ * once at server startup (`DockerInitializer.ensureSharedNetwork`), but this suite
+ * never boots the server, so a fresh Docker daemon (e.g. a CI runner) won't have it.
+ */
+async function ensureSharedNetwork(): Promise<void> {
+  const networks = await docker.listNetworks();
+  if (!networks.some((n) => n.Name === 'akal-lab-network')) {
+    await docker.createNetwork({ Name: 'akal-lab-network', Driver: 'bridge' });
+  }
+}
+
+async function waitUntilReady(check: () => Promise<string>, label: string): Promise<void> {
+  const deadline = Date.now() + 60000;
+  let lastOutput = '';
+  while (Date.now() < deadline) {
+    lastOutput = await check();
+    if (!lastOutput.startsWith('ERROR')) return;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`${label} did not become ready in time (last output: ${lastOutput})`);
+}
+
+describe('container ownership — real containers', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/projects/:projectId/containers', containerRouter);
+
+  let projectAId = '';
+  let projectBId = '';
+  let appContainerId = '';
+  let dbContainerId = '';
+  let foreignContainerId = '';
+  let rogueContainerId = '';
+
+  beforeAll(async () => {
+    try {
+      await docker.ping();
+    } catch {
+      throw new Error(
+        'Docker daemon is not reachable. Integration tests require a running Docker daemon.'
+      );
+    }
+
+    await ensureSharedNetwork();
+
+    const projectA = await ProjectService.createProject('s2-ownership-fixture-a');
+    projectAId = projectA.id;
+    const projectB = await ProjectService.createProject('s2-ownership-fixture-b');
+    projectBId = projectB.id;
+
+    const appContainer = await containerProvider.createContainer(projectAId, 'app', 'ubuntu');
+    appContainerId = appContainer.id;
+    const db = await containerProvider.createContainer(projectAId, 'db', 'postgres');
+    dbContainerId = db.id;
+    const foreign = await containerProvider.createContainer(projectBId, 'other', 'ubuntu');
+    foreignContainerId = foreign.id;
+
+    // A container launched by hand, outside the app: same image (already pulled
+    // above), no akal label at all. A leftover from an aborted previous run
+    // would make createContainer fail on the name conflict — clear it first.
+    try {
+      await docker.getContainer('s2-rogue-container').remove({ force: true });
+    } catch {
+      // no leftover
+    }
+    const rogue = await docker.createContainer({
+      Image: resolveNodeType('ubuntu').image,
+      name: 's2-rogue-container',
+      Cmd: ['sleep', 'infinity'],
+    });
+    rogueContainerId = rogue.id;
+    await rogue.start();
+
+    await waitUntilReady(
+      () => containerProvider.executePsqlCommand(dbContainerId, 'postgres', 'SELECT 1;'),
+      'PostgreSQL'
+    );
+  });
+
+  afterAll(async () => {
+    try {
+      await docker.getContainer(rogueContainerId).remove({ force: true });
+    } catch {
+      // already gone
+    }
+    if (projectAId) await ProjectService.deleteProject(projectAId);
+    if (projectBId) await ProjectService.deleteProject(projectBId);
+  });
+
+  describe('a container launched outside the app is unreachable', () => {
+    it.each([
+      ['start', () => request(app).post(`/api/projects/${projectAId}/containers/${rogueContainerId}/start`)],
+      ['stop', () => request(app).post(`/api/projects/${projectAId}/containers/${rogueContainerId}/stop`)],
+      ['rename', () => request(app).patch(`/api/projects/${projectAId}/containers/${rogueContainerId}/rename`).send({ newName: 'stolen' })],
+      ['scale', () => request(app).post(`/api/projects/${projectAId}/containers/${rogueContainerId}/scale`).send({ cpus: 1 })],
+      ['postgres explorer', () => request(app).get(`/api/projects/${projectAId}/containers/${rogueContainerId}/postgres/explorer`)],
+      ['redis query', () => request(app).post(`/api/projects/${projectAId}/containers/${rogueContainerId}/redis/query`).send({ query: 'KEYS *' })],
+      ['nosql explorer', () => request(app).get(`/api/projects/${projectAId}/containers/${rogueContainerId}/nosql/explorer`)],
+      ['delete', () => request(app).delete(`/api/projects/${projectAId}/containers/${rogueContainerId}`)],
+    ])('%s answers 404 CONTAINER_NOT_FOUND', async (_op, doRequest) => {
+      const res = await doRequest();
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('CONTAINER_NOT_FOUND');
+    });
+
+    it('left the rogue container untouched by the refused stop/delete', async () => {
+      const info = await docker.getContainer(rogueContainerId).inspect();
+      expect(info.State.Running).toBe(true);
+      expect(info.Name).toContain('s2-rogue-container');
+    });
+  });
+
+  describe("another project's container is invisible through this project's URLs", () => {
+    it.each([
+      ['start', () => request(app).post(`/api/projects/${projectAId}/containers/${foreignContainerId}/start`)],
+      ['postgres explorer', () => request(app).get(`/api/projects/${projectAId}/containers/${foreignContainerId}/postgres/explorer`)],
+      ['delete', () => request(app).delete(`/api/projects/${projectAId}/containers/${foreignContainerId}`)],
+    ])('%s answers 404 CONTAINER_NOT_FOUND', async (_op, doRequest) => {
+      const res = await doRequest();
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('CONTAINER_NOT_FOUND');
+    });
+
+    it("left project B's container running", async () => {
+      const info = await docker.getContainer(foreignContainerId).inspect();
+      expect(info.State.Running).toBe(true);
+    });
+  });
+
+  describe("the project's own containers stay fully operable", () => {
+    it('stops, renames and restarts a project container', async () => {
+      const stop = await request(app).post(`/api/projects/${projectAId}/containers/${appContainerId}/stop`);
+      expect(stop.status).toBe(200);
+      expect(stop.body).toEqual({ success: true });
+
+      const rename = await request(app)
+        .patch(`/api/projects/${projectAId}/containers/${appContainerId}/rename`)
+        .send({ newName: 'app-renamed' });
+      expect(rename.status).toBe(200);
+      expect(rename.body.success).toBe(true);
+
+      const start = await request(app).post(`/api/projects/${projectAId}/containers/${appContainerId}/start`);
+      expect(start.status).toBe(200);
+      expect(start.body).toEqual({ success: true });
+
+      const info = await docker.getContainer(appContainerId).inspect();
+      expect(info.State.Running).toBe(true);
+      expect(info.Name).toContain('app-renamed');
+    });
+
+    it('serves the postgres explorer of a project container', async () => {
+      const res = await request(app).get(`/api/projects/${projectAId}/containers/${dbContainerId}/postgres/explorer`);
+      expect(res.status).toBe(200);
+      expect(res.body.map((entry: { database: string }) => entry.database)).toEqual(
+        expect.arrayContaining(['postgres'])
+      );
+    });
+  });
+
+  describe('terminal gateway', () => {
+    let io: Server;
+    let port = 0;
+    let client: ClientSocket | null = null;
+
+    beforeAll((done) => {
+      const httpServer = createServer();
+      io = new Server(httpServer);
+      TerminalGateway.handleConnections(io);
+      httpServer.listen(() => {
+        port = (httpServer.address() as AddressInfo).port;
+        done();
+      });
+    });
+
+    afterAll((done) => {
+      io.close(() => done());
+    });
+
+    afterEach(() => {
+      client?.disconnect();
+      client = null;
+    });
+
+    function joinAndWaitForOutput(containerId: string, projectId: string): Promise<string> {
+      return new Promise((resolve) => {
+        client = ioClient(`http://127.0.0.1:${port}`, { transports: ['websocket'] });
+        client.on('connect', () => {
+          client!.once('terminal-output', resolve);
+          client!.emit('join-terminal', { containerId, projectId });
+        });
+      });
+    }
+
+    it('refuses a shell into the rogue container and creates no exec', async () => {
+      const output = await joinAndWaitForOutput(rogueContainerId, projectAId);
+      expect(output).toContain('Error starting terminal');
+
+      const info = await docker.getContainer(rogueContainerId).inspect();
+      expect(info.ExecIDs ?? []).toHaveLength(0);
+    });
+
+    it("opens a shell into the project's own container", async () => {
+      const output = await joinAndWaitForOutput(appContainerId, projectAId);
+      expect(output).not.toContain('Error starting terminal');
+      expect(output.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/backend/src/modules/containers/controllers/containerController.test.ts
+++ b/backend/src/modules/containers/controllers/containerController.test.ts
@@ -1,35 +1,33 @@
 import request from 'supertest';
 import express from 'express';
 import { ContainerController } from './containerController';
+import { requireContainerOwnership } from '../middleware/containerOwnership';
 import { ContainerService } from '../services/containerService';
 import { ProjectService } from '../../projects/services/projectService';
 import { NetworkService } from '../../network/services/networkService';
-import docker from '../../../infrastructure/docker/DockerClient';
+import { ContainerNotFoundError } from '../../../infrastructure/docker/dockerErrors';
 
 // Mock Services
 jest.mock('../services/containerService');
 jest.mock('../../projects/services/projectService');
 jest.mock('../../network/services/networkService');
-jest.mock('../../../infrastructure/docker/DockerClient', () => ({
-  __esModule: true,
-  default: {
-    getContainer: jest.fn()
-  }
-}));
 
 const app = express();
 app.use(express.json());
 
 app.get('/api/projects/:projectId/containers', ContainerController.list);
 app.post('/api/projects/:projectId/containers', ContainerController.create);
-app.post('/api/containers/:id/start', ContainerController.start);
-app.post('/api/containers/:id/stop', ContainerController.stop);
-app.delete('/api/containers/:id', ContainerController.delete);
-app.patch('/api/projects/:projectId/containers/:id/rename', ContainerController.rename);
+app.post('/api/projects/:projectId/containers/:id/start', requireContainerOwnership, ContainerController.start);
+app.post('/api/projects/:projectId/containers/:id/stop', requireContainerOwnership, ContainerController.stop);
+app.delete('/api/projects/:projectId/containers/:id', requireContainerOwnership, ContainerController.delete);
+app.patch('/api/projects/:projectId/containers/:id/rename', requireContainerOwnership, ContainerController.rename);
+app.get('/api/projects/:projectId/containers/:id/postgres/explorer', requireContainerOwnership, ContainerController.postgresExplorer);
 
 describe('ContainerController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // The ownership guard passes by default; denial cases override this.
+    (ContainerService.assertContainerInProject as jest.Mock).mockResolvedValue(undefined);
   });
 
   describe('GET /api/projects/:projectId/containers', () => {
@@ -85,19 +83,46 @@ describe('ContainerController', () => {
     });
   });
 
-  describe('PATCH /api/projects/:projectId/containers/:id/rename', () => {
+  describe('container ownership guard', () => {
     beforeEach(() => {
-      (docker.getContainer as jest.Mock).mockReturnValue({
-        inspect: jest.fn().mockResolvedValue({
-          Config: {
-            Labels: {
-              'akal.project.id': 'test-project'
-            }
-          }
-        })
-      });
+      (ContainerService.assertContainerInProject as jest.Mock).mockRejectedValue(new ContainerNotFoundError('1'));
     });
 
+    it.each([
+      ['start', () => request(app).post('/api/projects/test-project/containers/1/start'), () => ContainerService.startContainer],
+      ['stop', () => request(app).post('/api/projects/test-project/containers/1/stop'), () => ContainerService.stopContainer],
+      ['delete', () => request(app).delete('/api/projects/test-project/containers/1'), () => ContainerService.deleteContainer],
+      ['rename', () => request(app).patch('/api/projects/test-project/containers/1/rename').send({ newName: 'x' }), () => ContainerService.renameContainer],
+      ['postgres explorer', () => request(app).get('/api/projects/test-project/containers/1/postgres/explorer'), () => ContainerService.getPostgresExplorer],
+    ])('answers 404 CONTAINER_NOT_FOUND on %s and never reaches the service', async (_op, doRequest, service) => {
+      const res = await doRequest();
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('CONTAINER_NOT_FOUND');
+      expect(ContainerService.assertContainerInProject).toHaveBeenCalledWith('1', 'test-project');
+      expect(service()).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/projects/:projectId/containers/:id/start', () => {
+    it('should start the container and re-apply the network policy of the URL project', async () => {
+      (ContainerService.startContainer as jest.Mock).mockResolvedValue(undefined);
+      (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue({ some: 'config' });
+      (NetworkService.applyPolicy as jest.Mock).mockResolvedValue(undefined);
+
+      const res = await request(app).post('/api/projects/test-project/containers/1/start');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true });
+      expect(ContainerService.assertContainerInProject).toHaveBeenCalledWith('1', 'test-project');
+      expect(ContainerService.startContainer).toHaveBeenCalledWith('1');
+      expect(ProjectService.getNetworkConfig).toHaveBeenCalledWith('test-project');
+      expect(NetworkService.clearPolicyHash).toHaveBeenCalledWith('test-project');
+      expect(NetworkService.applyPolicy).toHaveBeenCalledWith('test-project', { some: 'config' });
+    });
+  });
+
+  describe('PATCH /api/projects/:projectId/containers/:id/rename', () => {
     it('should rename a container successfully', async () => {
       (ContainerService.renameContainer as jest.Mock).mockResolvedValue(undefined);
       (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue({ some: 'config' });
@@ -105,7 +130,7 @@ describe('ContainerController', () => {
 
       const res = await request(app)
         .patch('/api/projects/test-project/containers/1/rename')
-        .send({ newName: 'new-name' });
+        .send({ newName: '  new-name  ' });
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true });
@@ -131,31 +156,6 @@ describe('ContainerController', () => {
 
       expect(res.status).toBe(400);
       expect(res.body).toEqual({ error: 'newName is required' });
-    });
-
-    it('should resolve the project from the container labels before renaming', async () => {
-      (docker.getContainer as jest.Mock).mockReturnValue({
-        inspect: jest.fn().mockResolvedValue({
-          Config: {
-            Labels: {
-              'akal.project.id': 'resolved-project'
-            }
-          }
-        })
-      });
-      (ContainerService.renameContainer as jest.Mock).mockResolvedValue(undefined);
-      (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue({ some: 'config' });
-      (NetworkService.applyPolicy as jest.Mock).mockResolvedValue(undefined);
-
-      const res = await request(app)
-        .patch('/api/projects/wrong-project/containers/1/rename')
-        .send({ newName: '  new-name  ' });
-
-      expect(res.status).toBe(200);
-      expect(ContainerService.renameContainer).toHaveBeenCalledWith('1', 'resolved-project', 'new-name');
-      expect(ProjectService.getNetworkConfig).toHaveBeenCalledWith('resolved-project');
-      expect(NetworkService.clearPolicyHash).toHaveBeenCalledWith('resolved-project');
-      expect(NetworkService.applyPolicy).toHaveBeenCalledWith('resolved-project', { some: 'config' });
     });
 
     it('should handle the same-name error gracefully by returning success', async () => {
@@ -189,7 +189,7 @@ describe('ContainerController', () => {
         Object.assign(new Error('connect ECONNREFUSED /var/run/docker.sock'), { code: 'ECONNREFUSED' })
       );
 
-      const res = await request(app).post('/api/containers/1/start');
+      const res = await request(app).post('/api/projects/test-project/containers/1/start');
 
       expect(res.status).toBe(503);
       expect(res.body.code).toBe('DOCKER_UNAVAILABLE');
@@ -231,7 +231,7 @@ describe('ContainerController', () => {
         Object.assign(new Error('container already started'), { statusCode: 304 })
       );
 
-      const res = await request(app).post('/api/containers/1/start');
+      const res = await request(app).post('/api/projects/test-project/containers/1/start');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true });

--- a/backend/src/modules/containers/controllers/containerController.ts
+++ b/backend/src/modules/containers/controllers/containerController.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'express';
 import { ContainerService } from '../services/containerService';
 import { ProjectService } from '../../projects/services/projectService';
 import { NetworkService } from '../../network/services/networkService';
-import docker from '../../../infrastructure/docker/DockerClient';
 import { sendDockerError } from '../../../infrastructure/docker/dockerErrors';
 
 export class ContainerController {
@@ -53,24 +52,16 @@ export class ContainerController {
   public static async start(req: Request, res: Response): Promise<void> {
     try {
       const containerId = req.params.id as string;
-      let projectId: string | undefined;
-      try {
-        const inspectData = await docker.getContainer(containerId).inspect();
-        projectId = inspectData.Config.Labels['akal.project.id'];
-      } catch (inspectErr) {
-        console.warn(`Failed to inspect container before starting:`, inspectErr);
-      }
+      const projectId = req.params.projectId as string;
 
       await ContainerService.startContainer(containerId);
 
-      if (projectId) {
-        const config = await ProjectService.getNetworkConfig(projectId);
-        if (config) {
-          NetworkService.clearPolicyHash(projectId);
-          NetworkService.applyPolicy(projectId, config).catch(err => {
-            console.error(`Failed to re-apply network policy on start:`, err);
-          });
-        }
+      const config = await ProjectService.getNetworkConfig(projectId);
+      if (config) {
+        NetworkService.clearPolicyHash(projectId);
+        NetworkService.applyPolicy(projectId, config).catch(err => {
+          console.error(`Failed to re-apply network policy on start:`, err);
+        });
       }
 
       res.json({ success: true });
@@ -82,24 +73,16 @@ export class ContainerController {
   public static async stop(req: Request, res: Response): Promise<void> {
     try {
       const containerId = req.params.id as string;
-      let projectId: string | undefined;
-      try {
-        const inspectData = await docker.getContainer(containerId).inspect();
-        projectId = inspectData.Config.Labels['akal.project.id'];
-      } catch (inspectErr) {
-        console.warn(`Failed to inspect container before stopping:`, inspectErr);
-      }
+      const projectId = req.params.projectId as string;
 
       await ContainerService.stopContainer(containerId);
 
-      if (projectId) {
-        const config = await ProjectService.getNetworkConfig(projectId);
-        if (config) {
-          NetworkService.clearPolicyHash(projectId);
-          NetworkService.applyPolicy(projectId, config).catch(err => {
-            console.error(`Failed to re-apply network policy on stop:`, err);
-          });
-        }
+      const config = await ProjectService.getNetworkConfig(projectId);
+      if (config) {
+        NetworkService.clearPolicyHash(projectId);
+        NetworkService.applyPolicy(projectId, config).catch(err => {
+          console.error(`Failed to re-apply network policy on stop:`, err);
+        });
       }
 
       res.json({ success: true });
@@ -111,24 +94,16 @@ export class ContainerController {
   public static async delete(req: Request, res: Response): Promise<void> {
     try {
       const containerId = req.params.id as string;
-      let projectId: string | undefined;
-      try {
-        const inspectData = await docker.getContainer(containerId).inspect();
-        projectId = inspectData.Config.Labels['akal.project.id'];
-      } catch (inspectErr) {
-        console.warn(`Failed to inspect container before deleting:`, inspectErr);
-      }
+      const projectId = req.params.projectId as string;
 
       await ContainerService.deleteContainer(containerId);
 
-      if (projectId) {
-        const config = await ProjectService.getNetworkConfig(projectId);
-        if (config) {
-          NetworkService.clearPolicyHash(projectId);
-          NetworkService.applyPolicy(projectId, config).catch(err => {
-            console.error(`Failed to re-apply network policy on delete:`, err);
-          });
-        }
+      const config = await ProjectService.getNetworkConfig(projectId);
+      if (config) {
+        NetworkService.clearPolicyHash(projectId);
+        NetworkService.applyPolicy(projectId, config).catch(err => {
+          console.error(`Failed to re-apply network policy on delete:`, err);
+        });
       }
 
       res.json({ success: true });
@@ -233,24 +208,13 @@ export class ContainerController {
         return;
       }
 
-      let resolvedProjectId: string | undefined;
-      try {
-        const inspectData = await docker.getContainer(id as string).inspect();
-        resolvedProjectId = inspectData.Config.Labels['akal.project.id'];
-      } catch (inspectErr) {
-        console.warn(`Failed to inspect container before renaming:`, inspectErr);
-      }
+      const projectId = req.params.projectId as string;
+      await ContainerService.renameContainer(id as string, projectId, trimmedNewName);
 
-      if (!resolvedProjectId) {
-        throw new Error('Unable to resolve project ID from container labels');
-      }
-
-      await ContainerService.renameContainer(id as string, resolvedProjectId, trimmedNewName);
-
-      const config = await ProjectService.getNetworkConfig(resolvedProjectId);
+      const config = await ProjectService.getNetworkConfig(projectId);
       if (config) {
-        NetworkService.clearPolicyHash(resolvedProjectId);
-        NetworkService.applyPolicy(resolvedProjectId, config).catch(err => {
+        NetworkService.clearPolicyHash(projectId);
+        NetworkService.applyPolicy(projectId, config).catch(err => {
           console.error(`Failed to re-apply network policy on rename:`, err);
         });
       }

--- a/backend/src/modules/containers/middleware/containerOwnership.ts
+++ b/backend/src/modules/containers/middleware/containerOwnership.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+import { ContainerService } from '../services/containerService';
+import { sendDockerError } from '../../../infrastructure/docker/dockerErrors';
+
+/**
+ * Guards every /:id container route: the container must carry the label
+ * `akal.project.id` matching the projectId in the URL, otherwise the request
+ * is answered 404 — indistinguishable from a missing container.
+ */
+export async function requireContainerOwnership(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await ContainerService.assertContainerInProject(req.params.id as string, req.params.projectId as string);
+    next();
+  } catch (err) {
+    sendDockerError(res, err, 'accessing the container');
+  }
+}

--- a/backend/src/modules/containers/routes/containerRoutes.ts
+++ b/backend/src/modules/containers/routes/containerRoutes.ts
@@ -1,22 +1,23 @@
 import { Router } from 'express';
 import { ContainerController } from '../controllers/containerController';
 import { AsgController } from '../controllers/asgController';
+import { requireContainerOwnership } from '../middleware/containerOwnership';
 
 const router = Router({ mergeParams: true });
 
 router.get('/', ContainerController.list);
 router.post('/', ContainerController.create);
-router.post('/:id/start', ContainerController.start);
-router.post('/:id/stop', ContainerController.stop);
-router.delete('/:id', ContainerController.delete);
-router.patch('/:id/rename', ContainerController.rename);
-router.get('/:id/postgres/explorer', ContainerController.postgresExplorer);
-router.post('/:id/postgres/query', ContainerController.postgresQuery);
-router.get('/:id/nosql/explorer', ContainerController.nosqlExplorer);
-router.post('/:id/nosql/query', ContainerController.nosqlQuery);
-router.get('/:id/redis/explorer', ContainerController.redisExplorer);
-router.post('/:id/redis/query', ContainerController.redisQuery);
-router.post('/:id/scale', ContainerController.scale);
+router.post('/:id/start', requireContainerOwnership, ContainerController.start);
+router.post('/:id/stop', requireContainerOwnership, ContainerController.stop);
+router.delete('/:id', requireContainerOwnership, ContainerController.delete);
+router.patch('/:id/rename', requireContainerOwnership, ContainerController.rename);
+router.get('/:id/postgres/explorer', requireContainerOwnership, ContainerController.postgresExplorer);
+router.post('/:id/postgres/query', requireContainerOwnership, ContainerController.postgresQuery);
+router.get('/:id/nosql/explorer', requireContainerOwnership, ContainerController.nosqlExplorer);
+router.post('/:id/nosql/query', requireContainerOwnership, ContainerController.nosqlQuery);
+router.get('/:id/redis/explorer', requireContainerOwnership, ContainerController.redisExplorer);
+router.post('/:id/redis/query', requireContainerOwnership, ContainerController.redisQuery);
+router.post('/:id/scale', requireContainerOwnership, ContainerController.scale);
 
 // ASG Routes
 router.post('/asg/:asgId/deploy', AsgController.deploy);

--- a/backend/src/modules/containers/services/containerService.ts
+++ b/backend/src/modules/containers/services/containerService.ts
@@ -21,6 +21,10 @@ export class ContainerService {
     return containerProvider.listContainersByProject(projectId);
   }
 
+  public static async assertContainerInProject(containerId: string, projectId: string): Promise<void> {
+    return containerProvider.assertContainerInProject(containerId, projectId);
+  }
+
   public static async createContainer(projectId: string, name: string, type?: string, isPublic?: boolean, customImage?: string, extraLabels?: Record<string, string>): Promise<ContainerInfo> {
     return containerProvider.createContainer(projectId, name, type, isPublic, customImage, extraLabels);
   }

--- a/backend/src/modules/terminal/gateway/terminalGateway.test.ts
+++ b/backend/src/modules/terminal/gateway/terminalGateway.test.ts
@@ -1,0 +1,106 @@
+import { createServer, Server as HttpServer } from 'http';
+import { AddressInfo } from 'net';
+import { Server } from 'socket.io';
+import { io as ioClient, Socket as ClientSocket } from 'socket.io-client';
+import { PassThrough } from 'stream';
+import { TerminalGateway } from './terminalGateway';
+import { TerminalManager } from '../../../infrastructure/docker/TerminalManager';
+import { ContainerService } from '../../containers/services/containerService';
+import { ContainerNotFoundError } from '../../../infrastructure/docker/dockerErrors';
+
+jest.mock('../../../infrastructure/docker/TerminalManager');
+jest.mock('../../containers/services/containerService');
+
+describe('TerminalGateway', () => {
+  let httpServer: HttpServer;
+  let io: Server;
+  let client: ClientSocket;
+  let port: number;
+
+  beforeAll((done) => {
+    httpServer = createServer();
+    io = new Server(httpServer);
+    TerminalGateway.handleConnections(io);
+    httpServer.listen(() => {
+      port = (httpServer.address() as AddressInfo).port;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    // io.close() also closes the underlying HTTP server.
+    io.close(() => done());
+  });
+
+  beforeEach((done) => {
+    jest.clearAllMocks();
+    client = ioClient(`http://127.0.0.1:${port}`, { transports: ['websocket'] });
+    client.on('connect', done);
+  });
+
+  afterEach(() => {
+    client.disconnect();
+  });
+
+  function nextOutput(): Promise<string> {
+    return new Promise((resolve) => client.once('terminal-output', resolve));
+  }
+
+  it('refuses a container that does not belong to the project and never opens a session', async () => {
+    (ContainerService.assertContainerInProject as jest.Mock).mockRejectedValue(new ContainerNotFoundError('foreign'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const output = nextOutput();
+    client.emit('join-terminal', { containerId: 'foreign', projectId: 'project-a' });
+
+    expect(await output).toContain('Error starting terminal');
+    expect(ContainerService.assertContainerInProject).toHaveBeenCalledWith('foreign', 'project-a');
+    expect(TerminalManager.createTerminalSession).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('does not leak the raw error and answers like a missing container', async () => {
+    (ContainerService.assertContainerInProject as jest.Mock).mockRejectedValue(new ContainerNotFoundError('foreign'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const output = nextOutput();
+    client.emit('join-terminal', { containerId: 'foreign', projectId: 'project-a' });
+
+    expect(await output).toContain('This container no longer exists in Docker');
+    consoleError.mockRestore();
+  });
+
+  it('opens a session and relays its output when the container belongs to the project', async () => {
+    (ContainerService.assertContainerInProject as jest.Mock).mockResolvedValue(undefined);
+    const stream = new PassThrough();
+    (TerminalManager.createTerminalSession as jest.Mock).mockResolvedValue({ stream, exec: {} });
+
+    const output = nextOutput();
+    client.emit('join-terminal', { containerId: 'legit', projectId: 'project-a' });
+
+    // Wait until the session is wired before writing to the stream.
+    await new Promise<void>((resolve) => {
+      const check = () => ((TerminalManager.createTerminalSession as jest.Mock).mock.calls.length ? resolve() : setTimeout(check, 10));
+      check();
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    stream.write('root@container:/# ');
+
+    expect(await output).toContain('root@container:/# ');
+    expect(ContainerService.assertContainerInProject).toHaveBeenCalledWith('legit', 'project-a');
+    expect(TerminalManager.createTerminalSession).toHaveBeenCalledWith('legit');
+  });
+
+  it('refuses a payload without projectId (fail closed)', async () => {
+    (ContainerService.assertContainerInProject as jest.Mock).mockRejectedValue(new ContainerNotFoundError('c1'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const output = nextOutput();
+    client.emit('join-terminal', { containerId: 'c1' });
+
+    expect(await output).toContain('Error starting terminal');
+    expect(ContainerService.assertContainerInProject).toHaveBeenCalledWith('c1', undefined);
+    expect(TerminalManager.createTerminalSession).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/backend/src/modules/terminal/gateway/terminalGateway.ts
+++ b/backend/src/modules/terminal/gateway/terminalGateway.ts
@@ -1,13 +1,16 @@
 import { Server, Socket } from 'socket.io';
 import { TerminalManager } from '../../../infrastructure/docker/TerminalManager';
+import { ContainerService } from '../../containers/services/containerService';
+import { classifyDockerError } from '../../../infrastructure/docker/dockerErrors';
 
 export class TerminalGateway {
   public static handleConnections(io: Server): void {
     io.on('connection', (socket: Socket) => {
       let execStream: NodeJS.ReadWriteStream | null = null;
 
-      socket.on('join-terminal', async ({ containerId }: { containerId: string }) => {
+      socket.on('join-terminal', async ({ containerId, projectId }: { containerId: string; projectId: string }) => {
         try {
+          await ContainerService.assertContainerInProject(containerId, projectId);
           const session = await TerminalManager.createTerminalSession(containerId);
           execStream = session.stream;
 
@@ -32,7 +35,8 @@ export class TerminalGateway {
 
         } catch (err: any) {
           console.error('Terminal session error:', err);
-          socket.emit('terminal-output', `\r\nError starting terminal: ${err.message}\r\n`);
+          const { userMessage } = classifyDockerError(err, 'starting the terminal');
+          socket.emit('terminal-output', `\r\nError starting terminal: ${userMessage}\r\n`);
         }
       });
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -42,9 +42,10 @@ function App() {
         />
       )}
 
-      {activeTerminal && (
+      {activeProject && activeTerminal && (
         <TerminalModal
           containerId={activeTerminal.id}
+          projectId={activeProject.id}
           nodeName={activeTerminal.name}
           onClose={() => setActiveTerminal(null)}
         />

--- a/frontend/src/features/terminal/components/TerminalModal.tsx
+++ b/frontend/src/features/terminal/components/TerminalModal.tsx
@@ -10,11 +10,12 @@ import { API_BASE } from '../../../shared/types';
 
 interface TerminalModalProps {
   containerId: string;
+  projectId: string;
   nodeName: string;
   onClose: () => void;
 }
 
-export default function TerminalModal({ containerId, nodeName, onClose }: TerminalModalProps) {
+export default function TerminalModal({ containerId, projectId, nodeName, onClose }: TerminalModalProps) {
   const { t } = useTranslation();
   const terminalRef = useRef<HTMLDivElement>(null);
   const socketRef = useRef<Socket | null>(null);
@@ -46,7 +47,7 @@ export default function TerminalModal({ containerId, nodeName, onClose }: Termin
       fitAddon.fit();
     }
 
-    socket.emit('join-terminal', { containerId });
+    socket.emit('join-terminal', { containerId, projectId });
 
     socket.on('terminal-output', (data: string) => {
       term.write(data);
@@ -72,7 +73,7 @@ export default function TerminalModal({ containerId, nodeName, onClose }: Termin
       socket.disconnect();
       term.dispose();
     };
-  }, [containerId]);
+  }, [containerId, projectId]);
 
   return (
     <div style={styles.overlay}>


### PR DESCRIPTION
## Summary of Changes

Every container operation now enforces project ownership: a container id (or name) is only reachable when the container carries the `akal.project.id` label matching the project of the request. Before this, the terminal gateway and all 11 `/:id` container endpoints (start/stop/delete/rename/scale + the Postgres/Redis/Mongo explorers and queries, which `docker exec` into the target) accepted **any** container id on the host — including containers that were never created by the app.

- New `assertContainerInProject(containerId, projectId)` on the container provider (single `inspect`, label check), exposed through `ContainerService`.
- New `requireContainerOwnership` Express middleware applied to all 11 `/:id` routes. Denials answer **404 with the exact same payload as a missing container** (`CONTAINER_NOT_FOUND`), so a caller cannot probe for a container's existence. Applied per-route (not `router.use('/:id')`) so the `/asg/*` routes are not shadowed.
- The terminal socket contract now requires `projectId` in `join-terminal`; the gateway verifies ownership before opening a shell and fails closed when `projectId` is absent. The frontend `TerminalModal` passes the active project id. Terminal errors now go through `classifyDockerError` instead of leaking raw Docker messages.
- `start`/`stop`/`delete`/`rename` handlers no longer re-inspect the container to resolve the project from labels — the guard guarantees the URL's `projectId` equals the label, so the duplicated inspect and its silent-failure path are gone. Renaming a foreign/unlabeled container now answers 404 instead of a 500.
- Since the guard resolves ids and names alike (`docker.getContainer` accepts both), access by container *name* is covered too.

**Known gap, out of scope here:** `asgService.scaleASG` lists ASG instances by the `akal.asg.id` label globally, without filtering by project (`backend/src/modules/containers/services/asgService.ts:56-59`). That file is being reworked in #73 and its follow-up, so the fix belongs there; flagging it for that work.

## Types of Changes

- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: lint + build + `npm test` → **29 suites, 263 tests green** (new: provider ownership tests, gateway tests over a real socket.io server, updated controller tests asserting the guard answers 404 and the service is never called). Frontend: lint + build + `npm test` → **19 files, 225 tests green** (run with `--maxWorkers=1`; parallel runs on my machine flake on unrelated CanvasPage/LearningPanel timeouts, also present on `main`).

New integration suite `containerOwnership.itest.ts` against a real Docker daemon (3 consecutive runs, 17/17 green):

```
PASS src/modules/containers/containerOwnership.itest.ts
Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
```

It creates project A (ubuntu + postgres), project B, and a hand-launched "rogue" container without any label, then proves: all 8 op families answer 404 `CONTAINER_NOT_FOUND` for the rogue id; project B's container is invisible through project A's URLs; the refused stop/delete left both untouched (`State.Running === true`); project A's own containers still stop/rename/start and serve the Postgres explorer; the real terminal gateway refuses the rogue (no exec created, `ExecIDs` empty) and opens a shell into the project's own container.

`integration.yml` paths now include the containers/terminal/provider modules so this suite runs in CI when they change.

### Manual Verification

Against the running app (real backend + real Docker), with `ROGUE` launched by hand via `docker run`:

```
POST /api/projects/<id>/containers/<rogueId>/start
{"error":"This container no longer exists in Docker. Refresh the canvas.","code":"CONTAINER_NOT_FOUND"} [404]
DELETE /api/projects/<id>/containers/<rogueId>
{"error":"...","code":"CONTAINER_NOT_FOUND"} [404]
GET /api/projects/<id>/containers/<rogueId>/postgres/explorer
{"error":"...","code":"CONTAINER_NOT_FOUND"} [404]
docker inspect s2-manual-rogue --format '{{.State.Running}}'  →  true (untouched)

POST .../containers/<ownId>/stop    → {"success":true} [200]
POST .../containers/<ownId>/start   → {"success":true} [200]
PATCH .../containers/<ownId>/rename → {"success":true} [200]
```

Forged `join-terminal` via a raw socket.io client against the running server:

```
[rogue]      first output: "\r\nError starting terminal: This container no longer exists in Docker. Refresh the canvas.\r\n"
[no-project] first output: "\r\nError starting terminal: This container no longer exists in Docker. Refresh the canvas.\r\n"
[legit]      first output: "...root@92e7c138cfa6:/# "
docker inspect s2-manual-rogue --format '{{.ExecIDs}}'  →  []  (no shell was ever created)
```

Real UI (Playwright, dev servers): opened the project, clicked the node's Terminal button, got a live `root@…:/#` shell in the xterm modal — the new client contract works end to end.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
