### PR TITLE
fix(security): bound asg capacity and validate custom image references

### DIFF
--- a/backend/jest.integration.config.js
+++ b/backend/jest.integration.config.js
@@ -7,6 +7,9 @@ module.exports = {
   verbose: true,
   forceExit: true,
   collectCoverage: false,
+  // The suites share one Docker daemon (shared network, iptables chains, real
+  // containers): run them serially so their setups/cleanups can't race.
+  maxWorkers: 1,
   // Generous per-test budget: a cold run may need to pull multi-hundred-MB images.
   testTimeout: 300000
 };

--- a/backend/src/infrastructure/docker/dockerErrors.test.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.test.ts
@@ -1,4 +1,5 @@
 import { classifyDockerError, sendDockerError, ContainerNotFoundError } from './dockerErrors';
+import { InvalidImageReferenceError } from './imageReference';
 
 describe('classifyDockerError', () => {
   it.each([
@@ -32,6 +33,13 @@ describe('classifyDockerError', () => {
     expect(result.code).toBe('IMAGE_NOT_FOUND');
     expect(result.httpStatus).toBe(502);
     expect(result.userMessage).toContain('image');
+  });
+
+  it('classifies an InvalidImageReferenceError as INVALID_IMAGE_REFERENCE (400) with its message', () => {
+    const result = classifyDockerError(new InvalidImageReferenceError('bad image'));
+    expect(result.code).toBe('INVALID_IMAGE_REFERENCE');
+    expect(result.httpStatus).toBe(400);
+    expect(result.userMessage).toContain('bad image');
   });
 
   it('classifies a port conflict (reported as a 500 by the engine) as PORT_IN_USE (409)', () => {

--- a/backend/src/infrastructure/docker/dockerErrors.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 export type DockerErrorCode =
   | 'DOCKER_UNAVAILABLE'
   | 'IMAGE_NOT_FOUND'
+  | 'INVALID_IMAGE_REFERENCE'
   | 'PORT_IN_USE'
   | 'NAME_CONFLICT'
   | 'CONTAINER_NOT_FOUND'
@@ -52,6 +53,14 @@ export function classifyDockerError(err: unknown, context?: string): ClassifiedD
 
   const e = (err ?? {}) as DockerErrorLike;
   const message = e.message ?? '';
+
+  if (e.code === 'INVALID_IMAGE_REFERENCE') {
+    return {
+      code: 'INVALID_IMAGE_REFERENCE',
+      httpStatus: 400,
+      userMessage: message || 'The Docker image reference for this node is invalid.',
+    };
+  }
 
   const daemonUnreachable =
     e.code === 'ECONNREFUSED' ||

--- a/backend/src/infrastructure/docker/imageReference.test.ts
+++ b/backend/src/infrastructure/docker/imageReference.test.ts
@@ -1,0 +1,56 @@
+import { isValidImageReference, InvalidImageReferenceError } from './imageReference';
+
+describe('isValidImageReference', () => {
+  const validReferences = [
+    'ubuntu',
+    'ubuntu:latest',
+    'ubuntu:20.04',
+    'redis:7-alpine',
+    'library/ubuntu:20.04',
+    'a/b/c:1',
+    'akal-lab-project-my-project-asg-asg-1-image:latest',
+    'ghcr.io/org/app:v1.2.3',
+    'registry.example.com:5000/team/app:v1.2.3',
+    'localhost:5000/app',
+    'ubuntu@sha256:' + 'a'.repeat(64),
+    'ubuntu:latest@sha256:' + 'a'.repeat(64),
+    'some__image.name-1',
+  ];
+
+  it.each(validReferences)('accepts %s', ref => {
+    expect(isValidImageReference(ref)).toBe(true);
+  });
+
+  const invalidReferences: [string, string][] = [
+    ['empty string', ''],
+    ['uppercase repository', 'Ubuntu:latest'],
+    ['whitespace', 'ubuntu latest'],
+    ['empty tag', 'ubuntu:'],
+    ['tag starting with dash', 'ubuntu:-bad'],
+    ['double dots', 'foo..bar'],
+    ['double slash', 'foo//bar'],
+    ['leading dash', '-leading'],
+    ['shell injection attempt', 'ubuntu:$(rm -rf /)'],
+    ['embedded newline', 'ubuntu\n:latest'],
+    ['bad digest', 'ubuntu@sha256:xyz'],
+    ['overlong reference', 'a'.repeat(600)],
+  ];
+
+  it.each(invalidReferences)('rejects %s', (_label, ref) => {
+    expect(isValidImageReference(ref)).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(isValidImageReference(undefined as unknown as string)).toBe(false);
+    expect(isValidImageReference(42 as unknown as string)).toBe(false);
+  });
+});
+
+describe('InvalidImageReferenceError', () => {
+  it('carries the classification code and the offending reference', () => {
+    const err = new InvalidImageReferenceError('bad image');
+    expect(err.code).toBe('INVALID_IMAGE_REFERENCE');
+    expect(err.message).toContain('bad image');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/backend/src/infrastructure/docker/imageReference.ts
+++ b/backend/src/infrastructure/docker/imageReference.ts
@@ -1,0 +1,28 @@
+const MAX_REFERENCE_LENGTH = 512;
+
+// Grammar from the Docker distribution reference spec, simplified to what the
+// engine accepts for `docker create`: [registry[:port]/]path[:tag][@digest].
+const PATH_COMPONENT = '[a-z0-9]+(?:(?:\\.|_|__|-+)[a-z0-9]+)*';
+const DOMAIN = '(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?';
+const REGISTRY = `(?:${DOMAIN}|localhost)(?::[0-9]{1,5})?`;
+const NAME = `(?:${REGISTRY}/)?${PATH_COMPONENT}(?:/${PATH_COMPONENT})*`;
+const TAG = ':[\\w][\\w.-]{0,127}';
+const DIGEST = '@sha256:[a-f0-9]{64}';
+
+const IMAGE_REFERENCE_REGEX = new RegExp(`^${NAME}(?:${TAG})?(?:${DIGEST})?$`);
+
+export function isValidImageReference(ref: string): boolean {
+  if (typeof ref !== 'string' || ref.length === 0 || ref.length > MAX_REFERENCE_LENGTH) {
+    return false;
+  }
+  return IMAGE_REFERENCE_REGEX.test(ref);
+}
+
+export class InvalidImageReferenceError extends Error {
+  public readonly code = 'INVALID_IMAGE_REFERENCE';
+
+  constructor(ref: string) {
+    super(`Invalid Docker image reference: "${ref}".`);
+    this.name = 'InvalidImageReferenceError';
+  }
+}

--- a/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
+++ b/backend/src/infrastructure/docker/providers/dockerContainerProvider.ts
@@ -1,6 +1,7 @@
 import docker from '../DockerClient';
 import { ContainerNotFoundError } from '../dockerErrors';
 import { NodeType, NodeTypeDescriptor, resolveNodeType } from '../nodeTypes';
+import { InvalidImageReferenceError, isValidImageReference } from '../imageReference';
 import { ContainerInfo, ContainerProvider } from './containerProvider';
 
 export class DockerContainerProvider implements ContainerProvider {
@@ -149,6 +150,9 @@ export class DockerContainerProvider implements ContainerProvider {
     extraLabels?: Record<string, string>
   ): Promise<ContainerInfo> {
     const desc = resolveNodeType(type);
+    if (customImage !== undefined && !isValidImageReference(customImage)) {
+      throw new InvalidImageReferenceError(customImage);
+    }
     const image = customImage ?? desc.image;
 
     if (customImage) {

--- a/backend/src/modules/containers/controllers/asgController.test.ts
+++ b/backend/src/modules/containers/controllers/asgController.test.ts
@@ -1,0 +1,120 @@
+import request from 'supertest';
+import express from 'express';
+import { AsgController } from './asgController';
+import { AsgService } from '../services/asgService';
+import { InvalidImageReferenceError } from '../../../infrastructure/docker/imageReference';
+
+jest.mock('../services/asgService');
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/projects/:projectId/containers/asg/:asgId/deploy', AsgController.deploy);
+app.post('/api/projects/:projectId/containers/asg/:asgId/scale', AsgController.scale);
+
+const deployUrl = '/api/projects/test-project/containers/asg/asg-1/deploy';
+const scaleUrl = '/api/projects/test-project/containers/asg/asg-1/scale';
+
+describe('AsgController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsgService.deployASG as jest.Mock).mockResolvedValue([]);
+    (AsgService.scaleASG as jest.Mock).mockResolvedValue([]);
+  });
+
+  describe('POST .../asg/:asgId/deploy', () => {
+    it('deploys with the requested capacity', async () => {
+      const res = await request(app)
+        .post(deployUrl)
+        .send({ parentNodeId: 'node-1', desiredCapacity: 10, subnetIds: ['s1'] });
+
+      expect(res.status).toBe(200);
+      expect(AsgService.deployASG).toHaveBeenCalledWith('test-project', 'asg-1', 'node-1', 10, ['s1']);
+    });
+
+    it('defaults desiredCapacity to 1 when omitted', async () => {
+      const res = await request(app)
+        .post(deployUrl)
+        .send({ parentNodeId: 'node-1', subnetIds: ['s1'] });
+
+      expect(res.status).toBe(200);
+      expect(AsgService.deployASG).toHaveBeenCalledWith('test-project', 'asg-1', 'node-1', 1, ['s1']);
+    });
+
+    it.each([[11], [0], [-1], [2.5], ['7']])(
+      'rejects desiredCapacity %p with a classified 400 without calling the service',
+      async desiredCapacity => {
+        const res = await request(app)
+          .post(deployUrl)
+          .send({ parentNodeId: 'node-1', desiredCapacity, subnetIds: ['s1'] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('INVALID_CAPACITY');
+        expect(res.body.error).toBeTruthy();
+        expect(AsgService.deployASG).not.toHaveBeenCalled();
+      }
+    );
+
+    it('still requires parentNodeId', async () => {
+      const res = await request(app).post(deployUrl).send({ subnetIds: ['s1'] });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'parentNodeId is required to deploy ASG' });
+    });
+
+    it('still requires subnetIds', async () => {
+      const res = await request(app).post(deployUrl).send({ parentNodeId: 'node-1' });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'At least one target subnetId is required' });
+    });
+
+    it('answers 400 INVALID_IMAGE_REFERENCE when the service rejects the golden image reference', async () => {
+      (AsgService.deployASG as jest.Mock).mockRejectedValue(new InvalidImageReferenceError('bad image'));
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const res = await request(app)
+        .post(deployUrl)
+        .send({ parentNodeId: 'node-1', desiredCapacity: 2, subnetIds: ['s1'] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_IMAGE_REFERENCE');
+      expect(res.body.error).toContain('bad image');
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('POST .../asg/:asgId/scale', () => {
+    it.each([[0], [10]])('scales to %d', async desiredCapacity => {
+      const res = await request(app).post(scaleUrl).send({ desiredCapacity, subnetIds: ['s1'] });
+
+      expect(res.status).toBe(200);
+      expect(AsgService.scaleASG).toHaveBeenCalledWith('test-project', 'asg-1', desiredCapacity, ['s1']);
+    });
+
+    it('defaults desiredCapacity to 1 when omitted', async () => {
+      const res = await request(app).post(scaleUrl).send({ subnetIds: ['s1'] });
+
+      expect(res.status).toBe(200);
+      expect(AsgService.scaleASG).toHaveBeenCalledWith('test-project', 'asg-1', 1, ['s1']);
+    });
+
+    it.each([[11], [-1], [1.5], ['7'], [null]])(
+      'rejects desiredCapacity %p with a classified 400 without calling the service',
+      async desiredCapacity => {
+        const res = await request(app).post(scaleUrl).send({ desiredCapacity, subnetIds: ['s1'] });
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('INVALID_CAPACITY');
+        expect(AsgService.scaleASG).not.toHaveBeenCalled();
+      }
+    );
+
+    it('still requires subnetIds', async () => {
+      const res = await request(app).post(scaleUrl).send({ desiredCapacity: 2 });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'At least one target subnetId is required' });
+    });
+  });
+});

--- a/backend/src/modules/containers/controllers/asgController.ts
+++ b/backend/src/modules/containers/controllers/asgController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { AsgService } from '../services/asgService';
 import { sendDockerError } from '../../../infrastructure/docker/dockerErrors';
+import { validateDesiredCapacity } from '../validation/asgCapacity';
 
 export class AsgController {
   public static async deploy(req: Request, res: Response): Promise<void> {
@@ -15,6 +16,11 @@ export class AsgController {
       }
       if (!subnetIds || subnetIds.length === 0) {
         res.status(400).json({ error: 'At least one target subnetId is required' });
+        return;
+      }
+      const capacityViolation = validateDesiredCapacity(desiredCapacity, 1);
+      if (capacityViolation) {
+        res.status(400).json({ error: capacityViolation.message, code: capacityViolation.code });
         return;
       }
 
@@ -39,6 +45,11 @@ export class AsgController {
 
       if (!subnetIds || subnetIds.length === 0) {
         res.status(400).json({ error: 'At least one target subnetId is required' });
+        return;
+      }
+      const capacityViolation = validateDesiredCapacity(desiredCapacity, 0);
+      if (capacityViolation) {
+        res.status(400).json({ error: capacityViolation.message, code: capacityViolation.code });
         return;
       }
 

--- a/backend/src/modules/containers/validation/asgCapacity.test.ts
+++ b/backend/src/modules/containers/validation/asgCapacity.test.ts
@@ -1,0 +1,75 @@
+import { validateDesiredCapacity, validateAsgCapacityConfig, ASG_MAX_CAPACITY } from './asgCapacity';
+
+describe('validateDesiredCapacity', () => {
+  it('accepts undefined (controllers default it)', () => {
+    expect(validateDesiredCapacity(undefined, 1)).toBeNull();
+  });
+
+  it.each([1, 5, ASG_MAX_CAPACITY])('accepts %d with floor 1', value => {
+    expect(validateDesiredCapacity(value, 1)).toBeNull();
+  });
+
+  it('accepts 0 with floor 0 (stop path)', () => {
+    expect(validateDesiredCapacity(0, 0)).toBeNull();
+  });
+
+  it('rejects 0 with floor 1 (deploy path)', () => {
+    expect(validateDesiredCapacity(0, 1)).toMatchObject({ code: 'INVALID_CAPACITY' });
+  });
+
+  it.each([11, -1, 100])('rejects out-of-range %d', value => {
+    const result = validateDesiredCapacity(value, 0);
+    expect(result).toMatchObject({ code: 'INVALID_CAPACITY' });
+    expect(result?.message).toContain('between 0 and 10');
+  });
+
+  it.each([[2.5], [NaN], ['5'], [null], [{}]])('rejects non-integer %p', value => {
+    const result = validateDesiredCapacity(value, 0);
+    expect(result).toMatchObject({ code: 'INVALID_CAPACITY' });
+    expect(result?.message).toContain('whole number');
+  });
+});
+
+describe('validateAsgCapacityConfig', () => {
+  it('accepts a full valid entry', () => {
+    expect(validateAsgCapacityConfig('asg-1', { minCapacity: 1, desiredCapacity: 2, maxCapacity: 4 })).toBeNull();
+  });
+
+  it('accepts partial entries (legacy configs)', () => {
+    expect(validateAsgCapacityConfig('asg-1', { parentId: 'x', subnetIds: [] })).toBeNull();
+    expect(validateAsgCapacityConfig('asg-1', { desiredCapacity: 3 })).toBeNull();
+  });
+
+  it('ignores non-object entries', () => {
+    expect(validateAsgCapacityConfig('asg-1', null)).toBeNull();
+    expect(validateAsgCapacityConfig('asg-1', 'junk')).toBeNull();
+  });
+
+  it.each([
+    ['minCapacity 0', { minCapacity: 0 }],
+    ['maxCapacity 11', { maxCapacity: 11 }],
+    ['maxCapacity 50', { maxCapacity: 50 }],
+    ['desiredCapacity -1', { desiredCapacity: -1 }],
+    ['non-integer desiredCapacity', { desiredCapacity: 2.5 }],
+    ['string maxCapacity', { maxCapacity: '4' }],
+  ])('rejects %s', (_label, entry) => {
+    const result = validateAsgCapacityConfig('asg-1', entry);
+    expect(result).toMatchObject({ code: 'INVALID_CAPACITY' });
+    expect(result?.message).toContain('asg-1');
+  });
+
+  it('rejects minCapacity > maxCapacity', () => {
+    const result = validateAsgCapacityConfig('asg-1', { minCapacity: 5, maxCapacity: 3 });
+    expect(result?.message).toContain('minCapacity');
+  });
+
+  it('rejects desiredCapacity below minCapacity', () => {
+    const result = validateAsgCapacityConfig('asg-1', { minCapacity: 2, desiredCapacity: 1, maxCapacity: 4 });
+    expect(result?.message).toContain('less than minCapacity');
+  });
+
+  it('rejects desiredCapacity above maxCapacity', () => {
+    const result = validateAsgCapacityConfig('asg-1', { minCapacity: 1, desiredCapacity: 5, maxCapacity: 4 });
+    expect(result?.message).toContain('greater than maxCapacity');
+  });
+});

--- a/backend/src/modules/containers/validation/asgCapacity.ts
+++ b/backend/src/modules/containers/validation/asgCapacity.ts
@@ -1,0 +1,61 @@
+export const ASG_MAX_CAPACITY = 10;
+
+export interface CapacityViolation {
+  code: 'INVALID_CAPACITY';
+  message: string;
+}
+
+function violation(message: string): CapacityViolation {
+  return { code: 'INVALID_CAPACITY', message };
+}
+
+function isIntegerIn(value: unknown, floor: number): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= floor && value <= ASG_MAX_CAPACITY;
+}
+
+/**
+ * Bounds check for the `desiredCapacity` of a scale/deploy request.
+ * `floor` is 0 for scaling (stopping an ASG scales it to 0) and 1 for deploys.
+ * An undefined value is accepted: controllers default it to 1.
+ */
+export function validateDesiredCapacity(value: unknown, floor: 0 | 1): CapacityViolation | null {
+  if (value === undefined) {
+    return null;
+  }
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return violation('Desired capacity must be a whole number.');
+  }
+  if (value < floor || value > ASG_MAX_CAPACITY) {
+    return violation(`Desired capacity must be between ${floor} and ${ASG_MAX_CAPACITY}.`);
+  }
+  return null;
+}
+
+/**
+ * Bounds check for one `networkConfig.asgs` entry. Lenient on purpose: only
+ * the capacity fields that are present are validated, so partial entries and
+ * configs saved by older versions keep saving.
+ */
+export function validateAsgCapacityConfig(asgId: string, entry: unknown): CapacityViolation | null {
+  if (typeof entry !== 'object' || entry === null) {
+    return null;
+  }
+  const { desiredCapacity, minCapacity, maxCapacity } = entry as Record<string, unknown>;
+
+  for (const [field, value] of Object.entries({ desiredCapacity, minCapacity, maxCapacity })) {
+    if (value !== undefined && !isIntegerIn(value, 1)) {
+      return violation(`ASG "${asgId}": ${field} must be a whole number between 1 and ${ASG_MAX_CAPACITY}.`);
+    }
+  }
+
+  if (minCapacity !== undefined && maxCapacity !== undefined && (minCapacity as number) > (maxCapacity as number)) {
+    return violation(`ASG "${asgId}": minCapacity cannot be greater than maxCapacity.`);
+  }
+  if (minCapacity !== undefined && desiredCapacity !== undefined && (desiredCapacity as number) < (minCapacity as number)) {
+    return violation(`ASG "${asgId}": desiredCapacity cannot be less than minCapacity.`);
+  }
+  if (maxCapacity !== undefined && desiredCapacity !== undefined && (desiredCapacity as number) > (maxCapacity as number)) {
+    return violation(`ASG "${asgId}": desiredCapacity cannot be greater than maxCapacity.`);
+  }
+  return null;
+}

--- a/backend/src/modules/projects/controllers/projectController.test.ts
+++ b/backend/src/modules/projects/controllers/projectController.test.ts
@@ -148,5 +148,40 @@ describe('ProjectController', () => {
       expect(res.status).toBe(400);
       expect(res.body).toEqual({ error: 'networkConfig is required' });
     });
+
+    it('should save a config whose ASG capacities are within bounds', async () => {
+      const mockConfig = { asgs: { 'asg-1': { minCapacity: 1, desiredCapacity: 2, maxCapacity: 4 } } };
+      (ProjectService.saveNetworkConfig as jest.Mock).mockResolvedValue(undefined);
+      (NetworkService.applyPolicy as jest.Mock).mockResolvedValue(undefined);
+      (ProjectService.getNetworkConfig as jest.Mock).mockResolvedValue(mockConfig);
+
+      const res = await request(app)
+        .post('/api/projects/project-1/network-config')
+        .send({ networkConfig: mockConfig });
+
+      expect(res.status).toBe(200);
+      expect(ProjectService.saveNetworkConfig).toHaveBeenCalledWith('project-1', mockConfig);
+    });
+
+    it('should return a classified 400 for an out-of-bounds ASG capacity without saving', async () => {
+      const res = await request(app)
+        .post('/api/projects/project-1/network-config')
+        .send({ networkConfig: { asgs: { 'asg-1': { minCapacity: 1, desiredCapacity: 2, maxCapacity: 50 } } } });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_CAPACITY');
+      expect(res.body.error).toContain('asg-1');
+      expect(ProjectService.saveNetworkConfig).not.toHaveBeenCalled();
+    });
+
+    it('should return a classified 400 when minCapacity exceeds maxCapacity', async () => {
+      const res = await request(app)
+        .post('/api/projects/project-1/network-config')
+        .send({ networkConfig: { asgs: { 'asg-1': { minCapacity: 5, maxCapacity: 3 } } } });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_CAPACITY');
+      expect(ProjectService.saveNetworkConfig).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/modules/projects/controllers/projectController.ts
+++ b/backend/src/modules/projects/controllers/projectController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { ProjectService } from '../services/projectService';
 import { NetworkService } from '../../network/services/networkService';
+import { validateAsgCapacityConfig } from '../../containers/validation/asgCapacity';
 
 export class ProjectController {
   public static async list(req: Request, res: Response): Promise<void> {
@@ -64,6 +65,13 @@ export class ProjectController {
       if (!networkConfig) {
         res.status(400).json({ error: 'networkConfig is required' });
         return;
+      }
+      for (const [asgId, entry] of Object.entries(networkConfig.asgs ?? {})) {
+        const capacityViolation = validateAsgCapacityConfig(asgId, entry);
+        if (capacityViolation) {
+          res.status(400).json({ error: capacityViolation.message, code: capacityViolation.code });
+          return;
+        }
       }
       await ProjectService.saveNetworkConfig(projectId, networkConfig);
       

--- a/docs/adding-a-node.md
+++ b/docs/adding-a-node.md
@@ -91,7 +91,10 @@ If the tools are missing, the failure is easy to miss:
   VPC routes won't apply.
 
 The published `derssa/backend-lab-*:v1` images already ship both tools. If you build your
-own image, either base it on one of those, or add the packages in your Dockerfile:
+own image, either base it on one of those, or add the packages in your Dockerfile.
+The backend only checks that a custom image reference is well-formed (standard
+`[registry/]name[:tag][@digest]` format) — the image itself runs locally under your own
+responsibility, like any container you'd start by hand:
 
 ```dockerfile
 # Debian/Ubuntu-based images

--- a/frontend/src/features/nodes/AsgNode/AsgModal.test.tsx
+++ b/frontend/src/features/nodes/AsgNode/AsgModal.test.tsx
@@ -1,0 +1,145 @@
+import '../../../i18n';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AsgModal from './AsgModal';
+import { mockFetchResponses } from '../../../test-utils/mockFetchSequence';
+import type { ContainerData } from '../../../shared/types';
+
+const template: ContainerData = { id: 'tpl-1', name: 'web-1', state: 'running', status: 'Up', type: 'ubuntu' };
+const instance: ContainerData = {
+  id: 'inst-1',
+  name: 'asg-asg-1-instance-abcd',
+  state: 'running',
+  status: 'Up',
+  type: 'ubuntu',
+  asgId: 'asg-1',
+  isAsgInstance: true,
+};
+
+const config = {
+  subnets: [{ id: 's1', name: 'subnet-1', type: 'public' }],
+  asgs: {
+    'asg-1': { desiredCapacity: 2, minCapacity: 1, maxCapacity: 4, parentId: 'tpl-1', subnetIds: ['s1'] },
+  },
+};
+
+function renderModal(overrides: { containers?: ContainerData[]; onSaveConfig?: () => Promise<void> } = {}) {
+  const onSaveConfig = vi.fn(overrides.onSaveConfig ?? (() => Promise.resolve()));
+  const onRefreshContainers = vi.fn().mockResolvedValue(undefined);
+  render(
+    <AsgModal
+      asgId="asg-1"
+      nodeName="my-asg"
+      projectId="p1"
+      config={config}
+      containers={overrides.containers ?? [template, instance]}
+      onClose={vi.fn()}
+      onSaveConfig={onSaveConfig}
+      onRefreshContainers={onRefreshContainers}
+    />
+  );
+  return { onSaveConfig, onRefreshContainers };
+}
+
+/** The Save button only shows when the config changed: bump Desired Instances via its stepper. */
+function bumpDesiredCapacity() {
+  const plusButtons = screen.getAllByRole('button', { name: '+' });
+  fireEvent.click(plusButtons[plusButtons.length - 1]);
+}
+
+describe('AsgModal error surfacing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the backend error message when the scale request is rejected', async () => {
+    mockFetchResponses([
+      { ok: false, json: { error: 'Desired capacity must be between 0 and 10.', code: 'INVALID_CAPACITY' } },
+    ]);
+    renderModal();
+
+    bumpDesiredCapacity();
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Desired capacity must be between 0 and 10.');
+  });
+
+  it('shows no error and refreshes containers when the scale request succeeds', async () => {
+    mockFetchResponses([{ ok: true, json: [] }]);
+    const { onSaveConfig, onRefreshContainers } = renderModal();
+
+    bumpDesiredCapacity();
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => expect(onRefreshContainers).toHaveBeenCalled());
+    expect(onSaveConfig).toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clears the previous error when a retry succeeds', async () => {
+    mockFetchResponses([
+      { ok: false, json: { error: 'Desired capacity must be between 0 and 10.', code: 'INVALID_CAPACITY' } },
+      { ok: true, json: [] },
+    ]);
+    renderModal();
+
+    bumpDesiredCapacity();
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+    await screen.findByRole('alert');
+
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+
+  it('shows the backend error message when stopping the ASG fails', async () => {
+    mockFetchResponses([{ ok: false, json: { error: 'Project configuration not found' } }]);
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Stop$/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Project configuration not found');
+  });
+
+  it('falls back to a generic message when the error response has no JSON body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, json: () => Promise.reject(new Error('no body')) } as unknown as Response)
+    );
+    renderModal();
+
+    bumpDesiredCapacity();
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('The request failed. Please try again.');
+  });
+
+  it('shows the config-save rejection message when onSaveConfig fails', async () => {
+    mockFetchResponses([]);
+    renderModal({
+      onSaveConfig: () =>
+        Promise.reject(new Error('ASG "asg-1": maxCapacity must be a whole number between 1 and 10.')),
+    });
+
+    bumpDesiredCapacity();
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('maxCapacity must be a whole number between 1 and 10.');
+  });
+
+  it('shows the backend error message when the deploy request is rejected', async () => {
+    mockFetchResponses([
+      { ok: false, json: { error: 'Desired capacity must be between 1 and 10.', code: 'INVALID_CAPACITY' } },
+    ]);
+    renderModal({ containers: [template] });
+
+    fireEvent.click(screen.getByRole('button', { name: /Save & Deploy/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Desired capacity must be between 1 and 10.');
+  });
+});

--- a/frontend/src/features/nodes/AsgNode/AsgModal.tsx
+++ b/frontend/src/features/nodes/AsgNode/AsgModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { X, Cpu, Server, AlertTriangle, RotateCw, Settings, Activity } from 'lucide-react';
 import { API_BASE } from '../../../shared/types';
 import type { ContainerData } from '../../../shared/types';
+import { readErrorMessage } from '../../../shared/utils/readErrorMessage';
 
 interface AsgModalProps {
   asgId: string;
@@ -51,6 +52,7 @@ export default function AsgModal({
   const [stopping, setStopping] = useState(false);
   const [saving, setSaving] = useState(false);
   const [terminatingId, setTerminatingId] = useState<string | null>(null);
+  const [apiError, setApiError] = useState<string | null>(null);
   const isScalingRef = useRef(false);
 
   const isConfigChanged = 
@@ -230,6 +232,7 @@ export default function AsgModal({
   const handleSaveAndDeploy = async () => {
     if (!parentId) return;
     setDeploying(true);
+    setApiError(null);
     try {
       // 1. Save settings
       await onSaveConfig({
@@ -251,9 +254,12 @@ export default function AsgModal({
       });
       if (res.ok) {
         await onRefreshContainers();
+      } else {
+        setApiError(await readErrorMessage(res, t('asg.details.requestFailed')));
       }
     } catch (err) {
       console.error(err);
+      setApiError(err instanceof Error && err.message ? err.message : t('asg.details.requestFailed'));
     } finally {
       setDeploying(false);
     }
@@ -261,6 +267,7 @@ export default function AsgModal({
 
   const handleSave = async () => {
     setSaving(true);
+    setApiError(null);
     try {
       await onSaveConfig({
         desiredCapacity,
@@ -269,7 +276,7 @@ export default function AsgModal({
         parentId,
         subnetIds: selectedSubnets
       });
-      await fetch(`${API_BASE}/api/projects/${projectId}/containers/asg/${asgId}/scale`, {
+      const res = await fetch(`${API_BASE}/api/projects/${projectId}/containers/asg/${asgId}/scale`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -277,9 +284,14 @@ export default function AsgModal({
           subnetIds: selectedSubnets
         })
       });
-      await onRefreshContainers();
+      if (res.ok) {
+        await onRefreshContainers();
+      } else {
+        setApiError(await readErrorMessage(res, t('asg.details.requestFailed')));
+      }
     } catch (err) {
       console.error(err);
+      setApiError(err instanceof Error && err.message ? err.message : t('asg.details.requestFailed'));
     } finally {
       setSaving(false);
     }
@@ -287,8 +299,9 @@ export default function AsgModal({
 
   const handleStop = async () => {
     setStopping(true);
+    setApiError(null);
     try {
-      await fetch(`${API_BASE}/api/projects/${projectId}/containers/asg/${asgId}/scale`, {
+      const res = await fetch(`${API_BASE}/api/projects/${projectId}/containers/asg/${asgId}/scale`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -296,9 +309,14 @@ export default function AsgModal({
           subnetIds: selectedSubnets
         })
       });
-      await onRefreshContainers();
+      if (res.ok) {
+        await onRefreshContainers();
+      } else {
+        setApiError(await readErrorMessage(res, t('asg.details.requestFailed')));
+      }
     } catch (err) {
       console.error(err);
+      setApiError(err instanceof Error && err.message ? err.message : t('asg.details.requestFailed'));
     } finally {
       setStopping(false);
     }
@@ -478,6 +496,13 @@ export default function AsgModal({
                   </div>
                 </div>
               </div>
+
+              {apiError && (
+                <div role="alert" style={styles.errorBanner}>
+                  <AlertTriangle size={14} style={{ flexShrink: 0 }} />
+                  <span>{apiError}</span>
+                </div>
+              )}
 
               {/* Save & Deploy / Stop buttons */}
               <div style={styles.footer}>
@@ -920,6 +945,18 @@ const styles: Record<string, React.CSSProperties> = {
     marginTop: '12px',
     borderTop: '1px solid rgba(0,0,0,0.05)',
     paddingTop: '16px',
+  },
+  errorBanner: {
+    backgroundColor: '#FEE2E2',
+    border: '1px solid #FECACA',
+    borderRadius: '6px',
+    padding: '10px 14px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    marginTop: '12px',
+    color: '#B91C1C',
+    fontSize: '12px',
   },
   actionBtn: {
     padding: '8px 16px',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -442,7 +442,8 @@
       "stopBtn": "Stop",
       "stoppingBtn": "Stopping...",
       "deployBtn": "Save & Deploy",
-      "deployingBtn": "Deploying..."
+      "deployingBtn": "Deploying...",
+      "requestFailed": "The request failed. Please try again."
     },
     "simulation": {
       "infoBanner": "Auto Scaling self-healing check runs every 2s. If an instance is crashed, a replacement will launch.",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -442,7 +442,8 @@
       "stopBtn": "Arrêter",
       "stoppingBtn": "Arrêt...",
       "deployBtn": "Sauvegarder & Déployer",
-      "deployingBtn": "Déploiement..."
+      "deployingBtn": "Déploiement...",
+      "requestFailed": "La requête a échoué. Veuillez réessayer."
     },
     "simulation": {
       "infoBanner": "La vérification d'auto-réparation Auto Scaling s'exécute toutes les 2s. Si une instance plante, une remplaçante sera lancée.",

--- a/frontend/src/pages/CanvasPage/hooks/useNetworkConfig.ts
+++ b/frontend/src/pages/CanvasPage/hooks/useNetworkConfig.ts
@@ -3,6 +3,7 @@ import type { ContainerData } from '../../../shared/types';
 import { API_BASE } from '../../../shared/types';
 import type { NetworkConfig } from '../../../shared/types/network';
 import { validateArchitecture } from '../../../shared/utils/architectureValidator';
+import { readErrorMessage } from '../../../shared/utils/readErrorMessage';
 import { autoGrowContainers } from '../utils/networkConfigOps';
 
 interface UseNetworkConfigArgs {
@@ -49,9 +50,9 @@ export function useNetworkConfig({ projectId, containers, showNotification }: Us
       },
       body: JSON.stringify({ networkConfig: grownConfig })
     })
-    .then(res => {
+    .then(async res => {
       if (!res.ok) {
-        throw new Error(`Failed to save network config (HTTP ${res.status})`);
+        throw new Error(await readErrorMessage(res, `Failed to save network config (HTTP ${res.status})`));
       }
       return res.json();
     })


### PR DESCRIPTION
## Summary of Changes

The ASG capacity endpoints accepted any `desiredCapacity` (unbounded container spawn: a single request could ask Docker for thousands of replicas), the network-config save accepted absurd `minCapacity`/`maxCapacity` values, and custom Docker image references reached `docker.createContainer` without any format validation. On top of that, the ASG modal silently swallowed every API error, so a backend rejection was invisible to the user.

This PR bounds those inputs server-side and surfaces rejections in the UI:

- **Capacity bounds** (`asgCapacity.ts`, new): `desiredCapacity` must be an integer in `0..10` on `/scale` (0 = stop) and `1..10` on `/deploy`; `minCapacity`/`maxCapacity`/`desiredCapacity` inside `networkConfig.asgs` must be integers in `1..10` with `min ≤ desired ≤ max`. Violations answer a classified `400 { error, code: 'INVALID_CAPACITY' }` before any service call. Validation of config entries is lenient (only fields that are present), so existing saved projects keep loading and saving.
- **Image reference validation** (`imageReference.ts`, new): `customImage` is checked against the Docker reference grammar (`[registry[:port]/]name[:tag][@digest]`, length caps) at the single choke point `dockerContainerProvider.createContainer`; invalid references throw and classify as `400 INVALID_IMAGE_REFERENCE` via the existing `sendDockerError` path. No allowlist — the image runs locally under the user's responsibility (doc note added in `docs/adding-a-node.md`).
- **UI surfacing**: `AsgModal` now checks every response and renders an inline `role="alert"` banner with the backend message (`readErrorMessage` reused); `useNetworkConfig` propagates the backend's error message instead of a generic HTTP status string. New `asg.details.requestFailed` key in both locales. No client-side clamp was added: the backend is the source of truth, and the rejection stays demonstrable from the UI.

## Types of Changes

- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: 34 suites / 373 tests green (new: `asgCapacity.test.ts`, `imageReference.test.ts`, `asgController.test.ts`; extended: `dockerErrors.test.ts`, `projectController.test.ts`). Frontend: 20 files / 232 tests green (new: `AsgModal.test.tsx`, 7 tests covering banner on 400, success, retry-clears-error, stop failure, non-JSON fallback, deploy rejection, config-save rejection).

### Manual Verification

Against real Docker (dev servers + `curl` + Playwright/Chrome):

```
$ curl -X POST .../containers/asg/demo/scale -d '{"desiredCapacity":11,"subnetIds":["s1"]}'
{"error":"Desired capacity must be between 0 and 10.","code":"INVALID_CAPACITY"}   (HTTP 400)

$ curl ... scale -d '{"desiredCapacity":2.5,...}'
{"error":"Desired capacity must be a whole number.","code":"INVALID_CAPACITY"}     (HTTP 400)

$ curl ... deploy -d '{"parentNodeId":"x","desiredCapacity":0,...}'
{"error":"Desired capacity must be between 1 and 10.","code":"INVALID_CAPACITY"}   (HTTP 400)

$ curl -X POST .../network-config -d '{"networkConfig":{"asgs":{"asg-demo":{"minCapacity":1,"desiredCapacity":2,"maxCapacity":50}}}}'
{"error":"ASG \"asg-demo\": maxCapacity must be a whole number between 1 and 10.","code":"INVALID_CAPACITY"} (HTTP 400)
```

- Deploy at `desiredCapacity: 10` → HTTP 200, `docker ps --filter label=akal.asg.id=...` = **10 running replicas** (~19 s).
- Playwright UI run on a real project (ubuntu template + ASG node): stepped Max/Desired to **11** in the modal → Save → red inline banner with the exact backend message (`... desiredCapacity must be a whole number between 1 and 10.`); stepped back to **10** → Save → banner cleared, ASG scaled to 10 real containers; **Stop** button (scale to 0) still works and terminated all replicas.
- Existing configs without an `asgs` section re-save with HTTP 200 (backward compatible).

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing


## CI note

The first `backend-integration-tests` run failed (twice) in `containerOwnership.itest.ts` setup with `network with name akal-lab-network already exists` — a pre-existing check-then-create race: both itest suites run `ensureSharedNetwork()` concurrently on a fresh runner (jest parallelizes suites by default), so both see the network missing and both create it. The same job also failed on `main` (run 29657312416) with the mid-run flavor of the same cross-suite interference. Fixed here with `maxWorkers: 1` in `jest.integration.config.js` — the suites share one Docker daemon (network, iptables chains, real containers), so they must run serially.
