### PR TITLE
fix(docker): show a clear message for a shell into a stopped container

### DIFF
--- a/backend/src/infrastructure/docker/dockerErrors.test.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.test.ts
@@ -49,6 +49,12 @@ describe('classifyDockerError', () => {
     expect(result).toMatchObject({ code: 'NAME_CONFLICT', httpStatus: 409 });
   });
 
+  it('classifies a 409 "is not running" (exec on a stopped container) as CONTAINER_NOT_RUNNING', () => {
+    const result = classifyDockerError({ statusCode: 409, message: '(HTTP code 409) container stopped/paused - container abc123 is not running' });
+    expect(result).toMatchObject({ code: 'CONTAINER_NOT_RUNNING', httpStatus: 409 });
+    expect(result.userMessage).toContain('not running');
+  });
+
   it('classifies 404 "no such container" as CONTAINER_NOT_FOUND', () => {
     const result = classifyDockerError({ statusCode: 404, message: '(HTTP code 404) no such container - No such container: abc123' });
     expect(result).toMatchObject({ code: 'CONTAINER_NOT_FOUND', httpStatus: 404 });

--- a/backend/src/infrastructure/docker/dockerErrors.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.ts
@@ -6,6 +6,7 @@ export type DockerErrorCode =
   | 'PORT_IN_USE'
   | 'NAME_CONFLICT'
   | 'CONTAINER_NOT_FOUND'
+  | 'CONTAINER_NOT_RUNNING'
   | 'DOCKER_ERROR';
 
 export interface ClassifiedDockerError {
@@ -82,6 +83,17 @@ export function classifyDockerError(err: unknown, context?: string): ClassifiedD
       code: 'PORT_IN_USE',
       httpStatus: 409,
       userMessage: 'A port this container needs is already taken on your machine. Stop the application using it, then try again.',
+    };
+  }
+
+  // Docker exec (terminal, DB explorers/queries) answers 409 "is not running"
+  // when the target container is stopped or paused — a different situation from
+  // a name clash, so it must be matched before the generic 409 branch.
+  if (e.statusCode === 409 && /is not running|is paused/i.test(message)) {
+    return {
+      code: 'CONTAINER_NOT_RUNNING',
+      httpStatus: 409,
+      userMessage: 'This container is not running. Start it, then try again.',
     };
   }
 

--- a/backend/src/modules/containers/containerOwnership.itest.ts
+++ b/backend/src/modules/containers/containerOwnership.itest.ts
@@ -70,9 +70,9 @@ describe('container ownership — real containers', () => {
 
     await ensureSharedNetwork();
 
-    const projectA = await ProjectService.createProject('s2-ownership-fixture-a');
+    const projectA = await ProjectService.createProject('ownership-fixture-a');
     projectAId = projectA.id;
-    const projectB = await ProjectService.createProject('s2-ownership-fixture-b');
+    const projectB = await ProjectService.createProject('ownership-fixture-b');
     projectBId = projectB.id;
 
     const appContainer = await containerProvider.createContainer(projectAId, 'app', 'ubuntu');
@@ -86,13 +86,13 @@ describe('container ownership — real containers', () => {
     // above), no akal label at all. A leftover from an aborted previous run
     // would make createContainer fail on the name conflict — clear it first.
     try {
-      await docker.getContainer('s2-rogue-container').remove({ force: true });
+      await docker.getContainer('rogue-container').remove({ force: true });
     } catch {
       // no leftover
     }
     const rogue = await docker.createContainer({
       Image: resolveNodeType('ubuntu').image,
-      name: 's2-rogue-container',
+      name: 'rogue-container',
       Cmd: ['sleep', 'infinity'],
     });
     rogueContainerId = rogue.id;
@@ -133,7 +133,7 @@ describe('container ownership — real containers', () => {
     it('left the rogue container untouched by the refused stop/delete', async () => {
       const info = await docker.getContainer(rogueContainerId).inspect();
       expect(info.State.Running).toBe(true);
-      expect(info.Name).toContain('s2-rogue-container');
+      expect(info.Name).toContain('rogue-container');
     });
   });
 


### PR DESCRIPTION
## Summary of Changes

Two small follow-up fixes on top of the container-ownership work already on `main`:

1. **Stopped-container terminal message.** Docker answers `409 "... is not running"` when you `exec` into a stopped container (terminal, DB explorers/queries). `classifyDockerError` matched this with its generic `409` branch and returned `NAME_CONFLICT` ("A container with this name already exists…"), which is nonsensical for a container that simply isn't running. A dedicated branch now maps this case to a new `CONTAINER_NOT_RUNNING` code with the message "This container is not running. Start it, then try again." This also corrects the same misclassification on the HTTP DB endpoints, which already routed through `classifyDockerError`.

2. **Neutral test-fixture names.** The container-ownership integration test used fixture names carrying a branch-scoped prefix (`ownership` fixtures). They are renamed to plain, self-descriptive names so no build-scoped identifier ships in the public test suite.

## Types of Changes

- [x] Bug fix (non-breaking change resolving an issue)
- [ ] New feature / node type addition
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (`tsc`, exit 0)
- [x] `npm test` — 298/298 unit tests pass (adds one classifier test for the stopped-container 409)
- [x] `npm run test:integration -- src/modules/containers/containerOwnership.itest.ts` — 17/17 pass against a real Docker daemon

### Manual Verification

Reproduced the original bug empirically: `exec` on a stopped container throws `statusCode 409 "container … is not running"`; running the compiled `classifyDockerError` on that error returned `NAME_CONFLICT` before this change and `CONTAINER_NOT_RUNNING` after. The 17-test ownership integration suite (rogue container + cross-project) stays green with the renamed fixtures.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [ ] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
