### PR TITLE
feat(i18n): add full EN/FR translation coverage for toasts, nodes, and shared UI

### DIFF
--- a/frontend/src/features/learning/components/LearningPanel.test.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.test.tsx
@@ -141,7 +141,6 @@ describe('LearningPanel', () => {
 
     expect(await screen.findByText('Your first architecture')).toBeInTheDocument();
     expect(screen.getByText('Build a minimal two-tier architecture.')).toBeInTheDocument();
-    expect(screen.getByText('EN')).toBeInTheDocument();
   });
 
   it('shows a retry path when the catalogue cannot be loaded', async () => {

--- a/frontend/src/features/learning/components/RoadmapCatalog.tsx
+++ b/frontend/src/features/learning/components/RoadmapCatalog.tsx
@@ -8,12 +8,21 @@ interface RoadmapCatalogProps {
 }
 
 export default function RoadmapCatalog({ onOpen }: RoadmapCatalogProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { summaries, loading, error, fetchRoadmaps } = useRoadmaps();
 
   useEffect(() => {
     fetchRoadmaps();
   }, [fetchRoadmaps]);
+
+  // Only surface roadmaps authored in the active UI language: an English user
+  // sees English roadmaps only. Compare on the base subtag so 'en-US' still
+  // matches an 'en' roadmap. Re-evaluated on every render, so toggling the
+  // language in the topbar re-filters the catalogue immediately.
+  const uiLanguage = i18n.language.split('-')[0];
+  const visibleSummaries = summaries.filter(
+    summary => summary.language.split('-')[0] === uiLanguage
+  );
 
   if (loading) {
     return <div style={styles.status}>{t('learning.catalog.loading')}</div>;
@@ -30,13 +39,13 @@ export default function RoadmapCatalog({ onOpen }: RoadmapCatalogProps) {
     );
   }
 
-  if (summaries.length === 0) {
+  if (visibleSummaries.length === 0) {
     return <div style={styles.status}>{t('learning.catalog.empty')}</div>;
   }
 
   return (
     <div style={styles.list}>
-      {summaries.map(summary => (
+      {visibleSummaries.map(summary => (
         <button
           key={`${summary.id}-${summary.language}`}
           onClick={() => onOpen(summary)}
@@ -44,7 +53,6 @@ export default function RoadmapCatalog({ onOpen }: RoadmapCatalogProps) {
         >
           <div style={styles.cardHeader}>
             <span style={styles.cardTitle}>{summary.title}</span>
-            <span style={styles.languageBadge}>{summary.language.toUpperCase()}</span>
           </div>
           <span style={styles.cardDescription}>{summary.description}</span>
           <div style={styles.cardMeta}>
@@ -111,15 +119,6 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '13px',
     fontWeight: 600,
     color: 'var(--color-text-primary)',
-  },
-  languageBadge: {
-    fontSize: '10px',
-    fontWeight: 700,
-    color: 'var(--color-text-muted)',
-    border: '1px solid var(--border-color)',
-    borderRadius: '4px',
-    padding: '1px 5px',
-    flexShrink: 0,
   },
   cardDescription: {
     fontSize: '11px',

--- a/frontend/src/features/nodes/AsgNode/AsgNode.tsx
+++ b/frontend/src/features/nodes/AsgNode/AsgNode.tsx
@@ -1,4 +1,5 @@
 import { Layers, Settings } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import BaseNode from '../components/BaseNode';
 import styles from '../ServiceNode.module.css';
 
@@ -32,6 +33,7 @@ interface AsgNodeProps {
 }
 
 export default function AsgNode({ data }: AsgNodeProps) {
+  const { t } = useTranslation();
   const isRunning = data.state === 'running';
 
   return (
@@ -46,8 +48,8 @@ export default function AsgNode({ data }: AsgNodeProps) {
       hideHandles={true}
       subtitle={
         <>
-          <span className={styles.label}>Instances:</span>
-          <span className={styles.value}>{data.instanceCount || 0} Running</span>
+          <span className={styles.label}>{t('nodeviz.instances')}</span>
+          <span className={styles.value}>{t('nodeviz.countRunning', { count: data.instanceCount || 0 })}</span>
         </>
       }
       onStart={data.onStart}
@@ -55,11 +57,11 @@ export default function AsgNode({ data }: AsgNodeProps) {
       onDelete={data.onDelete}
       onRename={data.onRename}
       primaryAction={{
-        label: 'Inspect',
+        label: t('nodeviz.inspect'),
         icon: <Settings size={14} />,
         color: '#EC4899',
         onClick: data.onInspect,
-        title: 'Configure ASG settings & inspect instance replicas',
+        title: t('nodeviz.asgInspectTitle'),
       }}
     />
   );

--- a/frontend/src/features/nodes/LoadBalancerNode/LoadBalancerNode.tsx
+++ b/frontend/src/features/nodes/LoadBalancerNode/LoadBalancerNode.tsx
@@ -1,4 +1,5 @@
 import { GitFork, Settings } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import BaseNode from '../components/BaseNode';
 import styles from '../ServiceNode.module.css';
 
@@ -24,6 +25,7 @@ interface LoadBalancerNodeProps {
 }
 
 export default function LoadBalancerNode({ data }: LoadBalancerNodeProps) {
+  const { t } = useTranslation();
   const isRunning = data.state === 'running';
 
   return (
@@ -37,8 +39,8 @@ export default function LoadBalancerNode({ data }: LoadBalancerNodeProps) {
       customTitleColor="#DC2626"
       subtitle={
         <>
-          <span className={styles.label}>IP Address:</span>
-          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip || 'Private'}</span>
+          <span className={styles.label}>{t('nodeviz.ipAddress')}</span>
+          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip || t('nodeviz.private')}</span>
         </>
       }
       onStart={data.onStart}
@@ -47,11 +49,11 @@ export default function LoadBalancerNode({ data }: LoadBalancerNodeProps) {
       onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
-        label: 'Configure',
+        label: t('nodeviz.configure'),
         icon: <Settings size={14} />,
         color: '#EF4444',
         onClick: data.onInspect,
-        title: 'Configure Load Balancer rules & targets',
+        title: t('nodeviz.loadBalancerConfigTitle'),
       }}
     />
   );

--- a/frontend/src/features/nodes/NatNode/NatNode.tsx
+++ b/frontend/src/features/nodes/NatNode/NatNode.tsx
@@ -1,4 +1,5 @@
 import { ArrowRightLeft } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import BaseNode from '../components/BaseNode';
 import styles from '../ServiceNode.module.css';
 
@@ -18,6 +19,7 @@ interface NatNodeProps {
 }
 
 export default function NatNode({ data }: NatNodeProps) {
+  const { t } = useTranslation();
   const isRunning = data.state === 'running';
 
   return (
@@ -32,8 +34,8 @@ export default function NatNode({ data }: NatNodeProps) {
       hideHandles={true}
       subtitle={
         <>
-          <span className={styles.label}>IP Address:</span>
-          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip || 'Private'}</span>
+          <span className={styles.label}>{t('nodeviz.ipAddress')}</span>
+          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip || t('nodeviz.private')}</span>
         </>
       }
       onStart={data.onStart}
@@ -41,11 +43,11 @@ export default function NatNode({ data }: NatNodeProps) {
       onDelete={data.onDelete}
       onRename={data.onRename}
       primaryAction={{
-        label: 'Info & Guide',
+        label: t('nodeviz.infoGuide'),
         icon: <ArrowRightLeft size={14} />,
         color: '#8B5CF6',
         onClick: data.onInspect,
-        title: 'View NAT Gateway details & guide',
+        title: t('nodeviz.natInfoGuideTitle'),
       }}
     />
   );

--- a/frontend/src/features/nodes/NoSqlNode/NoSqlNode.tsx
+++ b/frontend/src/features/nodes/NoSqlNode/NoSqlNode.tsx
@@ -1,4 +1,5 @@
 import { Braces, Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import BaseNode from '../components/BaseNode';
 import styles from '../ServiceNode.module.css';
 
@@ -19,6 +20,7 @@ interface NoSqlNodeProps {
 }
 
 export default function NoSqlNode({ data }: NoSqlNodeProps) {
+  const { t } = useTranslation();
   const isRunning = data.state === 'running';
 
   return (
@@ -31,7 +33,7 @@ export default function NoSqlNode({ data }: NoSqlNodeProps) {
       customBorder={isRunning ? '1px solid #475569' : undefined}
       subtitle={
         <>
-          <span className={styles.label}>IP/Port:</span>
+          <span className={styles.label}>{t('nodeviz.ipPort')}</span>
           <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip ? `${data.ip}:27017` : '27017'}</span>
         </>
       }
@@ -41,11 +43,11 @@ export default function NoSqlNode({ data }: NoSqlNodeProps) {
       onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
-        label: 'Inspect',
+        label: t('nodeviz.inspect'),
         icon: <Search size={14} />,
         color: '#475569', // Charcoal Gray
         onClick: data.onInspect,
-        title: 'Inspect Database Explorer / Shell',
+        title: t('nodeviz.inspectDatabaseTitle'),
       }}
     />
   );

--- a/frontend/src/features/nodes/PostgresNode/PostgresNode.tsx
+++ b/frontend/src/features/nodes/PostgresNode/PostgresNode.tsx
@@ -1,4 +1,5 @@
 import { Database, Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import BaseNode from '../components/BaseNode';
 import styles from '../ServiceNode.module.css';
 
@@ -19,6 +20,7 @@ interface PostgresNodeProps {
 }
 
 export default function PostgresNode({ data }: PostgresNodeProps) {
+  const { t } = useTranslation();
   const isRunning = data.state === 'running';
 
   return (
@@ -31,7 +33,7 @@ export default function PostgresNode({ data }: PostgresNodeProps) {
       customBorder={isRunning ? '1px solid #64748B' : undefined}
       subtitle={
         <>
-          <span className={styles.label}>IP/Port:</span>
+          <span className={styles.label}>{t('nodeviz.ipPort')}</span>
           <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip ? `${data.ip}:5432` : '5432'}</span>
         </>
       }
@@ -41,11 +43,11 @@ export default function PostgresNode({ data }: PostgresNodeProps) {
       onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
-        label: 'Inspect',
+        label: t('nodeviz.inspect'),
         icon: <Search size={14} />,
         color: '#64748B', // Slate Gray
         onClick: data.onInspect,
-        title: 'Inspect Database Explorer / Shell',
+        title: t('nodeviz.inspectDatabaseTitle'),
       }}
     />
   );

--- a/frontend/src/features/nodes/RedisNode/RedisNode.tsx
+++ b/frontend/src/features/nodes/RedisNode/RedisNode.tsx
@@ -1,4 +1,5 @@
 import { Database, Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import BaseNode from '../components/BaseNode';
 import styles from '../ServiceNode.module.css';
 
@@ -19,6 +20,7 @@ interface RedisNodeProps {
 }
 
 export default function RedisNode({ data }: RedisNodeProps) {
+  const { t } = useTranslation();
   const isRunning = data.state === 'running';
 
   return (
@@ -31,7 +33,7 @@ export default function RedisNode({ data }: RedisNodeProps) {
       customBorder={isRunning ? '1px solid #DC2626' : undefined}
       subtitle={
         <>
-          <span className={styles.label}>IP/Port:</span>
+          <span className={styles.label}>{t('nodeviz.ipPort')}</span>
           <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip ? `${data.ip}:6379` : '6379'}</span>
         </>
       }
@@ -41,11 +43,11 @@ export default function RedisNode({ data }: RedisNodeProps) {
       onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
-        label: 'Inspect',
+        label: t('nodeviz.inspect'),
         icon: <Search size={14} />,
         color: '#DC2626', // Redis Red
         onClick: data.onInspect,
-        title: 'Inspect Redis Keys / Shell',
+        title: t('nodeviz.inspectRedisTitle'),
       }}
     />
   );

--- a/frontend/src/features/nodes/SecurityGroups/NetworkSimulatorPanel.tsx
+++ b/frontend/src/features/nodes/SecurityGroups/NetworkSimulatorPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Send, CheckCircle2, XCircle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { ContainerData } from '../../../shared/types';
 import type { SecurityGroupRule } from './SecurityGroupsModal';
 
@@ -16,6 +17,7 @@ export default function NetworkSimulatorPanel({
   nodeSecurityGroups,
   nodeSubnetMap
 }: NetworkSimulatorPanelProps) {
+  const { t } = useTranslation();
   const [sourceNodeId, setSourceNodeId] = useState('');
   const [destNodeId, setDestNodeId] = useState('');
   const [port, setPort] = useState('80');
@@ -29,8 +31,8 @@ export default function NetworkSimulatorPanel({
     if (!sourceNodeId || !destNodeId) {
       setSimulationResult({
         success: false,
-        message: 'Simulation Error',
-        details: 'Please select both source and destination nodes.'
+        message: t('nodeshared.netsim.simulationError'),
+        details: t('nodeshared.netsim.selectBothNodes')
       });
       return;
     }
@@ -38,8 +40,8 @@ export default function NetworkSimulatorPanel({
     if (sourceNodeId === destNodeId) {
       setSimulationResult({
         success: false,
-        message: 'Loopback Connection',
-        details: 'Local loopback connection (localhost) is always allowed.'
+        message: t('nodeshared.netsim.loopbackConnection'),
+        details: t('nodeshared.netsim.loopbackDetails')
       });
       return;
     }
@@ -50,8 +52,8 @@ export default function NetworkSimulatorPanel({
     if (!sourceNode || !destNode) {
       setSimulationResult({
         success: false,
-        message: 'Simulation Error',
-        details: 'Selected nodes could not be found.'
+        message: t('nodeshared.netsim.simulationError'),
+        details: t('nodeshared.netsim.nodesNotFound')
       });
       return;
     }
@@ -69,8 +71,8 @@ export default function NetworkSimulatorPanel({
     if (sourceVpcId !== destVpcId) {
       setSimulationResult({
         success: false,
-        message: 'Connection Blocked',
-        details: 'Blocked: Nodes are in different VPCs. Inter-VPC traffic is isolated by default.'
+        message: t('nodeshared.netsim.connectionBlocked'),
+        details: t('nodeshared.netsim.differentVpcs')
       });
       return;
     }
@@ -78,8 +80,8 @@ export default function NetworkSimulatorPanel({
     if (!sourceVpcId) {
       setSimulationResult({
         success: false,
-        message: 'Connection Blocked',
-        details: 'Blocked: Nodes must be assigned to subnets inside a VPC to communicate.'
+        message: t('nodeshared.netsim.connectionBlocked'),
+        details: t('nodeshared.netsim.noVpc')
       });
       return;
     }
@@ -125,16 +127,19 @@ export default function NetworkSimulatorPanel({
     if (isAllowed) {
       setSimulationResult({
         success: true,
-        message: 'Connection Allowed',
-        details: `Allowed by rule: Inbound ALLOW port ${matchingRule?.port} from ${
-          matchingRule?.source === '0.0.0.0/0' ? 'Anywhere' : 'authorized source'
-        }.`
+        message: t('nodeshared.netsim.connectionAllowed'),
+        details: t('nodeshared.netsim.allowedByRule', {
+          port: matchingRule?.port,
+          source: matchingRule?.source === '0.0.0.0/0'
+            ? t('nodeshared.netsim.anywhere')
+            : t('nodeshared.netsim.authorizedSource')
+        })
       });
     } else {
       setSimulationResult({
         success: false,
-        message: 'Blocked by Security Group',
-        details: `Implicit Deny: No security group rule on "${destNode.name}" allows inbound traffic on port ${port} from "${sourceNode.name}".`
+        message: t('nodeshared.netsim.blockedBySecurityGroup'),
+        details: t('nodeshared.netsim.implicitDeny', { dest: destNode.name, port, source: sourceNode.name })
       });
     }
   };
@@ -143,55 +148,55 @@ export default function NetworkSimulatorPanel({
     <div style={styles.panel} className="glass">
       <div style={styles.header}>
         <Send size={14} color="var(--color-accent)" />
-        <span style={styles.title}>Traffic Route Simulator</span>
+        <span style={styles.title}>{t('nodeshared.netsim.title')}</span>
       </div>
 
       <div style={styles.body}>
         <div style={styles.formGroup}>
-          <label style={styles.label}>Source Node</label>
+          <label style={styles.label}>{t('nodeshared.netsim.sourceNode')}</label>
           <select 
             value={sourceNodeId}
             onChange={(e) => setSourceNodeId(e.target.value)}
             style={styles.select}
           >
-            <option value="">-- Select Source --</option>
+            <option value="">{t('nodeshared.netsim.selectSource')}</option>
             {nodes.map(n => (
               <option key={n.id} value={n.id}>
-                {n.name} ({nodeSubnetMap[n.id] ? 'Subnet' : 'No Subnet'})
+                {n.name} ({nodeSubnetMap[n.id] ? t('nodeshared.netsim.subnet') : t('nodeshared.netsim.noSubnet')})
               </option>
             ))}
           </select>
         </div>
 
         <div style={styles.formGroup}>
-          <label style={styles.label}>Destination Node</label>
+          <label style={styles.label}>{t('nodeshared.netsim.destinationNode')}</label>
           <select 
             value={destNodeId}
             onChange={(e) => setDestNodeId(e.target.value)}
             style={styles.select}
           >
-            <option value="">-- Select Destination --</option>
+            <option value="">{t('nodeshared.netsim.selectDestination')}</option>
             {nodes.map(n => (
               <option key={n.id} value={n.id}>
-                {n.name} ({nodeSubnetMap[n.id] ? 'Subnet' : 'No Subnet'})
+                {n.name} ({nodeSubnetMap[n.id] ? t('nodeshared.netsim.subnet') : t('nodeshared.netsim.noSubnet')})
               </option>
             ))}
           </select>
         </div>
 
         <div style={styles.formGroupShort}>
-          <label style={styles.label}>Dest Port</label>
+          <label style={styles.label}>{t('nodeshared.netsim.destPort')}</label>
           <input 
             type="text" 
             value={port}
             onChange={(e) => setPort(e.target.value)}
-            placeholder="e.g. 80, 5432"
+            placeholder={t('nodeshared.netsim.portPlaceholder')}
             style={styles.input}
           />
         </div>
 
         <button onClick={handleSimulate} style={styles.simulateBtn}>
-          Test Packet
+          {t('nodeshared.netsim.testPacket')}
         </button>
 
         {simulationResult && (

--- a/frontend/src/features/nodes/SubnetNode/SubnetNode.tsx
+++ b/frontend/src/features/nodes/SubnetNode/SubnetNode.tsx
@@ -1,4 +1,5 @@
 import { Eye, EyeOff, Route, Trash } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface SubnetNodeProps {
   id: string;
@@ -16,7 +17,9 @@ interface SubnetNodeProps {
 }
 
 export default function SubnetNode({ id, data }: SubnetNodeProps) {
+  const { t } = useTranslation();
   const isPublic = data.type === 'public';
+  const defaultName = isPublic ? t('nodeviz.publicSubnet') : t('nodeviz.privateSubnet');
   const isHovered = data.hoverStatus === 'valid' || data.hoverStatus === 'invalid';
   
   const defaultColor = isPublic ? '#10B981' : '#F59E0B';
@@ -110,7 +113,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
         zIndex: 10,
       }}>
         {isPublic ? <Eye size={12} /> : <EyeOff size={12} />}
-        <span>{data.name || (isPublic ? 'Public Subnet' : 'Private Subnet')}</span>
+        <span>{data.name || defaultName}</span>
 
         {/* Grid Controls (Rows & Cols) */}
         <div 
@@ -125,7 +128,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
           }}
           onClick={(e) => e.stopPropagation()}
         >
-          <span style={{ fontSize: '11px', opacity: 0.9 }}>Grid:</span>
+          <span style={{ fontSize: '11px', opacity: 0.9 }}>{t('nodeviz.grid')}</span>
           
           <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
             <button
@@ -133,7 +136,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
                 if (cols > 2) data.onResize?.(id, 'columns', cols - 1);
               }}
               style={btnStyle}
-              title="Reduce Columns"
+              title={t('nodeviz.reduceColumns')}
             >
               -
             </button>
@@ -161,7 +164,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
             <button
               onClick={() => data.onResize?.(id, 'columns', cols + 1)}
               style={btnStyle}
-              title="Increase Columns"
+              title={t('nodeviz.increaseColumns')}
             >
               +
             </button>
@@ -174,7 +177,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
             <button
               onClick={() => data.onResize?.(id, 'rows', rows - 1)}
               style={btnStyle}
-              title="Reduce Rows"
+              title={t('nodeviz.reduceRows')}
             >
               -
             </button>
@@ -202,7 +205,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
             <button
               onClick={() => data.onResize?.(id, 'rows', rows + 1)}
               style={btnStyle}
-              title="Increase Rows"
+              title={t('nodeviz.increaseRows')}
             >
               +
             </button>
@@ -214,7 +217,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
       <button
         onClick={(e) => {
           e.stopPropagation();
-          data.onManageRoutes?.(id, data.name || (isPublic ? 'Public Subnet' : 'Private Subnet'));
+          data.onManageRoutes?.(id, data.name || defaultName);
         }}
         style={{
           position: 'absolute',
@@ -234,10 +237,10 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
           boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
           zIndex: 10,
         }}
-        title="Manage Subnet Routing Table"
+        title={t('nodeviz.manageRoutingTable')}
       >
         <Route size={12} />
-        <span>Routes</span>
+        <span>{t('nodeviz.routes')}</span>
       </button>
 
       <button
@@ -261,7 +264,7 @@ export default function SubnetNode({ id, data }: SubnetNodeProps) {
           boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
           zIndex: 10,
         }}
-        title="Delete Subnet"
+        title={t('nodeviz.deleteSubnet')}
       >
         <Trash size={12} />
       </button>

--- a/frontend/src/features/nodes/UbuntuNode/UbuntuNode.tsx
+++ b/frontend/src/features/nodes/UbuntuNode/UbuntuNode.tsx
@@ -1,4 +1,5 @@
 import { Terminal as TermIcon, Cpu } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import BaseNode from '../components/BaseNode';
 import styles from '../ServiceNode.module.css';
 
@@ -21,6 +22,7 @@ interface UbuntuNodeProps {
 }
 
 export default function UbuntuNode({ data }: UbuntuNodeProps) {
+  const { t } = useTranslation();
   const isRunning = data.state === 'running';
 
   return (
@@ -33,8 +35,8 @@ export default function UbuntuNode({ data }: UbuntuNodeProps) {
       customTitleColor="var(--color-text-primary)"
       subtitle={
         <>
-          <span className={styles.label}>IP Address:</span>
-          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip || 'Private'}</span>
+          <span className={styles.label}>{t('nodeviz.ipAddress')}</span>
+          <span className={styles.value} style={{ color: data.ip ? '#10B981' : undefined }}>{data.ip || t('nodeviz.private')}</span>
         </>
       }
       onStart={data.onStart}
@@ -43,10 +45,10 @@ export default function UbuntuNode({ data }: UbuntuNodeProps) {
       onRename={data.onRename}
       onSecurityGroupOpen={data.onSecurityGroupOpen}
       primaryAction={{
-        label: 'Terminal',
+        label: t('nodeviz.terminal'),
         icon: <TermIcon size={14} />,
         onClick: data.onTerminalOpen,
-        title: 'Open Terminal',
+        title: t('nodeviz.openTerminal'),
       }}
     />
   );

--- a/frontend/src/features/nodes/VpcNode/VpcNode.tsx
+++ b/frontend/src/features/nodes/VpcNode/VpcNode.tsx
@@ -1,4 +1,5 @@
 import { Shield, Settings, Trash } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface VpcNodeProps {
   data: {
@@ -11,6 +12,7 @@ interface VpcNodeProps {
 }
 
 export default function VpcNode({ data }: VpcNodeProps) {
+  const { t } = useTranslation();
   const isHovered = data.hoverStatus === 'valid' || data.hoverStatus === 'invalid';
   const borderColor = isHovered 
     ? (data.hoverStatus === 'valid' ? '#10B981' : '#EF4444') 
@@ -49,7 +51,7 @@ export default function VpcNode({ data }: VpcNodeProps) {
         zIndex: 10,
       }}>
         <Shield size={12} />
-        <span>VPC: {data.name || 'Lab-VPC'}</span>
+        <span>{t('nodeviz.vpcLabel', { name: data.name || 'Lab-VPC' })}</span>
       </div>
 
       <button
@@ -75,10 +77,10 @@ export default function VpcNode({ data }: VpcNodeProps) {
           boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
           zIndex: 10,
         }}
-        title="Configure VPC / Network Simulator"
+        title={t('nodeviz.configureVpcTitle')}
       >
         <Settings size={10} />
-        <span>Configure</span>
+        <span>{t('nodeviz.configure')}</span>
       </button>
 
       <button
@@ -102,7 +104,7 @@ export default function VpcNode({ data }: VpcNodeProps) {
           boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
           zIndex: 10,
         }}
-        title="Delete VPC"
+        title={t('nodeviz.deleteVpc')}
       >
         <Trash size={9} />
       </button>
@@ -129,7 +131,7 @@ export default function VpcNode({ data }: VpcNodeProps) {
         transition: 'all 0.2s ease',
       }}>
         <span style={{ fontSize: '14px' }}>+</span>
-        <span>DROP SUBNETS OR SERVICES HERE</span>
+        <span>{t('nodeviz.dropZone')}</span>
       </div>
     </div>
   );

--- a/frontend/src/features/nodes/components/BaseNode.tsx
+++ b/frontend/src/features/nodes/components/BaseNode.tsx
@@ -1,6 +1,7 @@
 import { Handle, Position } from '@xyflow/react';
 import { Play, Square, Trash2, Shield, Pencil } from 'lucide-react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styles from '../ServiceNode.module.css';
 
 interface BaseNodeProps {
@@ -54,6 +55,7 @@ export default function BaseNode({
   subtitle,
   errorMessage
 }: BaseNodeProps) {
+  const { t } = useTranslation();
 
   const titleColor = customTitleColor || 'var(--color-text-primary)';
   const hasError = Boolean(errorMessage) && !isRunning;
@@ -88,7 +90,7 @@ export default function BaseNode({
                 }
               }}
               className={`${styles.renameBtn} ${isRunning ? styles.disabled : ''}`}
-              data-tooltip={isRunning ? "Stop the service to rename this node" : "Rename node"}
+              data-tooltip={isRunning ? t('nodeshared.base.renameStopFirst') : t('nodeshared.base.renameNode')}
             >
               <Pencil size={12} />
             </button>
@@ -109,7 +111,7 @@ export default function BaseNode({
                 alignItems: 'center',
                 marginLeft: '4px',
               }}
-              title="Configure Security Group (Firewall)"
+              title={t('nodeshared.base.securityGroupTitle')}
             >
               <Shield size={13} color="#EF4444" fill="rgba(239, 68, 68, 0.1)" />
             </button>
@@ -124,7 +126,7 @@ export default function BaseNode({
               boxShadow: `0 0 8px ${shadowColor}`
             }}
           />
-          <span className={styles.statusText}>{isRunning ? 'Online' : hasError ? 'Error' : 'Offline'}</span>
+          <span className={styles.statusText}>{isRunning ? t('nodeshared.base.online') : hasError ? t('nodeshared.base.error') : t('nodeshared.base.offline')}</span>
         </div>
       </div>
 
@@ -166,7 +168,7 @@ export default function BaseNode({
             <button
               onClick={() => onStop(id)}
               className={`${styles.btn} ${styles.btnSecondary}`}
-              title="Stop Node"
+              title={t('nodeshared.base.stopNode')}
             >
               <Square size={14} fill="#9CA3AF" />
             </button>
@@ -175,17 +177,17 @@ export default function BaseNode({
           <button
             onClick={() => onStart(id)}
             className={`${styles.btn} ${styles.btnSuccess}`}
-            title="Start Node"
+            title={t('nodeshared.base.startNode')}
           >
             <Play size={14} style={{ marginRight: 4 }} fill="#10B981" />
-            Start
+            {t('nodeshared.base.start')}
           </button>
         )}
 
         <button
           onClick={() => onDelete(id)}
           className={`${styles.btn} ${styles.btnDanger}`}
-          title="Delete Node"
+          title={t('nodeshared.base.deleteNode')}
         >
           <Trash2 size={14} />
         </button>

--- a/frontend/src/features/nodes/components/ResourceLimitsPanel.tsx
+++ b/frontend/src/features/nodes/components/ResourceLimitsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface ResourceLimitsPanelProps {
   labels: {
@@ -20,6 +21,7 @@ interface ResourceLimitsPanelProps {
  * it does not touch the real container.
  */
 export default function ResourceLimitsPanel({ labels, onScalingLog }: ResourceLimitsPanelProps) {
+  const { t } = useTranslation();
   const [cpuLimit, setCpuLimit] = useState(1);
   const [memoryLimit, setMemoryLimit] = useState(512);
   const [storageLimit, setStorageLimit] = useState(50);
@@ -28,7 +30,7 @@ export default function ResourceLimitsPanel({ labels, onScalingLog }: ResourceLi
   const [appliedStorage, setAppliedStorage] = useState(50);
   const [scalingLoading, setScalingLoading] = useState(false);
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(
-    "Database operating at baseline resources: 1 vCPU, 512MB RAM, 50GB storage. Handles standard query throughput."
+    t('nodeshared.resources.baseline')
   );
 
   const handleUpdateLimits = () => {
@@ -48,27 +50,27 @@ export default function ResourceLimitsPanel({ labels, onScalingLog }: ResourceLi
 
       let customMsg: string;
       if (throughputIncreased && storageIncreased) {
-        customMsg = "now the database can handle more concurrent requests/transactions and store more data (expanded persistent disk).";
+        customMsg = t('nodeshared.resources.impactUpStorageUp');
       } else if (throughputDecreased && storageDecreased) {
-        customMsg = "now the database will handle fewer requests (higher risk of CPU/RAM throttling) and store less data (reduced storage space).";
+        customMsg = t('nodeshared.resources.impactDownStorageDown');
       } else if (throughputIncreased && storageDecreased) {
-        customMsg = "now the database can handle more requests (faster query performance) but will store less data due to reduced storage limit.";
+        customMsg = t('nodeshared.resources.impactUpStorageDown');
       } else if (throughputDecreased && storageIncreased) {
-        customMsg = "now the database server will handle fewer requests (slower processing capacity) but can store more persistent data.";
+        customMsg = t('nodeshared.resources.impactDownStorageUp');
       } else if (throughputIncreased) {
-        customMsg = "now the database can handle more requests and process queries faster.";
+        customMsg = t('nodeshared.resources.impactUp');
       } else if (throughputDecreased) {
-        customMsg = "now the database will handle fewer requests and experience increased latency under query loads.";
+        customMsg = t('nodeshared.resources.impactDown');
       } else if (storageIncreased) {
-        customMsg = "now the database can store more data with expanded disk capacity.";
+        customMsg = t('nodeshared.resources.impactStorageUp');
       } else if (storageDecreased) {
-        customMsg = "now the database storage capacity is reduced.";
+        customMsg = t('nodeshared.resources.impactStorageDown');
       } else {
-        customMsg = "no resource limits were changed.";
+        customMsg = t('nodeshared.resources.impactNone');
       }
 
-      onScalingLog(`RESOURCE SCALING UPDATE: Vertical limits applied. Configured: CPU=${cpuLimit} Cores, RAM=${memoryLimit}MB, Storage=${storageLimit}GB. Impact: ${customMsg}`);
-      setFeedbackMessage(`Limits Applied! Impact: ${customMsg}`);
+      onScalingLog(t('nodeshared.resources.scalingLog', { cpu: cpuLimit, ram: memoryLimit, storage: storageLimit, impact: customMsg }));
+      setFeedbackMessage(t('nodeshared.resources.limitsApplied', { impact: customMsg }));
 
       setAppliedCpu(cpuLimit);
       setAppliedMemory(memoryLimit);

--- a/frontend/src/features/nodes/components/SchemaTreeExplorer.tsx
+++ b/frontend/src/features/nodes/components/SchemaTreeExplorer.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Database, Table, Columns, RefreshCw, AlertCircle, Eye, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { inspectorStyles } from './inspectorStyles';
 
 export interface DBColumn {
@@ -53,6 +54,7 @@ export default function SchemaTreeExplorer({
   initialExpandedDb,
   labels,
 }: SchemaTreeExplorerProps) {
+  const { t } = useTranslation();
   const [expandedDBs, setExpandedDBs] = useState<Record<string, boolean>>({ [initialExpandedDb]: true });
   const [expandedTables, setExpandedTables] = useState<Record<string, boolean>>({});
 
@@ -96,7 +98,7 @@ export default function SchemaTreeExplorer({
               <Database size={16} color="#3B82F6" style={{ marginRight: 8 }} />
               <span style={styles.dbName}>{node.database}</span>
               {node.error && (
-                <span title="Database offline/unreachable">
+                <span title={t('nodeshared.schema.offlineUnreachable')}>
                   <AlertCircle size={14} color="#EF4444" style={{ marginLeft: 8 }} />
                 </span>
               )}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5,7 +5,8 @@
     "saveGraph": "Save Graph",
     "backToProjects": "Back to Projects",
     "refreshNodes": "Refresh Nodes",
-    "learning": "Learning"
+    "learning": "Learning",
+    "toggleLanguage": "Toggle Language"
   },
   "learning": {
     "panelTitle": "Learning",
@@ -76,7 +77,12 @@
     "open": "Open",
     "delete": "Delete",
     "storeRecovered": "Your projects file could not be read and had to be reset. The unreadable file was kept as projects.json.corrupt in your .torollo folder.",
-    "dismissNotice": "Dismiss notice"
+    "dismissNotice": "Dismiss notice",
+    "emptyTitle": "No projects yet",
+    "emptyDesc": "Click \"New Project\" to create your first infrastructure stack.",
+    "deleting": "Deleting...",
+    "deleteProjectTooltip": "Delete project",
+    "openStack": "Open Stack"
   },
   "vpc": {
     "titleInfo": "Project VPC Settings",
@@ -481,6 +487,225 @@
       "example": "Example Usage",
       "copied": "Copied!",
       "copy": "Copy"
+    }
+  },
+  "common": {
+    "delete": "Delete",
+    "rename": "Rename",
+    "deleteContainerTitle": "Delete Container",
+    "deleteContainerMessage": "This will permanently stop and remove this container. This action cannot be undone.",
+    "renameNodeTitle": "Rename Node",
+    "renameNodeLabel": "Enter a new name for this node.",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "deleting": "Deleting...",
+    "creating": "Creating...",
+    "create": "Create",
+    "genericError": "An error occurred",
+    "dockerUnavailable": "Docker daemon unreachable — start Docker and the lab will reconnect automatically.",
+    "deleteConnection": "Delete Connection"
+  },
+  "toasts": {
+    "subnetDeleteBlocked": "Cannot delete subnet: Move or delete all nodes inside the subnet first.",
+    "subnetDeleted": "Subnet deleted successfully",
+    "gridShrinkBlocked": "Cannot shrink grid. You should remove the node with name '{{name}}' to be able to reduce the size",
+    "firewallConnectionRemoved": "Firewall connection removed",
+    "sgAllTraffic": "all traffic",
+    "sgPort": "Port {{port}}",
+    "sgAllowedInbound": "Security Group: Allowed {{traffic}} inbound from {{source}}",
+    "firewallRuleRemoved": "Firewall rule removed",
+    "graphSaved": "Graph layout saved successfully",
+    "nodeExists": "A node named \"{{name}}\" already exists in this project.",
+    "nodeAlreadyNamed": "The node is already named \"{{name}}\".",
+    "renameFailedGeneric": "Rename failed.",
+    "renameFailedServer": "Rename failed: could not reach the server.",
+    "nodeRenamed": "Node renamed to \"{{name}}\"",
+    "subnetNestingInvalid": "Invalid placement: Subnets cannot be nested inside other subnets.",
+    "nodeRemovedFromSubnet": "Node \"{{node}}\" removed from Subnet \"{{subnet}}\"",
+    "nodeAddedToSubnet": "Node \"{{node}}\" added to Subnet \"{{subnet}}\"",
+    "nodesMustResideInSubnet": "Nodes must reside within a subnet.",
+    "asgTemplateDeleteBlocked": "Cannot delete node \"{{name}}\": it is used as a template by an active Auto Scaling Group. Please stop the ASG first.",
+    "subnetFallback": "Subnet",
+    "nodeFallback": "Node",
+    "nodeCreated": "Node \"{{name}}\" created successfully",
+    "nodeCreateFailed": "Failed to create node \"{{name}}\"",
+    "nodeCreateError": "Error creating container node",
+    "containerStartFailed": "Failed to start the container",
+    "containerStartUnreachable": "Could not reach the server to start the container",
+    "containerStopFailed": "Failed to stop the container",
+    "containerStopUnreachable": "Could not reach the server to stop the container",
+    "containerDeleted": "Container deleted",
+    "containerDeleteFailed": "Failed to delete the container",
+    "containerDeleteUnreachable": "Could not reach the server to delete the container"
+  },
+  "audit": {
+    "nodeMissingSubnet": "Node \"{{name}}\" is assigned to a subnet that does not exist.",
+    "dataStorePublicSubnet": "Data store \"{{name}}\" is in a public subnet. For safety, data store instances should be kept in private subnets.",
+    "dataStorePublicExposure": "Data store \"{{name}}\" is exposed to the public internet (0.0.0.0/0) in its security group.",
+    "noCachingTier": "No caching tier (e.g., Redis or Memcached) detected. Consider adding one to optimize database loads.",
+    "directPublicToDb": "Database \"{{db}}\" receives direct connections from public-facing node \"{{src}}\". Traffic should go through a backend application layer.",
+    "secure3Tier": "Secure 3-Tier VPC Architecture detected! (Public Gateway -> Private App Server -> Private Isolated Database)",
+    "vpcValid": "VPC Network is fully valid and adheres to basic system design security guidelines!"
+  },
+  "nodeviz": {
+    "inspect": "Inspect",
+    "configure": "Configure",
+    "ipAddress": "IP Address:",
+    "ipPort": "IP/Port:",
+    "private": "Private",
+    "instances": "Instances:",
+    "countRunning": "{{count}} Running",
+    "asgInspectTitle": "Configure ASG settings & inspect instance replicas",
+    "loadBalancerConfigTitle": "Configure Load Balancer rules & targets",
+    "infoGuide": "Info & Guide",
+    "natInfoGuideTitle": "View NAT Gateway details & guide",
+    "inspectDatabaseTitle": "Inspect Database Explorer / Shell",
+    "inspectRedisTitle": "Inspect Redis Keys / Shell",
+    "terminal": "Terminal",
+    "openTerminal": "Open Terminal",
+    "publicSubnet": "Public Subnet",
+    "privateSubnet": "Private Subnet",
+    "grid": "Grid:",
+    "reduceColumns": "Reduce Columns",
+    "increaseColumns": "Increase Columns",
+    "reduceRows": "Reduce Rows",
+    "increaseRows": "Increase Rows",
+    "manageRoutingTable": "Manage Subnet Routing Table",
+    "routes": "Routes",
+    "deleteSubnet": "Delete Subnet",
+    "vpcLabel": "VPC: {{name}}",
+    "configureVpcTitle": "Configure VPC / Network Simulator",
+    "deleteVpc": "Delete VPC",
+    "dropZone": "DROP SUBNETS OR SERVICES HERE"
+  },
+  "nodeshared": {
+    "base": {
+      "renameStopFirst": "Stop the service to rename this node",
+      "renameNode": "Rename node",
+      "securityGroupTitle": "Configure Security Group (Firewall)",
+      "online": "Online",
+      "error": "Error",
+      "offline": "Offline",
+      "stopNode": "Stop Node",
+      "startNode": "Start Node",
+      "start": "Start",
+      "deleteNode": "Delete Node"
+    },
+    "schema": {
+      "offlineUnreachable": "Database offline/unreachable"
+    },
+    "resources": {
+      "baseline": "Database operating at baseline resources: 1 vCPU, 512MB RAM, 50GB storage. Handles standard query throughput.",
+      "impactUpStorageUp": "now the database can handle more concurrent requests/transactions and store more data (expanded persistent disk).",
+      "impactDownStorageDown": "now the database will handle fewer requests (higher risk of CPU/RAM throttling) and store less data (reduced storage space).",
+      "impactUpStorageDown": "now the database can handle more requests (faster query performance) but will store less data due to reduced storage limit.",
+      "impactDownStorageUp": "now the database server will handle fewer requests (slower processing capacity) but can store more persistent data.",
+      "impactUp": "now the database can handle more requests and process queries faster.",
+      "impactDown": "now the database will handle fewer requests and experience increased latency under query loads.",
+      "impactStorageUp": "now the database can store more data with expanded disk capacity.",
+      "impactStorageDown": "now the database storage capacity is reduced.",
+      "impactNone": "no resource limits were changed.",
+      "scalingLog": "RESOURCE SCALING UPDATE: Vertical limits applied. Configured: CPU={{cpu}} Cores, RAM={{ram}}MB, Storage={{storage}}GB. Impact: {{impact}}",
+      "limitsApplied": "Limits Applied! Impact: {{impact}}"
+    },
+    "netsim": {
+      "simulationError": "Simulation Error",
+      "selectBothNodes": "Please select both source and destination nodes.",
+      "loopbackConnection": "Loopback Connection",
+      "loopbackDetails": "Local loopback connection (localhost) is always allowed.",
+      "nodesNotFound": "Selected nodes could not be found.",
+      "connectionBlocked": "Connection Blocked",
+      "differentVpcs": "Blocked: Nodes are in different VPCs. Inter-VPC traffic is isolated by default.",
+      "noVpc": "Blocked: Nodes must be assigned to subnets inside a VPC to communicate.",
+      "connectionAllowed": "Connection Allowed",
+      "allowedByRule": "Allowed by rule: Inbound ALLOW port {{port}} from {{source}}.",
+      "anywhere": "Anywhere",
+      "authorizedSource": "authorized source",
+      "blockedBySecurityGroup": "Blocked by Security Group",
+      "implicitDeny": "Implicit Deny: No security group rule on \"{{dest}}\" allows inbound traffic on port {{port}} from \"{{source}}\".",
+      "title": "Traffic Route Simulator",
+      "sourceNode": "Source Node",
+      "destinationNode": "Destination Node",
+      "destPort": "Dest Port",
+      "selectSource": "-- Select Source --",
+      "selectDestination": "-- Select Destination --",
+      "subnet": "Subnet",
+      "noSubnet": "No Subnet",
+      "portPlaceholder": "e.g. 80, 5432",
+      "testPacket": "Test Packet"
+    }
+  },
+  "nodeLibrary": {
+    "title": "Node Library",
+    "search": "Search nodes...",
+    "expand": "Expand Sidebar",
+    "collapse": "Collapse Sidebar",
+    "noMatch": "No matching nodes found",
+    "dragNode": "Drag {{name}}",
+    "categories": {
+      "networking": "Networking",
+      "compute": "Compute",
+      "databases": "Databases"
+    },
+    "types": {
+      "subnet-public": {
+        "name": "Public Subnet",
+        "desc": "Allows public access"
+      },
+      "subnet-private": {
+        "name": "Private Subnet",
+        "desc": "Internal instances only"
+      },
+      "nat": {
+        "name": "NAT Gateway",
+        "desc": "Outbound internet routing"
+      },
+      "loadbalancer": {
+        "name": "Load Balancer",
+        "desc": "Inbound HTTP proxying"
+      },
+      "ubuntu": {
+        "name": "Server",
+        "desc": "Standard terminal shell"
+      },
+      "autoscalinggroup": {
+        "name": "Auto Scaling Group",
+        "desc": "Dynamic instance pool"
+      },
+      "postgres": {
+        "name": "SQL Database",
+        "desc": "Relational DB + Shell"
+      },
+      "nosql": {
+        "name": "NoSQL Database",
+        "desc": "Document DB + Shell"
+      },
+      "redis": {
+        "name": "Cache Store",
+        "desc": "In-memory key-value cache"
+      }
+    },
+    "createNode": {
+      "label": "Give your new container a descriptive name.",
+      "submit": "Create Node",
+      "titles": {
+        "ubuntu": "Create Ubuntu Node",
+        "postgres": "Create SQL Database Node",
+        "nosql": "Create NoSQL Database Node",
+        "redis": "Create Cache Store Node",
+        "nat": "Create NAT Gateway Node",
+        "loadbalancer": "Create Load Balancer Node",
+        "autoscalinggroup": "Create Auto Scaling Group Node"
+      },
+      "placeholders": {
+        "ubuntu": "e.g. server-1",
+        "postgres": "e.g. sql-1",
+        "nosql": "e.g. nosql-1",
+        "redis": "e.g. redis-1",
+        "nat": "e.g. nat-1",
+        "loadbalancer": "e.g. alb-1",
+        "autoscalinggroup": "e.g. asg-1"
+      }
     }
   }
 }

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -5,7 +5,8 @@
     "saveGraph": "Enregistrer le Graphe",
     "backToProjects": "Retour aux Projets",
     "refreshNodes": "Actualiser les Nœuds",
-    "learning": "Apprentissage"
+    "learning": "Apprentissage",
+    "toggleLanguage": "Changer de langue"
   },
   "learning": {
     "panelTitle": "Apprentissage",
@@ -76,7 +77,12 @@
     "open": "Ouvrir",
     "delete": "Supprimer",
     "storeRecovered": "Votre fichier de projets était illisible et a dû être réinitialisé. Le fichier illisible a été conservé sous projects.json.corrupt dans votre dossier .torollo.",
-    "dismissNotice": "Fermer l'avertissement"
+    "dismissNotice": "Fermer l'avertissement",
+    "emptyTitle": "Aucun projet pour l'instant",
+    "emptyDesc": "Cliquez sur « Nouveau projet » pour créer votre première stack d'infrastructure.",
+    "deleting": "Suppression...",
+    "deleteProjectTooltip": "Supprimer le projet",
+    "openStack": "Ouvrir la stack"
   },
   "vpc": {
     "titleInfo": "Paramètres VPC du Projet",
@@ -481,6 +487,225 @@
       "example": "Exemple d'Utilisation",
       "copied": "Copié !",
       "copy": "Copier"
+    }
+  },
+  "common": {
+    "delete": "Supprimer",
+    "rename": "Renommer",
+    "deleteContainerTitle": "Supprimer le conteneur",
+    "deleteContainerMessage": "Cela arrêtera et supprimera définitivement ce conteneur. Cette action est irréversible.",
+    "renameNodeTitle": "Renommer le nœud",
+    "renameNodeLabel": "Saisissez un nouveau nom pour ce nœud.",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "deleting": "Suppression...",
+    "creating": "Création...",
+    "create": "Créer",
+    "genericError": "Une erreur s'est produite",
+    "dockerUnavailable": "Démon Docker injoignable — démarrez Docker et le lab se reconnectera automatiquement.",
+    "deleteConnection": "Supprimer la connexion"
+  },
+  "toasts": {
+    "subnetDeleteBlocked": "Impossible de supprimer le sous-réseau : déplacez ou supprimez d'abord tous les nœuds qu'il contient.",
+    "subnetDeleted": "Sous-réseau supprimé avec succès",
+    "gridShrinkBlocked": "Impossible de réduire la grille. Retirez le nœud nommé « {{name}} » pour pouvoir réduire la taille.",
+    "firewallConnectionRemoved": "Connexion du pare-feu supprimée",
+    "sgAllTraffic": "tout le trafic",
+    "sgPort": "Port {{port}}",
+    "sgAllowedInbound": "Groupe de sécurité : {{traffic}} autorisé en entrée depuis {{source}}",
+    "firewallRuleRemoved": "Règle de pare-feu supprimée",
+    "graphSaved": "Disposition du graphe enregistrée avec succès",
+    "nodeExists": "Un nœud nommé « {{name}} » existe déjà dans ce projet.",
+    "nodeAlreadyNamed": "Le nœud s'appelle déjà « {{name}} ».",
+    "renameFailedGeneric": "Échec du renommage.",
+    "renameFailedServer": "Échec du renommage : serveur injoignable.",
+    "nodeRenamed": "Nœud renommé en « {{name}} »",
+    "subnetNestingInvalid": "Placement invalide : les sous-réseaux ne peuvent pas être imbriqués dans d'autres sous-réseaux.",
+    "nodeRemovedFromSubnet": "Nœud « {{node}} » retiré du sous-réseau « {{subnet}} »",
+    "nodeAddedToSubnet": "Nœud « {{node}} » ajouté au sous-réseau « {{subnet}} »",
+    "nodesMustResideInSubnet": "Les nœuds doivent se trouver dans un sous-réseau.",
+    "asgTemplateDeleteBlocked": "Impossible de supprimer le nœud « {{name}} » : il sert de modèle à un groupe d'auto-scaling actif. Arrêtez d'abord l'ASG.",
+    "subnetFallback": "Sous-réseau",
+    "nodeFallback": "Nœud",
+    "nodeCreated": "Nœud « {{name}} » créé avec succès",
+    "nodeCreateFailed": "Échec de la création du nœud « {{name}} »",
+    "nodeCreateError": "Erreur lors de la création du nœud conteneur",
+    "containerStartFailed": "Échec du démarrage du conteneur",
+    "containerStartUnreachable": "Serveur injoignable pour démarrer le conteneur",
+    "containerStopFailed": "Échec de l'arrêt du conteneur",
+    "containerStopUnreachable": "Serveur injoignable pour arrêter le conteneur",
+    "containerDeleted": "Conteneur supprimé",
+    "containerDeleteFailed": "Échec de la suppression du conteneur",
+    "containerDeleteUnreachable": "Serveur injoignable pour supprimer le conteneur"
+  },
+  "audit": {
+    "nodeMissingSubnet": "Le nœud « {{name}} » est affecté à un sous-réseau qui n'existe pas.",
+    "dataStorePublicSubnet": "Le magasin de données « {{name}} » se trouve dans un sous-réseau public. Par sécurité, les magasins de données devraient rester dans des sous-réseaux privés.",
+    "dataStorePublicExposure": "Le magasin de données « {{name}} » est exposé à l'Internet public (0.0.0.0/0) dans son groupe de sécurité.",
+    "noCachingTier": "Aucune couche de cache (par ex. Redis ou Memcached) détectée. Envisagez d'en ajouter une pour optimiser la charge de la base de données.",
+    "directPublicToDb": "La base de données « {{db}} » reçoit des connexions directes du nœud public « {{src}} ». Le trafic devrait passer par une couche applicative back-end.",
+    "secure3Tier": "Architecture VPC 3-tiers sécurisée détectée ! (Passerelle publique -> Serveur d'application privé -> Base de données privée isolée)",
+    "vpcValid": "Le réseau VPC est entièrement valide et respecte les règles de sécurité de base en conception système !"
+  },
+  "nodeviz": {
+    "inspect": "Inspecter",
+    "configure": "Configurer",
+    "ipAddress": "Adresse IP :",
+    "ipPort": "IP/Port :",
+    "private": "Privée",
+    "instances": "Réplicas :",
+    "countRunning": "{{count}} en cours d'exécution",
+    "asgInspectTitle": "Configurer les paramètres de l'ASG et inspecter les réplicas d'instances",
+    "loadBalancerConfigTitle": "Configurer les règles et cibles du répartiteur de charge",
+    "infoGuide": "Infos et guide",
+    "natInfoGuideTitle": "Voir les détails et le guide de la passerelle NAT",
+    "inspectDatabaseTitle": "Inspecter l'explorateur de base de données / le shell",
+    "inspectRedisTitle": "Inspecter les clés Redis / le shell",
+    "terminal": "Terminal",
+    "openTerminal": "Ouvrir le terminal",
+    "publicSubnet": "Sous-réseau public",
+    "privateSubnet": "Sous-réseau privé",
+    "grid": "Grille :",
+    "reduceColumns": "Réduire les colonnes",
+    "increaseColumns": "Augmenter les colonnes",
+    "reduceRows": "Réduire les rangées",
+    "increaseRows": "Augmenter les rangées",
+    "manageRoutingTable": "Gérer la table de routage du sous-réseau",
+    "routes": "Routes",
+    "deleteSubnet": "Supprimer le sous-réseau",
+    "vpcLabel": "VPC : {{name}}",
+    "configureVpcTitle": "Configurer le VPC / simulateur réseau",
+    "deleteVpc": "Supprimer le VPC",
+    "dropZone": "DÉPOSEZ DES SOUS-RÉSEAUX OU SERVICES ICI"
+  },
+  "nodeshared": {
+    "base": {
+      "renameStopFirst": "Arrêtez le service pour renommer ce nœud",
+      "renameNode": "Renommer le nœud",
+      "securityGroupTitle": "Configurer le groupe de sécurité (pare-feu)",
+      "online": "En ligne",
+      "error": "Erreur",
+      "offline": "Hors ligne",
+      "stopNode": "Arrêter le nœud",
+      "startNode": "Démarrer le nœud",
+      "start": "Démarrer",
+      "deleteNode": "Supprimer le nœud"
+    },
+    "schema": {
+      "offlineUnreachable": "Base de données hors ligne/injoignable"
+    },
+    "resources": {
+      "baseline": "Base de données fonctionnant avec les ressources de base : 1 vCPU, 512 Mo de mémoire, 50 Go de stockage. Gère un débit de requêtes standard.",
+      "impactUpStorageUp": "la base de données peut désormais gérer plus de requêtes/transactions simultanées et stocker plus de données (disque persistant étendu).",
+      "impactDownStorageDown": "la base de données gérera désormais moins de requêtes (risque accru de throttling CPU/mémoire) et stockera moins de données (espace de stockage réduit).",
+      "impactUpStorageDown": "la base de données peut désormais gérer plus de requêtes (meilleures performances des requêtes) mais stockera moins de données en raison de la limite de stockage réduite.",
+      "impactDownStorageUp": "le serveur de base de données gérera désormais moins de requêtes (capacité de traitement plus lente) mais peut stocker plus de données persistantes.",
+      "impactUp": "la base de données peut désormais gérer plus de requêtes et traiter les requêtes plus rapidement.",
+      "impactDown": "la base de données gérera désormais moins de requêtes et connaîtra une latence accrue en charge.",
+      "impactStorageUp": "la base de données peut désormais stocker plus de données grâce à la capacité disque étendue.",
+      "impactStorageDown": "la capacité de stockage de la base de données est désormais réduite.",
+      "impactNone": "aucune limite de ressources n'a été modifiée.",
+      "scalingLog": "MISE À JOUR DE MISE À L'ÉCHELLE DES RESSOURCES : limites verticales appliquées. Configuré : CPU={{cpu}} cœurs, mémoire={{ram}} Mo, stockage={{storage}} Go. Impact : {{impact}}",
+      "limitsApplied": "Limites appliquées ! Impact : {{impact}}"
+    },
+    "netsim": {
+      "simulationError": "Erreur de simulation",
+      "selectBothNodes": "Veuillez sélectionner les nœuds source et destination.",
+      "loopbackConnection": "Connexion en boucle locale",
+      "loopbackDetails": "La connexion en boucle locale (localhost) est toujours autorisée.",
+      "nodesNotFound": "Les nœuds sélectionnés sont introuvables.",
+      "connectionBlocked": "Connexion bloquée",
+      "differentVpcs": "Bloqué : les nœuds sont dans des VPC différents. Le trafic inter-VPC est isolé par défaut.",
+      "noVpc": "Bloqué : les nœuds doivent être affectés à des sous-réseaux dans un VPC pour communiquer.",
+      "connectionAllowed": "Connexion autorisée",
+      "allowedByRule": "Autorisé par la règle : entrant ALLOW port {{port}} depuis {{source}}.",
+      "anywhere": "N'importe où",
+      "authorizedSource": "source autorisée",
+      "blockedBySecurityGroup": "Bloqué par le groupe de sécurité",
+      "implicitDeny": "Refus implicite : aucune règle de groupe de sécurité sur « {{dest}} » n'autorise le trafic entrant sur le port {{port}} depuis « {{source}} ».",
+      "title": "Simulateur de route de trafic",
+      "sourceNode": "Nœud source",
+      "destinationNode": "Nœud de destination",
+      "destPort": "Port de destination",
+      "selectSource": "-- Sélectionner la source --",
+      "selectDestination": "-- Sélectionner la destination --",
+      "subnet": "Sous-réseau",
+      "noSubnet": "Aucun sous-réseau",
+      "portPlaceholder": "ex. 80, 5432",
+      "testPacket": "Tester le paquet"
+    }
+  },
+  "nodeLibrary": {
+    "title": "Bibliothèque de nœuds",
+    "search": "Rechercher des nœuds...",
+    "expand": "Développer la barre latérale",
+    "collapse": "Réduire la barre latérale",
+    "noMatch": "Aucun nœud correspondant",
+    "dragNode": "Glisser {{name}}",
+    "categories": {
+      "networking": "Réseau",
+      "compute": "Calcul",
+      "databases": "Bases de données"
+    },
+    "types": {
+      "subnet-public": {
+        "name": "Sous-réseau public",
+        "desc": "Autorise l'accès public"
+      },
+      "subnet-private": {
+        "name": "Sous-réseau privé",
+        "desc": "Instances internes uniquement"
+      },
+      "nat": {
+        "name": "Passerelle NAT",
+        "desc": "Routage sortant vers Internet"
+      },
+      "loadbalancer": {
+        "name": "Répartiteur de charge",
+        "desc": "Proxy HTTP entrant"
+      },
+      "ubuntu": {
+        "name": "Serveur",
+        "desc": "Shell de terminal standard"
+      },
+      "autoscalinggroup": {
+        "name": "Groupe d'auto-scaling",
+        "desc": "Pool d'instances dynamique"
+      },
+      "postgres": {
+        "name": "Base de données SQL",
+        "desc": "BD relationnelle + Shell"
+      },
+      "nosql": {
+        "name": "Base de données NoSQL",
+        "desc": "BD documentaire + Shell"
+      },
+      "redis": {
+        "name": "Cache",
+        "desc": "Cache clé-valeur en mémoire"
+      }
+    },
+    "createNode": {
+      "label": "Donnez un nom descriptif à votre nouveau conteneur.",
+      "submit": "Créer le nœud",
+      "titles": {
+        "ubuntu": "Créer un nœud Ubuntu",
+        "postgres": "Créer un nœud Base de données SQL",
+        "nosql": "Créer un nœud Base de données NoSQL",
+        "redis": "Créer un nœud Cache",
+        "nat": "Créer un nœud Passerelle NAT",
+        "loadbalancer": "Créer un nœud Répartiteur de charge",
+        "autoscalinggroup": "Créer un nœud Groupe d'auto-scaling"
+      },
+      "placeholders": {
+        "ubuntu": "ex. server-1",
+        "postgres": "ex. sql-1",
+        "nosql": "ex. nosql-1",
+        "redis": "ex. redis-1",
+        "nat": "ex. nat-1",
+        "loadbalancer": "ex. alb-1",
+        "autoscalinggroup": "ex. asg-1"
+      }
     }
   }
 }

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ReactFlow, Background, Controls, BackgroundVariant, useNodesState } from '@xyflow/react';
 import type { Node, Edge, ReactFlowInstance, Connection } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
@@ -55,6 +56,7 @@ const INSPECTOR_KIND_BY_NODE_TYPE: Record<string, InspectorState['kind']> = {
 };
 
 export default function CanvasPage({ projectId, projectName, onBackToProjects, onTerminalOpen }: CanvasPageProps) {
+  const { t } = useTranslation();
   const { toast, showNotification, showToast, dismissToast } = useToast();
 
   const {
@@ -143,7 +145,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     if (hasNodes) {
       showNotification({
         type: 'error',
-        message: 'Cannot delete subnet: Move or delete all nodes inside the subnet first.'
+        message: t('toasts.subnetDeleteBlocked')
       });
       return;
     }
@@ -155,9 +157,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     });
     const newConfig = { ...networkConfig, subnets: updatedSubnets, nodeSubnetMap: updatedNodeSubnetMap };
     saveNetworkConfig(newConfig);
-    showToast("Subnet deleted successfully");
+    showToast(t('toasts.subnetDeleted'));
     triggerArchitectureAudit(newConfig);
-  }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit, showNotification]);
+  }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit, showNotification, t]);
 
   const handleSubnetResize = useCallback((subnetId: string, dimension: 'columns' | 'rows', newValue: number) => {
     if (dimension === 'columns' && newValue < 2) return;
@@ -184,7 +186,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
           if (col >= targetCols || row >= targetRows) {
             showNotification({
               type: 'error',
-              message: `Cannot shrink grid. You should remove the node with name '${node.name}' to be able to reduce the size`
+              message: t('toasts.gridShrinkBlocked', { name: node.name })
             });
             return;
           }
@@ -209,7 +211,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     const newConfig = { ...networkConfig, subnets: updatedSubnets };
     saveNetworkConfig(newConfig);
     triggerArchitectureAudit(newConfig);
-  }, [networkConfig, containers, saveNetworkConfig, triggerArchitectureAudit, showNotification]);
+  }, [networkConfig, containers, saveNetworkConfig, triggerArchitectureAudit, showNotification, t]);
 
   const handleDeleteEdge = useCallback((edgeId: string) => {
     const parsed = parseEdgeId(edgeId);
@@ -219,9 +221,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     if (!newConfig) return;
 
     saveNetworkConfig(newConfig);
-    showToast("Firewall connection removed");
+    showToast(t('toasts.firewallConnectionRemoved'));
     triggerArchitectureAudit(newConfig);
-  }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
+  }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit, t]);
 
   // Dynamic edges representing firewall rules
   const edges = useMemo(
@@ -242,9 +244,10 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
     saveNetworkConfig(result.config);
     const sourceName = sourceNode?.name || source;
-    showToast(`Security Group: Allowed ${result.port === 'ALL' ? 'all traffic' : `Port ${result.port}`} inbound from ${sourceName}`);
+    const traffic = result.port === 'ALL' ? t('toasts.sgAllTraffic') : t('toasts.sgPort', { port: result.port });
+    showToast(t('toasts.sgAllowedInbound', { traffic, source: sourceName }));
     triggerArchitectureAudit(result.config);
-  }, [containers, networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
+  }, [containers, networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit, t]);
 
   // Handle connection line deletion (removes matching firewall rule)
   const onEdgesDelete = useCallback((deletedEdges: Edge[]) => {
@@ -255,9 +258,9 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     if (!newConfig) return;
 
     saveNetworkConfig(newConfig);
-    showToast("Firewall rule removed");
+    showToast(t('toasts.firewallRuleRemoved'));
     triggerArchitectureAudit(newConfig);
-  }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit]);
+  }, [networkConfig, saveNetworkConfig, showToast, triggerArchitectureAudit, t]);
 
   // Load saved positions, network configurations and start polling
   useEffect(() => {
@@ -451,7 +454,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     });
     positionsRef.current = currentPositions;
     localStorage.setItem(`akal-lab-graph-layout-${projectId}`, JSON.stringify(currentPositions));
-    showToast('Graph layout saved successfully');
+    showToast(t('toasts.graphSaved'));
   };
 
   const handleCreateNode = async (name: string) => {
@@ -459,7 +462,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
     if (exists) {
       showNotification({
         type: 'error',
-        message: `A node named "${name}" already exists in this project.`
+        message: t('toasts.nodeExists', { name })
       });
       return;
     }
@@ -499,7 +502,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
 
     // Guard against renaming to the same name
     if (trimmedNewName.toLowerCase() === currentName.toLowerCase()) {
-      showNotification({ type: 'warning', message: `The node is already named "${currentName}".` });
+      showNotification({ type: 'warning', message: t('toasts.nodeAlreadyNamed', { name: currentName }) });
       setRenamingNode(null);
       return;
     }
@@ -509,7 +512,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
       c => c.name.toLowerCase() === trimmedNewName.toLowerCase() && c.id !== id
     );
     if (exists) {
-      showNotification({ type: 'error', message: `A node named "${trimmedNewName}" already exists in this project.` });
+      showNotification({ type: 'error', message: t('toasts.nodeExists', { name: trimmedNewName }) });
       return;
     }
 
@@ -520,7 +523,7 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         body: JSON.stringify({ newName: trimmedNewName }),
       });
       if (!res.ok) {
-        let message = 'Rename failed.';
+        let message = t('toasts.renameFailedGeneric');
         try {
           const data = await res.json();
           if (typeof data?.error === 'string' && data.error.trim()) {
@@ -533,12 +536,12 @@ export default function CanvasPage({ projectId, projectName, onBackToProjects, o
         return;
       }
     } catch {
-      showNotification({ type: 'error', message: 'Rename failed: could not reach the server.' });
+      showNotification({ type: 'error', message: t('toasts.renameFailedServer') });
       return;
     }
 
     setRenamingNode(null);
-    showToast(`Node renamed to "${trimmedNewName}"`);
+    showToast(t('toasts.nodeRenamed', { name: trimmedNewName }));
     await fetchContainers();
   };
 

--- a/frontend/src/pages/CanvasPage/components/ButtonEdge.tsx
+++ b/frontend/src/pages/CanvasPage/components/ButtonEdge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BaseEdge, EdgeLabelRenderer, getBezierPath } from '@xyflow/react';
 import type { EdgeProps } from '@xyflow/react';
+import { useTranslation } from 'react-i18next';
 
 export default function ButtonEdge({
   id,
@@ -15,6 +16,7 @@ export default function ButtonEdge({
   label,
   data
 }: EdgeProps) {
+  const { t } = useTranslation();
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -71,7 +73,7 @@ export default function ButtonEdge({
               padding: 0,
               fontWeight: 'bold',
             }}
-            title="Delete Connection"
+            title={t('common.deleteConnection')}
           >
             ✕
           </button>

--- a/frontend/src/pages/CanvasPage/components/CanvasModals.tsx
+++ b/frontend/src/pages/CanvasPage/components/CanvasModals.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import PostgresModal from '../../../features/nodes/PostgresNode/PostgresModal';
 import NoSqlModal from '../../../features/nodes/NoSqlNode/NoSqlModal';
 import RedisModal from '../../../features/nodes/RedisNode/RedisModal';
@@ -56,6 +57,7 @@ export default function CanvasModals({
   vpcSettings,
   trafficSimulator,
 }: CanvasModalsProps) {
+  const { t } = useTranslation();
   const renderVpcModal = (initialTab: 'info' | 'simulator', onClose: () => void) => (
     <VpcModal
       vpcConfig={networkConfig.vpcConfig}
@@ -68,7 +70,7 @@ export default function CanvasModals({
         const newConfig = { ...networkConfig, vpcConfig: config };
         saveNetworkConfig(newConfig);
         onClose();
-        showToast("VPC configuration saved");
+        showToast(t('toasts.vpcConfigSaved'));
         triggerArchitectureAudit(newConfig);
       }}
       initialTab={initialTab}
@@ -88,9 +90,9 @@ export default function CanvasModals({
 
       {deleteNode && (
         <ConfirmModal
-          title="Delete Container"
-          message="This will permanently stop and remove this container. This action cannot be undone."
-          confirmText="Delete"
+          title={t('common.deleteContainerTitle')}
+          message={t('common.deleteContainerMessage')}
+          confirmText={t('common.delete')}
           variant="danger"
           onConfirm={deleteNode.onConfirm}
           onCancel={deleteNode.onCancel}
@@ -99,13 +101,13 @@ export default function CanvasModals({
 
       {renameNode && (
         <InputModal
-          title="Rename Node"
-          label="Enter a new name for this node."
+          title={t('common.renameNodeTitle')}
+          label={t('common.renameNodeLabel')}
           placeholder="e.g. api-gateway"
           maxLength={20}
           restrictPattern={/[^a-zA-Z0-9-]/g}
           defaultValue={renameNode.currentName}
-          submitText="Rename"
+          submitText={t('common.rename')}
           onSubmit={renameNode.onSubmit}
           onCancel={renameNode.onCancel}
         />
@@ -171,7 +173,7 @@ export default function CanvasModals({
               loadBalancerRoutingRules: { ...(networkConfig.loadBalancerRoutingRules || {}), [inspector.id]: routingRules }
             };
             await saveNetworkConfig(newConfig);
-            showToast("Load Balancer configuration applied");
+            showToast(t('toasts.lbConfigApplied'));
             triggerArchitectureAudit(newConfig);
           }}
         />
@@ -191,7 +193,7 @@ export default function CanvasModals({
               asgs: { ...(networkConfig.asgs || {}), [inspector.id]: asgConfig }
             };
             await saveNetworkConfig(newConfig);
-            showToast("Auto Scaling Group configuration saved");
+            showToast(t('toasts.asgConfigSaved'));
             triggerArchitectureAudit(newConfig);
           }}
           onRefreshContainers={fetchContainers}

--- a/frontend/src/pages/CanvasPage/components/CanvasTopbar.tsx
+++ b/frontend/src/pages/CanvasPage/components/CanvasTopbar.tsx
@@ -51,7 +51,7 @@ export default function CanvasTopbar({
         <button
           onClick={toggleLanguage}
           style={{...styles.saveBtn, padding: '0 10px', minWidth: '40px'}}
-          title="Toggle Language"
+          title={t('topbar.toggleLanguage')}
         >
           {i18n.language.toUpperCase()}
         </button>

--- a/frontend/src/pages/CanvasPage/components/CreateNodeModal.tsx
+++ b/frontend/src/pages/CanvasPage/components/CreateNodeModal.tsx
@@ -1,15 +1,16 @@
+import { useTranslation } from 'react-i18next';
 import InputModal from '../../../shared/components/InputModal';
 import type { ContainerData } from '../../../shared/types';
 
-const COPY_BY_TYPE: Record<string, { title: string; placeholder: string; prefix: string }> = {
-  ubuntu: { title: 'Create Ubuntu Node', placeholder: 'e.g. server-1', prefix: 'srv-' },
-  postgres: { title: 'Create SQL Database Node', placeholder: 'e.g. sql-1', prefix: 'sql-' },
-  sql: { title: 'Create SQL Database Node', placeholder: 'e.g. sql-1', prefix: 'sql-' },
-  nosql: { title: 'Create NoSQL Database Node', placeholder: 'e.g. nosql-1', prefix: 'nosql-' },
-  redis: { title: 'Create Cache Store Node', placeholder: 'e.g. redis-1', prefix: 'redis-' },
-  nat: { title: 'Create NAT Gateway Node', placeholder: 'e.g. nat-1', prefix: 'nat-' },
-  loadbalancer: { title: 'Create Load Balancer Node', placeholder: 'e.g. alb-1', prefix: 'alb-' },
-  autoscalinggroup: { title: 'Create Auto Scaling Group Node', placeholder: 'e.g. asg-1', prefix: 'asg-' },
+const META_BY_TYPE: Record<string, { titleKey: string; placeholderKey: string; prefix: string }> = {
+  ubuntu: { titleKey: 'nodeLibrary.createNode.titles.ubuntu', placeholderKey: 'nodeLibrary.createNode.placeholders.ubuntu', prefix: 'srv-' },
+  postgres: { titleKey: 'nodeLibrary.createNode.titles.postgres', placeholderKey: 'nodeLibrary.createNode.placeholders.postgres', prefix: 'sql-' },
+  sql: { titleKey: 'nodeLibrary.createNode.titles.postgres', placeholderKey: 'nodeLibrary.createNode.placeholders.postgres', prefix: 'sql-' },
+  nosql: { titleKey: 'nodeLibrary.createNode.titles.nosql', placeholderKey: 'nodeLibrary.createNode.placeholders.nosql', prefix: 'nosql-' },
+  redis: { titleKey: 'nodeLibrary.createNode.titles.redis', placeholderKey: 'nodeLibrary.createNode.placeholders.redis', prefix: 'redis-' },
+  nat: { titleKey: 'nodeLibrary.createNode.titles.nat', placeholderKey: 'nodeLibrary.createNode.placeholders.nat', prefix: 'nat-' },
+  loadbalancer: { titleKey: 'nodeLibrary.createNode.titles.loadbalancer', placeholderKey: 'nodeLibrary.createNode.placeholders.loadbalancer', prefix: 'alb-' },
+  autoscalinggroup: { titleKey: 'nodeLibrary.createNode.titles.autoscalinggroup', placeholderKey: 'nodeLibrary.createNode.placeholders.autoscalinggroup', prefix: 'asg-' },
 };
 
 interface CreateNodeModalProps {
@@ -21,22 +22,23 @@ interface CreateNodeModalProps {
 
 /** Name prompt for a dropped node, pre-filled with the first free `<prefix><n>` name. */
 export default function CreateNodeModal({ type, containers, onSubmit, onCancel }: CreateNodeModalProps) {
-  const copy = COPY_BY_TYPE[type] ?? COPY_BY_TYPE.ubuntu;
+  const { t } = useTranslation();
+  const meta = META_BY_TYPE[type] ?? META_BY_TYPE.ubuntu;
 
   let suffix = 1;
-  while (containers.some(c => c.name === `${copy.prefix}${suffix}`)) {
+  while (containers.some(c => c.name === `${meta.prefix}${suffix}`)) {
     suffix++;
   }
 
   return (
     <InputModal
-      title={copy.title}
-      label="Give your new container a descriptive name."
-      placeholder={copy.placeholder}
+      title={t(meta.titleKey)}
+      label={t('nodeLibrary.createNode.label')}
+      placeholder={t(meta.placeholderKey)}
       maxLength={20}
       restrictPattern={/[^a-zA-Z0-9-]/g}
-      defaultValue={`${copy.prefix}${suffix}`}
-      submitText="Create Node"
+      defaultValue={`${meta.prefix}${suffix}`}
+      submitText={t('nodeLibrary.createNode.submit')}
       onSubmit={onSubmit}
       onCancel={onCancel}
     />

--- a/frontend/src/pages/CanvasPage/components/NodeLibrary.tsx
+++ b/frontend/src/pages/CanvasPage/components/NodeLibrary.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, Database, Library, Network, Search, GitFork, Braces, Layers, ArrowRightLeft, Cpu } from 'lucide-react';
 
 interface NodeLibraryProps {
@@ -6,6 +7,7 @@ interface NodeLibraryProps {
 }
 
 export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
+  const { t } = useTranslation();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -22,78 +24,78 @@ export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
 
   const categories = [
     {
-      title: 'Networking',
+      title: t('nodeLibrary.categories.networking'),
       nodes: [
         {
           type: 'subnet-public',
-          name: 'Public Subnet',
-          desc: 'Allows public access',
+          name: t('nodeLibrary.types.subnet-public.name'),
+          desc: t('nodeLibrary.types.subnet-public.desc'),
           icon: <Network size={18} color="#10B981" />,
           collapsedIcon: <Network size={20} color="#10B981" />
         },
         {
           type: 'subnet-private',
-          name: 'Private Subnet',
-          desc: 'Internal instances only',
+          name: t('nodeLibrary.types.subnet-private.name'),
+          desc: t('nodeLibrary.types.subnet-private.desc'),
           icon: <Network size={18} color="#F59E0B" />,
           collapsedIcon: <Network size={20} color="#F59E0B" />
         },
         {
           type: 'nat',
-          name: 'NAT Gateway',
-          desc: 'Outbound internet routing',
+          name: t('nodeLibrary.types.nat.name'),
+          desc: t('nodeLibrary.types.nat.desc'),
           icon: <ArrowRightLeft size={18} color="#8B5CF6" />,
           collapsedIcon: <ArrowRightLeft size={20} color="#8B5CF6" />
         },
         {
           type: 'loadbalancer',
-          name: 'Load Balancer',
-          desc: 'Inbound HTTP proxying',
+          name: t('nodeLibrary.types.loadbalancer.name'),
+          desc: t('nodeLibrary.types.loadbalancer.desc'),
           icon: <GitFork size={18} color="#EF4444" />,
           collapsedIcon: <GitFork size={20} color="#EF4444" />
         }
       ]
     },
     {
-      title: 'Compute',
+      title: t('nodeLibrary.categories.compute'),
       nodes: [
         {
           type: 'ubuntu',
-          name: 'Server',
-          desc: 'Standard terminal shell',
+          name: t('nodeLibrary.types.ubuntu.name'),
+          desc: t('nodeLibrary.types.ubuntu.desc'),
           icon: <Cpu size={18} color="#3B82F6" />,
           collapsedIcon: <Cpu size={20} color="#3B82F6" />
         },
         {
           type: 'autoscalinggroup',
-          name: 'Auto Scaling Group',
-          desc: 'Dynamic instance pool',
+          name: t('nodeLibrary.types.autoscalinggroup.name'),
+          desc: t('nodeLibrary.types.autoscalinggroup.desc'),
           icon: <Layers size={18} color="#EC4899" />,
           collapsedIcon: <Layers size={20} color="#EC4899" />
         }
       ]
     },
     {
-      title: 'Databases',
+      title: t('nodeLibrary.categories.databases'),
       nodes: [
         {
           type: 'postgres',
-          name: 'SQL Database',
-          desc: 'Relational DB + Shell',
+          name: t('nodeLibrary.types.postgres.name'),
+          desc: t('nodeLibrary.types.postgres.desc'),
           icon: <Database size={18} color="#64748B" />,
           collapsedIcon: <Database size={20} color="#64748B" />
         },
         {
           type: 'nosql',
-          name: 'NoSQL Database',
-          desc: 'Document DB + Shell',
+          name: t('nodeLibrary.types.nosql.name'),
+          desc: t('nodeLibrary.types.nosql.desc'),
           icon: <Braces size={18} color="#475569" />,
           collapsedIcon: <Braces size={20} color="#475569" />
         },
         {
           type: 'redis',
-          name: 'Cache Store',
-          desc: 'In-memory key-value cache',
+          name: t('nodeLibrary.types.redis.name'),
+          desc: t('nodeLibrary.types.redis.desc'),
           icon: <Database size={18} color="#DC2626" />,
           collapsedIcon: <Database size={20} color="#DC2626" />
         }
@@ -118,10 +120,10 @@ export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
         {!isCollapsed && (
           <div style={styles.headerTitle}>
             <Library size={16} color="var(--color-accent)" style={{ marginRight: 8 }} />
-            <span>Node Library</span>
+            <span>{t('nodeLibrary.title')}</span>
           </div>
         )}
-        <button onClick={toggleCollapse} style={styles.collapseBtn} title={isCollapsed ? "Expand Sidebar" : "Collapse Sidebar"}>
+        <button onClick={toggleCollapse} style={styles.collapseBtn} title={isCollapsed ? t('nodeLibrary.expand') : t('nodeLibrary.collapse')}>
           {isCollapsed ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
         </button>
       </div>
@@ -133,7 +135,7 @@ export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
               <Search size={14} color="var(--color-text-muted)" style={{ marginRight: 6 }} />
               <input
                 type="text"
-                placeholder="Search nodes..."
+                placeholder={t('nodeLibrary.search')}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 style={styles.searchInput}
@@ -164,7 +166,7 @@ export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
               </div>
             ))}
             {filteredCategories.length === 0 && (
-              <div style={styles.emptySearch}>No matching nodes found</div>
+              <div style={styles.emptySearch}>{t('nodeLibrary.noMatch')}</div>
             )}
           </div>
         </>
@@ -178,7 +180,7 @@ export default function NodeLibrary({ onCollapseChange }: NodeLibraryProps) {
               draggable
               onDragStart={(e) => handleDragStart(e, node.type)}
               style={styles.collapsedIconNode}
-              title={`Drag ${node.name}`}
+              title={t('nodeLibrary.dragNode', { name: node.name })}
             >
               {node.collapsedIcon}
             </div>

--- a/frontend/src/pages/CanvasPage/hooks/useCanvasDragDrop.ts
+++ b/frontend/src/pages/CanvasPage/hooks/useCanvasDragDrop.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { MutableRefObject, Dispatch, SetStateAction } from 'react';
 import type { Node, ReactFlowInstance } from '@xyflow/react';
 import type { ContainerData } from '../../../shared/types';
@@ -39,6 +40,7 @@ export function useCanvasDragDrop({
   fetchContainers,
   onRequestCreateNode,
 }: UseCanvasDragDropArgs) {
+  const { t } = useTranslation();
   const dragStartPositionsRef = useRef<Record<string, { x: number; y: number; parentId?: string }>>({});
   const draggingNodeIdRef = useRef<string | null>(null);
 
@@ -160,7 +162,7 @@ export function useCanvasDragDrop({
 
       // Check if dropped inside another subnet
       if (findSubnetAtPoint(subnetCenter, networkConfig.subnets, draggedNode.id)) {
-        revertNode({ type: 'error', text: 'Invalid placement: Subnets cannot be nested inside other subnets.' });
+        revertNode({ type: 'error', text: t('toasts.subnetNestingInvalid') });
         return;
       }
 
@@ -191,17 +193,17 @@ export function useCanvasDragDrop({
         const oldSubnet = networkConfig.subnets.find(s => s.id === oldParentId);
 
         if (oldParentId && oldParentId.startsWith('subnet-')) {
-          showNotification({ type: 'warning', message: `Node "${draggedNode.data.name}" removed from Subnet "${oldSubnet?.name || 'Subnet'}"` });
+          showNotification({ type: 'warning', message: t('toasts.nodeRemovedFromSubnet', { node: draggedNode.data.name, subnet: oldSubnet?.name || t('toasts.subnetFallback') }) });
         }
 
         if (newParentId && newParentId.startsWith('subnet-')) {
-          showNotification({ type: 'success', message: `Node "${draggedNode.data.name}" added to Subnet "${targetSubnet?.name || 'Subnet'}"` });
+          showNotification({ type: 'success', message: t('toasts.nodeAddedToSubnet', { node: draggedNode.data.name, subnet: targetSubnet?.name || t('toasts.subnetFallback') }) });
         }
       }
 
       if (!targetSubnet) {
         // Revert container node drag to its original subnet position
-        revertNode({ type: 'warning', text: 'Nodes must reside within a subnet.' });
+        revertNode({ type: 'warning', text: t('toasts.nodesMustResideInSubnet') });
         return;
       }
 
@@ -216,7 +218,7 @@ export function useCanvasDragDrop({
       saveNetworkConfig(newConfig);
       triggerArchitectureAudit(newConfig);
     }
-  }, [reactFlowInstance, networkConfig, projectId, positionsRef, saveNetworkConfig, setNodes, triggerArchitectureAudit, showNotification]);
+  }, [reactFlowInstance, networkConfig, projectId, positionsRef, saveNetworkConfig, setNodes, triggerArchitectureAudit, showNotification, t]);
 
   const onNodesDelete = useCallback((deleted: Node[]) => {
     const blockedNode = deleted.find(node => {
@@ -230,7 +232,7 @@ export function useCanvasDragDrop({
     if (blockedNode) {
       showNotification({
         type: 'error',
-        message: `Cannot delete node "${blockedNode.data?.name || 'Node'}": it is used as a template by an active Auto Scaling Group. Please stop the ASG first.`
+        message: t('toasts.asgTemplateDeleteBlocked', { name: blockedNode.data?.name || t('toasts.nodeFallback') })
       });
       fetchContainers();
       return;
@@ -265,7 +267,7 @@ export function useCanvasDragDrop({
         nodeIpMap: updatedNodeIpMap
       });
     }
-  }, [networkConfig, saveNetworkConfig, containers, fetchContainers, showNotification]);
+  }, [networkConfig, saveNetworkConfig, containers, fetchContainers, showNotification, t]);
 
   // React Flow Drag-and-Drop handlers
   const onDragOver = useCallback((event: React.DragEvent) => {
@@ -298,7 +300,7 @@ export function useCanvasDragDrop({
         // Check if dropped inside another subnet
         const subnetCenter = { x: position.x + newSubnet.width / 2, y: position.y + newSubnet.height / 2 };
         if (findSubnetAtPoint(subnetCenter, networkConfig.subnets)) {
-          showNotification({ type: 'error', message: 'Invalid placement: Subnets cannot be nested inside other subnets.' });
+          showNotification({ type: 'error', message: t('toasts.subnetNestingInvalid') });
           return;
         }
 
@@ -313,7 +315,7 @@ export function useCanvasDragDrop({
         const targetSubnet = findSubnetAtPoint(nodeCenter, networkConfig.subnets);
 
         if (!targetSubnet) {
-          showNotification({ type: 'error', message: 'Nodes must reside within a subnet.' });
+          showNotification({ type: 'error', message: t('toasts.nodesMustResideInSubnet') });
           return;
         }
 
@@ -326,7 +328,7 @@ export function useCanvasDragDrop({
         onRequestCreateNode({ position: finalDropPos, type, subnetId: targetSubnet.id });
       }
     },
-    [reactFlowInstance, networkConfig, saveNetworkConfig, showNotification, triggerArchitectureAudit, onRequestCreateNode]
+    [reactFlowInstance, networkConfig, saveNetworkConfig, showNotification, triggerArchitectureAudit, onRequestCreateNode, t]
   );
 
   return {

--- a/frontend/src/pages/CanvasPage/hooks/useNetworkConfig.ts
+++ b/frontend/src/pages/CanvasPage/hooks/useNetworkConfig.ts
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { ContainerData } from '../../../shared/types';
 import { API_BASE } from '../../../shared/types';
 import type { NetworkConfig } from '../../../shared/types/network';
@@ -17,6 +18,7 @@ interface UseNetworkConfigArgs {
  * config from the response) and the architecture audit toasts.
  */
 export function useNetworkConfig({ projectId, containers, showNotification }: UseNetworkConfigArgs) {
+  const { t } = useTranslation();
   const prevDbCountRef = useRef(0);
   const hasShownCacheWarningRef = useRef(false);
 
@@ -121,12 +123,12 @@ export function useNetworkConfig({ projectId, containers, showNotification }: Us
     prevDbCountRef.current = currentDbCount;
 
     let warnings = result.warnings;
-    const hasCacheWarning = warnings.some(w => w.includes('No caching tier'));
+    const hasCacheWarning = warnings.some(w => w.key === 'noCachingTier');
 
     if (hasCacheWarning) {
       if (hasShownCacheWarningRef.current) {
         // Filter it out so it doesn't toast again
-        warnings = warnings.filter(w => !w.includes('No caching tier'));
+        warnings = warnings.filter(w => w.key !== 'noCachingTier');
       } else {
         // Mark as shown so subsequent non-add actions don't trigger it
         hasShownCacheWarningRef.current = true;
@@ -137,14 +139,19 @@ export function useNetworkConfig({ projectId, containers, showNotification }: Us
       }
     }
 
+    // Resolve the finding's translation key against the active UI language here,
+    // at display time — the validator is language-neutral.
     if (result.errors.length > 0) {
-      showNotification({ type: 'error', message: result.errors[0] });
+      const m = result.errors[0];
+      showNotification({ type: 'error', message: t(`audit.${m.key}`, m.params) });
     } else if (warnings.length > 0) {
-      showNotification({ type: 'warning', message: warnings[0] });
+      const m = warnings[0];
+      showNotification({ type: 'warning', message: t(`audit.${m.key}`, m.params) });
     } else if (result.successes.length > 0) {
-      showNotification({ type: 'success', message: result.successes[0] });
+      const m = result.successes[0];
+      showNotification({ type: 'success', message: t(`audit.${m.key}`, m.params) });
     }
-  }, [containers, showNotification]);
+  }, [containers, showNotification, t]);
 
   return { networkConfig, saveNetworkConfig, fetchNetworkConfig, triggerArchitectureAudit };
 }

--- a/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -111,8 +111,8 @@ export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
         <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
           <button 
             onClick={toggleLanguage} 
-            style={{...styles.createBtn, background: 'var(--bg-surface-solid)', color: 'var(--color-text-primary)', border: '1px solid var(--border-color)', padding: '0 12px'}} 
-            title="Toggle Language"
+            style={{...styles.createBtn, background: 'var(--bg-surface-solid)', color: 'var(--color-text-primary)', border: '1px solid var(--border-color)', padding: '0 12px'}}
+            title={t('topbar.toggleLanguage')}
           >
             {i18n.language.toUpperCase()}
           </button>

--- a/frontend/src/pages/ProjectsPage/components/EmptyState.tsx
+++ b/frontend/src/pages/ProjectsPage/components/EmptyState.tsx
@@ -1,14 +1,16 @@
 import { Folder } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 export default function EmptyState() {
+  const { t } = useTranslation();
   return (
     <div style={styles.empty}>
       <div style={styles.emptyIcon}>
         <Folder size={40} color="var(--color-text-muted)" strokeWidth={1.2} />
       </div>
-      <p style={styles.emptyTitle}>No projects yet</p>
+      <p style={styles.emptyTitle}>{t('projects.emptyTitle')}</p>
       <p style={styles.emptyDesc}>
-        Click "New Project" to create your first infrastructure stack.
+        {t('projects.emptyDesc')}
       </p>
     </div>
   );

--- a/frontend/src/pages/ProjectsPage/components/ProjectCard.tsx
+++ b/frontend/src/pages/ProjectsPage/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import { Folder, Trash2, ArrowRight, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { Project } from '../../../shared/types';
 
 interface ProjectCardProps {
@@ -9,6 +10,7 @@ interface ProjectCardProps {
 }
 
 export default function ProjectCard({ project, onSelect, onDelete, isDeleting }: ProjectCardProps) {
+  const { t } = useTranslation();
   return (
     <div
       onClick={() => !isDeleting && onSelect(project.id, project.name)}
@@ -23,7 +25,7 @@ export default function ProjectCard({ project, onSelect, onDelete, isDeleting }:
       {isDeleting && (
         <div style={styles.loadingOverlay}>
           <Loader2 className="spin" size={24} color="var(--color-accent)" />
-          <span style={{ fontSize: '11px', marginTop: '6px', color: 'var(--color-text-secondary)', fontWeight: 600 }}>Deleting...</span>
+          <span style={{ fontSize: '11px', marginTop: '6px', color: 'var(--color-text-secondary)', fontWeight: 600 }}>{t('projects.deleting')}</span>
         </div>
       )}
       <div style={styles.cardHeader}>
@@ -33,7 +35,7 @@ export default function ProjectCard({ project, onSelect, onDelete, isDeleting }:
         <button
           onClick={(e) => !isDeleting && onDelete(project, e)}
           style={styles.deleteBtn}
-          title="Delete project"
+          title={t('projects.deleteProjectTooltip')}
           id={`delete-project-${project.id}`}
           disabled={isDeleting}
         >
@@ -51,7 +53,7 @@ export default function ProjectCard({ project, onSelect, onDelete, isDeleting }:
         </p>
       </div>
       <div style={styles.cardFooter}>
-        <span>Open Stack</span>
+        <span>{t('projects.openStack')}</span>
         <ArrowRight size={14} style={{ marginLeft: 6 }} />
       </div>
     </div>

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom/vitest';
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
+// Initialize the i18next singleton once for every test. Components render through
+// react-i18next's `t()`, so without this they would render raw keys. Language
+// defaults to 'en' (empty localStorage), matching the English strings assertions expect.
+import './i18n';
 
 // Testing Library's automatic cleanup relies on a global afterEach, which is
 // absent when Vitest runs without `globals: true` — register it explicitly.

--- a/frontend/src/shared/components/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Modal from './Modal';
 import { AlertTriangle, Loader2 } from 'lucide-react';
 
@@ -14,11 +15,12 @@ interface ConfirmModalProps {
 export default function ConfirmModal({
   title,
   message,
-  confirmText = 'Confirm',
+  confirmText,
   variant = 'default',
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
+  const { t } = useTranslation();
   const [isDeleting, setIsDeleting] = useState(false);
   const isDanger = variant === 'danger';
 
@@ -47,7 +49,7 @@ export default function ConfirmModal({
       <h3 style={styles.title}>{title}</h3>
       <p style={styles.message}>{message}</p>
       <div style={styles.actions}>
-        <button onClick={onCancel} style={styles.cancelBtn} disabled={isDeleting}>Cancel</button>
+        <button onClick={onCancel} style={styles.cancelBtn} disabled={isDeleting}>{t('common.cancel')}</button>
         <button onClick={handleConfirm} disabled={isDeleting} style={{
           ...styles.confirmBtn,
           background: isDanger ? 'var(--color-danger)' : 'var(--color-accent)',
@@ -61,9 +63,9 @@ export default function ConfirmModal({
           {isDeleting ? (
             <>
               <Loader2 size={14} className="spin" />
-              Deleting...
+              {t('common.deleting')}
             </>
-          ) : confirmText}
+          ) : (confirmText ?? t('common.confirm'))}
         </button>
       </div>
     </Modal>

--- a/frontend/src/shared/components/DockerUnavailableBanner.tsx
+++ b/frontend/src/shared/components/DockerUnavailableBanner.tsx
@@ -1,15 +1,17 @@
 import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Persistent (non-dismissable) banner shown while the Docker daemon is
  * unreachable. It disappears on its own once container polling succeeds again.
  */
 export function DockerUnavailableBanner() {
+  const { t } = useTranslation();
   return (
     <div style={bannerStyles.wrapper}>
       <div style={bannerStyles.banner}>
         <AlertTriangle size={16} color="#F59E0B" style={{ flexShrink: 0 }} />
-        <span>Docker daemon unreachable — start Docker and the lab will reconnect automatically.</span>
+        <span>{t('common.dockerUnavailable')}</span>
       </div>
     </div>
   );

--- a/frontend/src/shared/components/InputModal.tsx
+++ b/frontend/src/shared/components/InputModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Modal from './Modal';
 import { Loader2 } from 'lucide-react';
 
@@ -19,12 +20,13 @@ export default function InputModal({
   label,
   placeholder = '',
   defaultValue = '',
-  submitText = 'Create',
+  submitText,
   maxLength,
   restrictPattern,
   onSubmit,
   onCancel,
 }: InputModalProps) {
+  const { t } = useTranslation();
   const [value, setValue] = useState(defaultValue);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -53,7 +55,7 @@ export default function InputModal({
       try {
         await onSubmit(value.trim());
       } catch (err: any) {
-        setError(err.message || 'An error occurred');
+        setError(err.message || t('common.genericError'));
       } finally {
         setIsSubmitting(false);
       }
@@ -86,7 +88,7 @@ export default function InputModal({
         )}
         <div style={styles.actions}>
           <button type="button" onClick={onCancel} style={styles.cancelBtn} disabled={isSubmitting}>
-            Cancel
+            {t('common.cancel')}
           </button>
           <button type="submit" disabled={!value.trim() || isSubmitting} style={{
             ...styles.submitBtn,
@@ -99,9 +101,9 @@ export default function InputModal({
             {isSubmitting ? (
               <>
                 <Loader2 size={14} className="spin" />
-                Creating...
+                {t('common.creating')}
               </>
-            ) : submitText}
+            ) : (submitText ?? t('common.create'))}
           </button>
         </div>
       </form>

--- a/frontend/src/shared/hooks/useContainers.ts
+++ b/frontend/src/shared/hooks/useContainers.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { API_BASE } from '../types';
 import type { ContainerData } from '../types';
 import type { NotificationData } from './useToast';
@@ -14,6 +15,7 @@ interface UseContainersOptions {
  * against the backend API, scoped to a specific project.
  */
 export function useContainers({ projectId, onNotify }: UseContainersOptions) {
+  const { t } = useTranslation();
   const [containers, setContainers] = useState<ContainerData[]>([]);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -72,19 +74,19 @@ export function useContainers({ projectId, onNotify }: UseContainersOptions) {
         body: JSON.stringify({ name, type, subnetId }),
       });
       if (res.ok) {
-        onNotify?.({ type: 'success', message: `Node "${name}" created successfully` });
+        onNotify?.({ type: 'success', message: t('toasts.nodeCreated', { name }) });
         fetchContainers();
       } else {
-        const message = await readErrorMessage(res, `Failed to create node "${name}"`);
+        const message = await readErrorMessage(res, t('toasts.nodeCreateFailed', { name }));
         onNotify?.({ type: 'error', message });
       }
     } catch (err) {
       console.error(err);
-      onNotify?.({ type: 'error', message: 'Error creating container node' });
+      onNotify?.({ type: 'error', message: t('toasts.nodeCreateError') });
     } finally {
       setCreating(false);
     }
-  }, [baseUrl, fetchContainers, onNotify]);
+  }, [baseUrl, fetchContainers, onNotify, t]);
 
   const startContainer = useCallback(async (id: string) => {
     try {
@@ -93,15 +95,15 @@ export function useContainers({ projectId, onNotify }: UseContainersOptions) {
         clearOpError(id);
         fetchContainers();
       } else {
-        const message = await readErrorMessage(res, 'Failed to start the container');
+        const message = await readErrorMessage(res, t('toasts.containerStartFailed'));
         setOpError(id, message);
         onNotify?.({ type: 'error', message });
       }
     } catch (err) {
       console.error(err);
-      onNotify?.({ type: 'error', message: 'Could not reach the server to start the container' });
+      onNotify?.({ type: 'error', message: t('toasts.containerStartUnreachable') });
     }
-  }, [baseUrl, fetchContainers, onNotify, setOpError, clearOpError]);
+  }, [baseUrl, fetchContainers, onNotify, setOpError, clearOpError, t]);
 
   const stopContainer = useCallback(async (id: string) => {
     try {
@@ -110,15 +112,15 @@ export function useContainers({ projectId, onNotify }: UseContainersOptions) {
         clearOpError(id);
         fetchContainers();
       } else {
-        const message = await readErrorMessage(res, 'Failed to stop the container');
+        const message = await readErrorMessage(res, t('toasts.containerStopFailed'));
         setOpError(id, message);
         onNotify?.({ type: 'error', message });
       }
     } catch (err) {
       console.error(err);
-      onNotify?.({ type: 'error', message: 'Could not reach the server to stop the container' });
+      onNotify?.({ type: 'error', message: t('toasts.containerStopUnreachable') });
     }
-  }, [baseUrl, fetchContainers, onNotify, setOpError, clearOpError]);
+  }, [baseUrl, fetchContainers, onNotify, setOpError, clearOpError, t]);
 
   const deleteContainer = useCallback(async (id: string) => {
     try {
@@ -126,19 +128,19 @@ export function useContainers({ projectId, onNotify }: UseContainersOptions) {
       if (res.ok) {
         setContainers(prev => prev.filter(c => c.id !== id));
         clearOpError(id);
-        onNotify?.({ type: 'success', message: 'Container deleted' });
+        onNotify?.({ type: 'success', message: t('toasts.containerDeleted') });
         fetchContainers();
         return true;
       }
-      const message = await readErrorMessage(res, 'Failed to delete the container');
+      const message = await readErrorMessage(res, t('toasts.containerDeleteFailed'));
       setOpError(id, message);
       onNotify?.({ type: 'error', message });
     } catch (err) {
       console.error(err);
-      onNotify?.({ type: 'error', message: 'Could not reach the server to delete the container' });
+      onNotify?.({ type: 'error', message: t('toasts.containerDeleteUnreachable') });
     }
     return false;
-  }, [baseUrl, fetchContainers, onNotify, setOpError, clearOpError]);
+  }, [baseUrl, fetchContainers, onNotify, setOpError, clearOpError, t]);
 
   return {
     containers,

--- a/frontend/src/shared/hooks/useToast.test.ts
+++ b/frontend/src/shared/hooks/useToast.test.ts
@@ -43,35 +43,21 @@ describe('useToast', () => {
   });
 
   it.each([
-    ['Save failed', 'error'],
-    ['An error occurred', 'error'],
-    ['Invalid configuration', 'error'],
-    ['Cannot delete node', 'error'],
-  ])('showToast classifies "%s" as %s', (message, expectedType) => {
+    ['error'],
+    ['warning'],
+    ['success'],
+  ] as const)('showToast honours the explicit "%s" type', (type) => {
     const { result } = renderHook(() => useToast());
     act(() => {
-      result.current.showToast(message);
+      result.current.showToast('Une notification', type);
     });
-    expect(result.current.toast?.type).toBe(expectedType);
+    expect(result.current.toast).toEqual({ type, message: 'Une notification' });
   });
 
-  it.each([
-    ['This is a warning', 'warning'],
-    ['Database is exposed publicly', 'warning'],
-    ['Security risk detected', 'warning'],
-    ['Alert: check your config', 'warning'],
-  ])('showToast classifies "%s" as %s', (message, expectedType) => {
+  it('showToast defaults to success when no type is given', () => {
     const { result } = renderHook(() => useToast());
     act(() => {
-      result.current.showToast(message);
-    });
-    expect(result.current.toast?.type).toBe(expectedType);
-  });
-
-  it('showToast defaults to success when no error/warning keywords match', () => {
-    const { result } = renderHook(() => useToast());
-    act(() => {
-      result.current.showToast('Node created successfully');
+      result.current.showToast('Nœud créé avec succès');
     });
     expect(result.current.toast?.type).toBe('success');
   });

--- a/frontend/src/shared/hooks/useToast.ts
+++ b/frontend/src/shared/hooks/useToast.ts
@@ -14,18 +14,19 @@ export function useToast() {
     return () => clearTimeout(timer);
   }, []);
 
-  const showToast = useCallback((message: string, duration = 4000) => {
-    let type: 'error' | 'warning' | 'success' = 'success';
-    const lower = message.toLowerCase();
-    if (lower.includes('failed') || lower.includes('error') || lower.includes('invalid') || lower.includes('cannot')) {
-      type = 'error';
-    } else if (lower.includes('warning') || lower.includes('expose') || lower.includes('risk') || lower.includes('alert')) {
-      type = 'warning';
-    }
-    setToast({ type, message });
-    const timer = setTimeout(() => setToast(null), duration);
-    return () => clearTimeout(timer);
-  }, []);
+  // A convenience wrapper for the common case: a positive confirmation toast.
+  // The severity is passed explicitly (default 'success') rather than inferred
+  // from the message text — the old keyword sniffing broke the moment messages
+  // were translated (a French "échec" is not "failed"). Callers that need a
+  // different severity pass it, or use showNotification directly.
+  const showToast = useCallback(
+    (message: string, type: 'error' | 'warning' | 'success' = 'success', duration = 4000) => {
+      setToast({ type, message });
+      const timer = setTimeout(() => setToast(null), duration);
+      return () => clearTimeout(timer);
+    },
+    []
+  );
 
   const dismissToast = useCallback(() => setToast(null), []);
 

--- a/frontend/src/shared/utils/architectureValidator.test.ts
+++ b/frontend/src/shared/utils/architectureValidator.test.ts
@@ -23,7 +23,7 @@ describe('validateArchitecture', () => {
 
     const result = validateArchitecture(config, [node]);
 
-    expect(result.errors).toContain('Node "App Server" is assigned to a subnet that does not exist.');
+    expect(result.errors).toContainEqual({ key: 'nodeMissingSubnet', params: { name: 'App Server' } });
   });
 
   it('does not error when a node maps to a vpc- prefixed id (not a subnet)', () => {
@@ -44,7 +44,7 @@ describe('validateArchitecture', () => {
 
     const result = validateArchitecture(config, [db]);
 
-    expect(result.warnings).toContain('Data store "Primary DB" is in a public subnet. For safety, data store instances should be kept in private subnets.');
+    expect(result.warnings).toContainEqual({ key: 'dataStorePublicSubnet', params: { name: 'Primary DB' } });
   });
 
   it('does not warn about public subnet placement for non-sensitive node types', () => {
@@ -69,7 +69,7 @@ describe('validateArchitecture', () => {
 
     const result = validateArchitecture(config, [db]);
 
-    expect(result.warnings).toContain('Data store "Cache" is exposed to the public internet (0.0.0.0/0) in its security group.');
+    expect(result.warnings).toContainEqual({ key: 'dataStorePublicExposure', params: { name: 'Cache' } });
   });
 
   it('does not warn about public exposure when the matching rule is outbound', () => {
@@ -90,7 +90,7 @@ describe('validateArchitecture', () => {
 
     const result = validateArchitecture(baseConfig(), [db]);
 
-    expect(result.warnings).toContain('No caching tier (e.g., Redis or Memcached) detected. Consider adding one to optimize database loads.');
+    expect(result.warnings).toContainEqual({ key: 'noCachingTier' });
   });
 
   it('does not warn about a missing caching tier when a redis node is present', () => {
@@ -99,7 +99,7 @@ describe('validateArchitecture', () => {
 
     const result = validateArchitecture(baseConfig(), [db, cache]);
 
-    expect(result.warnings).not.toContain('No caching tier (e.g., Redis or Memcached) detected. Consider adding one to optimize database loads.');
+    expect(result.warnings).not.toContainEqual({ key: 'noCachingTier' });
   });
 
   it('does not warn about a missing caching tier when there is no database at all', () => {
@@ -123,9 +123,10 @@ describe('validateArchitecture', () => {
 
     const result = validateArchitecture(config, [gateway, db]);
 
-    expect(result.warnings).toContain(
-      'Database "Primary DB" receives direct connections from public-facing node "api-gateway". Traffic should go through a backend application layer.'
-    );
+    expect(result.warnings).toContainEqual({
+      key: 'directPublicToDb',
+      params: { db: 'Primary DB', src: 'api-gateway' },
+    });
   });
 
   it('reports a secure 3-tier success when frontend -> backend -> db flow is properly isolated', () => {
@@ -146,9 +147,7 @@ describe('validateArchitecture', () => {
 
     const result = validateArchitecture(config, [frontend, backend, db]);
 
-    expect(result.successes).toContain(
-      'Secure 3-Tier VPC Architecture detected! (Public Gateway -> Private App Server -> Private Isolated Database)'
-    );
+    expect(result.successes).toContainEqual({ key: 'secure3Tier' });
   });
 
   it('produces the generic success message when a valid multi-node config has no errors or warnings', () => {
@@ -159,7 +158,7 @@ describe('validateArchitecture', () => {
 
     expect(result.errors).toEqual([]);
     expect(result.warnings).toEqual([]);
-    expect(result.successes).toContain('VPC Network is fully valid and adheres to basic system design security guidelines!');
+    expect(result.successes).toContainEqual({ key: 'vpcValid' });
   });
 
   it('produces no successes for an empty container list', () => {

--- a/frontend/src/shared/utils/architectureValidator.ts
+++ b/frontend/src/shared/utils/architectureValidator.ts
@@ -4,19 +4,30 @@ import type { NetworkConfig as FullNetworkConfig } from '../types/network';
 /** The validator only reads the topology-related slice of the network config. */
 export type NetworkConfig = Pick<FullNetworkConfig, 'subnets' | 'nodeSubnetMap' | 'nodeSecurityGroups'>;
 
+/**
+ * A validation finding as a translation key plus its interpolation params,
+ * NOT a rendered string. The UI language is unknown here (this is a pure util),
+ * so the caller resolves `audit.<key>` against i18next at display time. `key`
+ * is also a stable identity the caller can dedupe on (e.g. the cache warning).
+ */
+export interface ValidationMessage {
+  key: string;
+  params?: Record<string, string | number>;
+}
+
 export interface ValidationResult {
-  errors: string[];
-  warnings: string[];
-  successes: string[];
+  errors: ValidationMessage[];
+  warnings: ValidationMessage[];
+  successes: ValidationMessage[];
 }
 
 export function validateArchitecture(
   networkConfig: NetworkConfig,
   containers: ContainerData[]
 ): ValidationResult {
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  const successes: string[] = [];
+  const errors: ValidationMessage[] = [];
+  const warnings: ValidationMessage[] = [];
+  const successes: ValidationMessage[] = [];
 
   const dbTypes = ['postgres', 'sql', 'nosql', 'mysql'];
   // Data stores that should be kept private and never exposed publicly. Redis is a
@@ -31,7 +42,7 @@ export function validateArchitecture(
     if (subnetId && !subnetId.startsWith('vpc-')) {
       const subnet = networkConfig.subnets.find(s => s.id === subnetId);
       if (!subnet) {
-        errors.push(`Node "${node.name}" is assigned to a subnet that does not exist.`);
+        errors.push({ key: 'nodeMissingSubnet', params: { name: node.name } });
       }
     }
   });
@@ -46,7 +57,7 @@ export function validateArchitecture(
       if (subnetId) {
         const subnet = networkConfig.subnets.find(s => s.id === subnetId);
         if (subnet && subnet.type === 'public') {
-          warnings.push(`Data store "${node.name}" is in a public subnet. For safety, data store instances should be kept in private subnets.`);
+          warnings.push({ key: 'dataStorePublicSubnet', params: { name: node.name } });
         }
       }
     }
@@ -61,7 +72,7 @@ export function validateArchitecture(
         rule => rule.type === 'inbound' && rule.action === 'ALLOW' && rule.source === '0.0.0.0/0'
       );
       if (hasPublicAccess) {
-        warnings.push(`Data store "${node.name}" is exposed to the public internet (0.0.0.0/0) in its security group.`);
+        warnings.push({ key: 'dataStorePublicExposure', params: { name: node.name } });
       }
     }
   });
@@ -75,7 +86,7 @@ export function validateArchitecture(
     // Only warn if there's at least one DB
     const hasDb = containers.some(c => dbTypes.includes(c.type || ''));
     if (hasDb) {
-      warnings.push('No caching tier (e.g., Redis or Memcached) detected. Consider adding one to optimize database loads.');
+      warnings.push({ key: 'noCachingTier' });
     }
   }
 
@@ -100,7 +111,7 @@ export function validateArchitecture(
           const srcSubnetId = networkConfig.nodeSubnetMap[srcNode.id];
           const srcSubnet = networkConfig.subnets.find(s => s.id === srcSubnetId);
           if (isPublicFacingNode(srcNode, srcSubnet?.type)) {
-            warnings.push(`Database "${dbNode.name}" receives direct connections from public-facing node "${srcNode.name}". Traffic should go through a backend application layer.`);
+            warnings.push({ key: 'directPublicToDb', params: { db: dbNode.name, src: srcNode.name } });
           }
         }
       }
@@ -154,14 +165,14 @@ export function validateArchitecture(
       );
 
       if (!directFromFrontendToDb) {
-        successes.push('Secure 3-Tier VPC Architecture detected! (Public Gateway -> Private App Server -> Private Isolated Database)');
+        successes.push({ key: 'secure3Tier' });
       }
     }
   }
 
   // Default success if everything is healthy and configured in subnets/VPCs
   if (errors.length === 0 && warnings.length === 0 && containers.length >= 2) {
-    successes.push('VPC Network is fully valid and adheres to basic system design security guidelines!');
+    successes.push({ key: 'vpcValid' });
   }
 
   return { errors, warnings, successes };


### PR DESCRIPTION
## Summary of Changes

Closes the remaining gaps in the app's EN/FR translation coverage. New i18n namespaces (`toasts`, `audit`, `nodeviz`, `nodeshared`) plus extended `common`/`projects`/`topbar` cover every user-facing string across the canvas node components, toast notifications, the architecture validator, and the projects page. The roadmap catalogue now filters entries by the active UI language instead of showing a language badge (a roadmap with no variant in the current language is hidden).

Two related design changes fell out of this:
- `architectureValidator.ts` now returns `{key, params?}` translation descriptors instead of raw English strings; the display site resolves them against `audit.*` at render time.
- `useToast.showToast` takes an explicit `type` parameter instead of sniffing severity from English keywords in the message (which broke under translation).

## Types of Changes

- [ ] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [x] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

tsc -b: 0 errors. eslint: 0 errors (6 pre-existing warnings, unrelated to this change). vitest: 220/220 passing across 19 files.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [ ] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing