### PR TITLE
feat(learning): add the workers and redis job queue roadmap

### DIFF
--- a/roadmaps/redis-queue-workers.fr.json
+++ b/roadmaps/redis-queue-workers.fr.json
@@ -1,0 +1,277 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Derssa/Torollo/main/backend/src/modules/learning/format/roadmap.schema.json",
+  "schemaVersion": 1,
+  "id": "redis-queue-workers",
+  "title": "Workers & file d'attente Redis",
+  "description": "Nimbus Books prospère — et le checkout se fige désormais deux longues secondes le temps de générer chaque reçu. Découvre le motif derrière tous les backends chargés : accepter vite, travailler plus tard. Pousse les commandes dans une vraie file Redis, embauche un worker pour la consommer, regarde une vente flash empiler un backlog, transforme les workers en flotte auto-réparante — et mets en dead-letter la commande corrompue qui aurait bloqué la chaîne.",
+  "language": "fr",
+  "estimatedMinutes": 40,
+  "difficulty": "intermediate",
+  "prerequisites": [
+    "Docker installé et en marche",
+    "Un projet Torollo créé et ouvert sur le canvas (pars d'un projet vide)",
+    "À l'aise avec les commandes de base dans un terminal Linux",
+    "Avoir joué « Déployer une application trois-tiers résiliente » ou « Cache-aside avec Redis » aide, mais cette histoire se suffit à elle-même"
+  ],
+  "steps": [
+    {
+      "id": "reopen-the-store",
+      "title": "Rouvrir la boutique",
+      "instruction": "Bon retour chez **Nimbus Books**. Le lancement a tenu, le catalogue est rapide — mais la plainte du soir vient de l'*autre* bout de la boutique : le **checkout**. Chaque commande confirmée doit produire un reçu — totaux, taxes, un PDF pour le client — et pour l'instant, le client fixe un spinner pendant que tout ça se fabrique. Le marketing, lui, vient de programmer une **vente flash** pour vendredi. Garde ces deux faits en tête.\n\nNouveau lab, canvas vierge, même boutique.\n\n1. Depuis la bibliothèque de nœuds, glisse un **Public Subnet** sur le canvas. Cinq machines finiront par y vivre — agrandis-le à environ **3 colonnes × 2 lignes** avec les **steppers C / R** de l'en-tête du subnet.\n2. Glisse un nœud **Server** *dans* le subnet (les nœuds ne peuvent vivre que dans un subnet), nomme-le `web`, et crée-le.\n3. La machine démarre dès sa création — attends que son point de statut passe au vert.",
+      "hints": [
+        "La bibliothèque de nœuds est le panneau latéral à côté du canvas. Glisse d'abord **Public Subnet** sur un espace vide — si tu déposes un Server hors d'un subnet, Torollo refuse avec « Nodes must reside within a subnet. »",
+        "Dépose la tuile **Server** sur une cellule libre du subnet. Un dialogue demande un nom : tape exactement `web` (les vérifications de cette roadmap retrouvent tes machines par leur nom). Il démarre tout seul après création ; si tu l'arrêtes un jour, le bouton play le ramène."
+      ],
+      "solution": "Glisse **Public Subnet** sur le canvas et agrandis-le à environ 3 × 2 avec les steppers C / R. Glisse **Server** dans une de ses cellules, nomme-le `web` dans le dialogue de création, clique **Create Node**, et attends que le point de statut du nœud passe au vert.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "web"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-slow-checkout",
+      "title": "Le checkout à deux secondes",
+      "instruction": "L'heure de ressentir ce que ressentent les clients. Ouvre le **Terminal** de `web` et construis le checkout tel qu'il existe aujourd'hui.\n\n1. Installe Python :\n\n```bash\napt-get update && apt-get install -y python3\n```\n\n2. Écris l'application. Un détail honnête avant de coller : quand une commande arrive, ce code génère le reçu *dans la requête* — totaux, taxes, le PDF — environ **2 secondes de travail** (simulées par un sleep), pendant que le client attend :\n\n```bash\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport time\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            time.sleep(2)  # the receipt engine: totals, taxes, the PDF\n            elapsed = int((time.monotonic() - started) * 1000)\n            html = (f'<p>Thank you for your order! Your receipt is ready.</p>'\n                    f'<p><i>checkout blocked for {elapsed} ms</i></p>'\n                    f'<p><a href=\"/\">Back to the desk</a></p>')\n        else:\n            html = ('<h2>Fulfillment desk</h2>'\n                    '<p>Orders are confirmed once their receipt is generated.</p>'\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\n```\n\n3. Fais démarrer le serveur à chaque boot de la machine, puis lance-le maintenant :\n\n```bash\necho '(python3 /root/server.py >/dev/null 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```\n\n4. Ouvre la porte de la boutique : sur `web`, ajoute une règle entrante **ALLOW TCP 80** depuis **Anywhere (0.0.0.0/0)**, et clique le lien `http://localhost:...` qui apparaît sous cette instruction.\n5. Maintenant, *passe une commande de test*. Puis une autre. **Deux secondes pleines, à chaque fois** — et le serveur intégré de Python traite une requête à la fois : pendant qu'un client paie, le suivant ne charge même pas la page. Multiplie par la vente flash de vendredi. (Les vérifications ci-dessous passent chacune une commande — elles le ressentent aussi.)",
+      "hints": [
+        "Clique le bouton **Terminal** sur le nœud `web` et colle les commandes bloc par bloc (le bloc `cat << 'EOF' ... EOF` se colle en une fois, lignes EOF comprises).",
+        "Pas de lien `http://localhost:...` sous l'instruction ? Ajoute la règle entrante **ALLOW TCP 80** depuis **Anywhere (0.0.0.0/0)** sur `web` (icône bouclier) — sans elle, le pare-feu garde la boutique fermée.",
+        "La page ne charge pas du tout ? Vérifie que le serveur tourne : `nohup python3 /root/server.py >/dev/null 2>&1 &` dans le terminal de `web`, puis rafraîchis."
+      ],
+      "solution": "Dans le terminal de `web`, colle ce bloc entier :\n\n```bash\napt-get update && apt-get install -y python3\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport time\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            time.sleep(2)  # the receipt engine: totals, taxes, the PDF\n            elapsed = int((time.monotonic() - started) * 1000)\n            html = (f'<p>Thank you for your order! Your receipt is ready.</p>'\n                    f'<p><i>checkout blocked for {elapsed} ms</i></p>'\n                    f'<p><a href=\"/\">Back to the desk</a></p>')\n        else:\n            html = ('<h2>Fulfillment desk</h2>'\n                    '<p>Orders are confirmed once their receipt is generated.</p>'\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\necho '(python3 /root/server.py >/dev/null 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```\n\nPuis sur le security group de `web` (icône bouclier) : Direction **Inbound**, Action **ALLOW**, Protocole **TCP**, Port **80**, Source **Anywhere (0.0.0.0/0)** → **Add Rule**.",
+      "validators": [
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/",
+            "expectedText": "Nimbus Books"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/order",
+            "expectedText": "Thank you"
+          }
+        }
+      ]
+    },
+    {
+      "id": "enter-the-queue",
+      "title": "Place à la file",
+      "instruction": "La solution n'est pas un moteur de reçus plus rapide. La solution, c'est de réaliser que le client n'a pas besoin de *regarder* : il lui faut une promesse — « commande prise, reçu en route » — et quelqu'un en arrière-boutique pour la tenir. C'est ça, le **travail asynchrone**, et la pièce d'infrastructure entre la promesse et sa tenue s'appelle une **file d'attente**.\n\nUne **liste** Redis est la file de départ classique : le checkout poussera commande après commande à un bout, et les workers tireront de l'autre. Premier arrivé, premier servi — comme la file d'une vraie boutique.\n\n1. Glisse un nœud **Redis** dans le subnet et nomme-le `queue` — il démarre à la création.\n2. Moindre privilège, dès le premier jour : seul le checkout a une raison de lui parler pour l'instant. Sur `queue`, ajoute une règle entrante **ALLOW TCP 6379** avec Source **`web`** (6379 est le port de Redis ; choisis le nœud dans le menu Source, *pas* Anywhere).\n3. **Inspect** sur `queue`, puis onglet **Explorer**. Torollo sème quelques clés de démo — remarque `queue:emails`, de type *list* : quelqu'un ici utilise déjà Redis exactement comme ça. La nôtre sera **`queue:orders`** ; le préfixe garde un Redis partagé lisible.",
+      "hints": [
+        "Dépose la tuile **Redis** sur une cellule libre du subnet et nomme-la exactement `queue`. Pas de cellule libre ? Agrandis le subnet avec les steppers C / R de son en-tête.",
+        "La règle 6379 va sur le security group de **`queue`** (icône bouclier sur le nœud queue) : Direction **Inbound**, Action **ALLOW**, Protocole **TCP**, Port **6379**, Source **web** (dans le groupe Nodes du menu) → **Add Rule**.",
+        "Une fois la règle ajoutée, une arête verte apparaît de `web` vers `queue` — l'écho visuel de ta règle, et exactement ce que cherche la deuxième vérification."
+      ],
+      "solution": "Dépose un nœud **Redis** nommé `queue` dans le subnet. Sur son security group (icône bouclier) : Direction **Inbound**, Action **ALLOW**, Protocole **TCP**, Port **6379**, Source **web** → **Add Rule**.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "queue"
+          }
+        },
+        {
+          "type": "edge_exists",
+          "params": {
+            "source": "web",
+            "target": "queue",
+            "port": 6379
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-producer",
+      "title": "Le producteur",
+      "instruction": "Réécris le checkout en **producteur** : au lieu de faire le travail, il *enregistre que le travail existe* — un `LPUSH` sur `queue:orders` — et répond immédiatement. La page d'accueil devient ton pupitre d'opérations, qui lit ses compteurs en direct dans Redis.\n\nDans le **Terminal** de `web` :\n\n1. Installe le client Redis :\n\n```bash\napt-get install -y python3-redis\n```\n\n2. Réécris l'application :\n\n```bash\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport json, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=1)\n\nCATALOG = ['The Pragmatic Programmer', 'Clean Code',\n           'Designing Data-Intensive Applications', 'Release It!']\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            try:\n                n = r.incr('stats:orders')\n                job = {'id': f'or-{n}', 'title': CATALOG[n % len(CATALOG)]}\n                r.lpush('queue:orders', json.dumps(job))\n                elapsed = int((time.monotonic() - started) * 1000)\n                html = (f'<p>Thank you for your order! Order <b>{job[\"id\"]}</b> '\n                        f'accepted in {elapsed} ms &mdash; your receipt is on its way.</p>'\n                        f'<p><a href=\"/\">Back to the desk</a></p>')\n            except Exception as e:\n                html = f'<p>We could not reach our queue: {str(e)}</p>'\n        else:\n            try:\n                stats = (f'<p>orders accepted: {r.get(\"stats:orders\") or 0}</p>'\n                         f'<p>backlog: {r.llen(\"queue:orders\")}</p>'\n                         f'<p>receipts issued: {r.get(\"stats:receipts\") or 0}</p>'\n                         f'<p>dead-lettered: {r.llen(\"queue:orders:dead\")}</p>')\n            except Exception as e:\n                stats = f'<p>We could not reach our queue: {str(e)}</p>'\n            html = ('<h2>Fulfillment desk</h2>' + stats +\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\n```\n\n3. Remplace le serveur en marche :\n\n```bash\npkill -f server.py\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```\n\n4. Passe une commande : **acceptée en quelques millisecondes.** Le checkout à deux secondes a disparu. Passes-en deux ou trois de plus, puis regarde le pupitre : `orders accepted` grimpe... et `backlog` aussi, pendant que `receipts issued` reste à **0**.\n\nSois honnête sur ce qui vient de se passer : tu n'as pas fait disparaître le travail — **tu as fait une promesse que personne ne tient encore.** Chaque commande « acceptée » est un reçu que tu dois toujours. Ouvre l'**Explorer** de `queue` : la voilà, `queue:orders`, une *liste* qui contient chaque promesse non tenue. (Deux compteurs du pupitre — `receipts issued` et `dead-lettered` — mériteront leur nom avant la fin.)\n\nUne dernière chose, parce que tu te souviens peut-être de la règle d'or de l'histoire du cache : contrairement à un cache, cette file n'est **pas** une optimisation qu'on peut hausser des épaules. Elle contient désormais les commandes de tes clients. Le pupitre survit à une file morte (le `try/except` le garde en vie), mais le checkout cesse d'accepter — une file est une dépendance que tu as *choisie*, deux secondes de latence échangées contre la machinerie que tu vas construire.",
+      "hints": [
+        "Colle les blocs un par un dans le terminal de `web`. Seul `python3-redis` est nouveau — Python est déjà là depuis l'étape précédente.",
+        "L'ancienne page s'affiche encore, ou « Address already in use » ? L'ancien serveur tient toujours le port 80 : lance `pkill -f server.py`, puis à nouveau la ligne `nohup python3 /root/server.py >/dev/null 2>&1 &`.",
+        "« We could not reach our queue » ? Vérifie l'étape précédente : le nœud doit s'appeler exactement `queue`, tourner, et porter la règle entrante **ALLOW TCP 6379** avec Source **web**.",
+        "La première vérification passe une commande via ton nouveau code — si elle reste rouge, le serveur qui tourne est probablement encore l'ancienne version (tue-le et relance-le)."
+      ],
+      "solution": "Dans le terminal de `web`, colle ce bloc entier :\n\n```bash\napt-get install -y python3-redis\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport json, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=1)\n\nCATALOG = ['The Pragmatic Programmer', 'Clean Code',\n           'Designing Data-Intensive Applications', 'Release It!']\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            try:\n                n = r.incr('stats:orders')\n                job = {'id': f'or-{n}', 'title': CATALOG[n % len(CATALOG)]}\n                r.lpush('queue:orders', json.dumps(job))\n                elapsed = int((time.monotonic() - started) * 1000)\n                html = (f'<p>Thank you for your order! Order <b>{job[\"id\"]}</b> '\n                        f'accepted in {elapsed} ms &mdash; your receipt is on its way.</p>'\n                        f'<p><a href=\"/\">Back to the desk</a></p>')\n            except Exception as e:\n                html = f'<p>We could not reach our queue: {str(e)}</p>'\n        else:\n            try:\n                stats = (f'<p>orders accepted: {r.get(\"stats:orders\") or 0}</p>'\n                         f'<p>backlog: {r.llen(\"queue:orders\")}</p>'\n                         f'<p>receipts issued: {r.get(\"stats:receipts\") or 0}</p>'\n                         f'<p>dead-lettered: {r.llen(\"queue:orders:dead\")}</p>')\n            except Exception as e:\n                stats = f'<p>We could not reach our queue: {str(e)}</p>'\n            html = ('<h2>Fulfillment desk</h2>' + stats +\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\npkill -f server.py\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```",
+      "validators": [
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/order",
+            "expectedText": "accepted"
+          }
+        },
+        {
+          "type": "redis_key_exists",
+          "params": {
+            "node": "queue",
+            "key": "stats:orders"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-first-worker",
+      "title": "Le premier worker",
+      "instruction": "L'arrière-boutique embauche son premier employé. Un **worker** est le programme le plus simple des systèmes distribués : une boucle infinie — *prendre un job, faire le travail, le marquer fait, recommencer.* Pas de serveur web, pas de routes ; juste la boucle.\n\n1. Glisse un second **Server** dans le subnet et nomme-le `worker-1`.\n2. Ouvre-lui la porte de la file : sur `queue`, ajoute une deuxième règle entrante — **ALLOW TCP 6379**, Source **`worker-1`**. Deux machines, deux règles précises.\n3. Dans le **Terminal** de `worker-1`, installe le nécessaire et écris la boucle :\n\n```bash\napt-get update && apt-get install -y python3 python3-redis\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n        if item is None:\n            continue  # queue empty — go right back to listening\n        job = json.loads(item[1])\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        with open('/root/receipts.log', 'a') as f:\n            f.write(f'{job[\"id\"]}: receipt for \"{job[\"title\"]}\"\\n')\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} done', flush=True)\n    except Exception as e:\n        print(f'[{WORKER}] error: {e}', flush=True)\n        time.sleep(1)\nEOF\n```\n\nLis la boucle avant de la lancer — deux détails contiennent tout le marché :\n- **`BRPOP` bloque.** Le worker ne tourne pas en boucle à vide ; il dort *dans Redis* jusqu'à l'arrivée d'un job, puis se réveille instantanément. Le producteur `LPUSH` à gauche, le worker `BRPOP` à droite : premier arrivé, premier servi.\n- **Le moteur de reçus a déménagé ici.** Le même coût d'une seconde par reçu qu'avant — il n'est pas devenu moins cher, il est *sorti du chemin du client*.\n\n4. Fais-le démarrer au boot — une ligne, et tout futur *clone* de cette machine se réveillera déjà au travail (souviens-t'en vendredi) — puis lance-le et regarde-le vivre :\n\n```bash\necho '(python3 /root/worker.py >> /root/worker.log 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\ntail -f /root/worker.log\n```\n\nEn quelques secondes, le backlog de l'étape précédente se vide, un `done` par seconde (`Ctrl+C` quitte le tail ; le worker continue). Regarde le pupitre : `backlog: 0`, et `receipts issued` compte enfin. `cat /root/receipts.log` — chaque promesse, tenue.",
+      "hints": [
+        "Deux choses avant le code : le nœud doit s'appeler exactement `worker-1`, et le security group de **`queue`** a besoin de la nouvelle règle entrante **ALLOW TCP 6379** avec Source **worker-1** — sans elle, le `BRPOP` du worker n'atteint pas Redis et le log se remplit d'erreurs.",
+        "Colle le bloc `cat << 'EOF' ... EOF` en une seule fois, puis le bloc boot/démarrage. Le worker écrit sa vie dans `/root/worker.log` — `tail -f` dessus dès que quelque chose semble coincé.",
+        "Le backlog ne bouge pas ? `tail -20 /root/worker.log` : des erreurs de connexion signifient que la règle 6379 manque ou que le nœud ne s'appelle pas `worker-1` ; aucune sortie du tout signifie que le worker ne tourne pas — relance-le avec la ligne `nohup`.",
+        "La dernière vérification veut voir `backlog: 0` sur le pupitre — laisse au worker quelques secondes pour finir de vider avant de valider."
+      ],
+      "solution": "Crée un **Server** nommé `worker-1` dans le subnet. Sur le security group de `queue` : Direction **Inbound**, Action **ALLOW**, Protocole **TCP**, Port **6379**, Source **worker-1** → **Add Rule**. Puis dans le terminal de `worker-1`, colle :\n\n```bash\napt-get update && apt-get install -y python3 python3-redis\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n        if item is None:\n            continue  # queue empty — go right back to listening\n        job = json.loads(item[1])\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        with open('/root/receipts.log', 'a') as f:\n            f.write(f'{job[\"id\"]}: receipt for \"{job[\"title\"]}\"\\n')\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} done', flush=True)\n    except Exception as e:\n        print(f'[{WORKER}] error: {e}', flush=True)\n        time.sleep(1)\nEOF\necho '(python3 /root/worker.py >> /root/worker.log 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\n```\n\nAttends que le pupitre affiche `backlog: 0`, puis valide.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "worker-1"
+          }
+        },
+        {
+          "type": "edge_exists",
+          "params": {
+            "source": "worker-1",
+            "target": "queue",
+            "port": 6379
+          }
+        },
+        {
+          "type": "redis_key_exists",
+          "params": {
+            "node": "queue",
+            "key": "stats:receipts"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/",
+            "expectedText": "backlog: 0"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-receipt-archive",
+      "title": "L'archive des reçus",
+      "instruction": "L'audit appelle : *« Envoyez-nous le reçu de la commande or-3. »* Il est dans `/root/receipts.log`... sur le disque local de `worker-1`. Passable aujourd'hui. Mais tu es sur le point d'embaucher d'autres workers, et alors chaque reçu vivrait sur la machine qui a attrapé la commande — éparpillés sur des disques privés qui **meurent avec leur machine**. La règle qui corrige ça vaut une réponse d'entretien à elle seule : **les workers restent stateless ; tout ce qui mérite d'être gardé va dans un magasin partagé.** Des reçus, ça se range dans les livres de comptes de l'entreprise — c'est un travail pour **PostgreSQL**.\n\n1. Glisse un nœud **SQL Database** (PostgreSQL) dans le subnet et nomme-le `archive` — il démarre à la création.\n2. Sur `archive`, ajoute une règle entrante **ALLOW TCP 5432** avec Source **`worker-1`** (5432 est le port de PostgreSQL).\n3. Dans le **Terminal** de `worker-1`, installe le driver PostgreSQL et réécris la boucle :\n\n```bash\napt-get install -y python3-psycopg2\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport psycopg2\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nMAX_ATTEMPTS = 3\n\ndef archive_receipt(job):\n    conn = psycopg2.connect(host='archive', database='postgres', user='postgres',\n                            password='postgres', connect_timeout=2)\n    cur = conn.cursor()\n    cur.execute('CREATE TABLE IF NOT EXISTS receipts '\n                '(id SERIAL PRIMARY KEY, order_id TEXT, title TEXT, worker TEXT, status TEXT)')\n    cur.execute('INSERT INTO receipts (order_id, title, worker, status) VALUES (%s, %s, %s, %s)',\n                (job['id'], job['title'], WORKER, 'issued'))\n    conn.commit()\n    cur.close(); conn.close()\n\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n    except Exception as e:\n        print(f'[{WORKER}] queue unreachable: {e}', flush=True)\n        time.sleep(1)\n        continue\n    if item is None:\n        continue  # queue empty — go right back to listening\n    raw = item[1]\n    try:\n        job = json.loads(raw)\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        archive_receipt(job)\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} archived', flush=True)\n    except Exception as e:\n        # One bad order must never kill the worker or jam the line.\n        # Count its attempts in Redis (shared with every other worker),\n        # give it MAX_ATTEMPTS tries, then park it in the dead-letter queue.\n        attempts = r.incr('attempts:' + raw[:64])\n        if attempts < MAX_ATTEMPTS:\n            print(f'[{WORKER}] job failed ({e}) — retry {attempts}/{MAX_ATTEMPTS}', flush=True)\n            time.sleep(1)\n            r.lpush('queue:orders', raw)\n        else:\n            print(f'[{WORKER}] job dead-lettered after {attempts} attempts: {raw[:60]}', flush=True)\n            r.rpush('queue:orders:dead', raw)\nEOF\npkill -f worker.py\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\n```\n\nLis la nouvelle branche `except` avant de continuer : un job qui échoue *retourne dans la file* avec un compteur de tentatives, et après trois prises il est garé dans `queue:orders:dead` au lieu d'être réessayé pour toujours — ou pire, silencieusement abandonné. Ça a l'air paranoïaque aujourd'hui. Ça gagnera sa place avant la fin de cette histoire.\n\n4. Passe une commande sur le pupitre, regarde `archived` apparaître dans `tail -5 /root/worker.log`, puis **Inspect** sur `archive` → onglet **Database Explorer** : voilà ta table `receipts` (parmi quelques tables de démo comme `users` et `products` que Torollo sème — ignore-les). Ouvre-la et regarde la colonne `worker` : elle nomme la machine qui a fait le travail. *Souviens-toi de cette colonne.*\n\n5. La dernière vérification ci-dessous pense déjà plus loin : elle s'assure que `web` ne peut **pas** atteindre l'archive. Le comptoir écrit des promesses dans la file ; seuls les workers écrivent des reçus. Si cette vérification échoue, une règle sur `archive` est plus large que Source `worker-1` — resserre-la.",
+      "hints": [
+        "La règle 5432 va sur le security group de **`archive`** : Direction **Inbound**, Action **ALLOW**, Protocole **TCP**, Port **5432**, Source **worker-1** (dans le groupe Nodes) → **Add Rule**.",
+        "La réécriture est un seul collage `cat << 'EOF' ... EOF`, puis `pkill -f worker.py` et la ligne `nohup` — la même danse de redémarrage que pour le producteur. `tail -5 /root/worker.log` doit t'accueillir avec `ready, waiting for orders...`.",
+        "Pas de table `receipts` dans le Database Explorer ? Elle apparaît avec la *première commande archivée* : passes-en une sur le pupitre, attends une seconde ou deux, puis utilise l'icône de rafraîchissement dans l'en-tête du modal. Si le log montre `retry 1/3` à la place, le worker n'atteint pas PostgreSQL — vérifie la règle 5432 et que le nœud s'appelle exactement `archive`.",
+        "Dernière vérification rouge ? Ouvre le security group d'`archive` : sa seule règle entrante doit avoir Source **worker-1** — pas Anywhere (0.0.0.0/0), et pas `web`."
+      ],
+      "solution": "Dépose un nœud **SQL Database** nommé `archive` dans le subnet. Sur son security group : Direction **Inbound**, Action **ALLOW**, Protocole **TCP**, Port **5432**, Source **worker-1** → **Add Rule**. Dans le terminal de `worker-1`, colle ce bloc entier :\n\n```bash\napt-get install -y python3-psycopg2\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport psycopg2\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nMAX_ATTEMPTS = 3\n\ndef archive_receipt(job):\n    conn = psycopg2.connect(host='archive', database='postgres', user='postgres',\n                            password='postgres', connect_timeout=2)\n    cur = conn.cursor()\n    cur.execute('CREATE TABLE IF NOT EXISTS receipts '\n                '(id SERIAL PRIMARY KEY, order_id TEXT, title TEXT, worker TEXT, status TEXT)')\n    cur.execute('INSERT INTO receipts (order_id, title, worker, status) VALUES (%s, %s, %s, %s)',\n                (job['id'], job['title'], WORKER, 'issued'))\n    conn.commit()\n    cur.close(); conn.close()\n\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n    except Exception as e:\n        print(f'[{WORKER}] queue unreachable: {e}', flush=True)\n        time.sleep(1)\n        continue\n    if item is None:\n        continue  # queue empty — go right back to listening\n    raw = item[1]\n    try:\n        job = json.loads(raw)\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        archive_receipt(job)\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} archived', flush=True)\n    except Exception as e:\n        # One bad order must never kill the worker or jam the line.\n        # Count its attempts in Redis (shared with every other worker),\n        # give it MAX_ATTEMPTS tries, then park it in the dead-letter queue.\n        attempts = r.incr('attempts:' + raw[:64])\n        if attempts < MAX_ATTEMPTS:\n            print(f'[{WORKER}] job failed ({e}) — retry {attempts}/{MAX_ATTEMPTS}', flush=True)\n            time.sleep(1)\n            r.lpush('queue:orders', raw)\n        else:\n            print(f'[{WORKER}] job dead-lettered after {attempts} attempts: {raw[:60]}', flush=True)\n            r.rpush('queue:orders:dead', raw)\nEOF\npkill -f worker.py\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\n```\n\nPasse une commande sur le pupitre et valide une fois `archived` visible dans le log du worker.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "archive"
+          }
+        },
+        {
+          "type": "edge_exists",
+          "params": {
+            "source": "worker-1",
+            "target": "archive",
+            "port": 5432
+          }
+        },
+        {
+          "type": "table_exists",
+          "params": {
+            "node": "archive",
+            "table": "receipts"
+          }
+        },
+        {
+          "type": "port_denied",
+          "params": {
+            "source": "web",
+            "target": "archive",
+            "port": 5432
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-flash-sale",
+      "title": "La vente flash",
+      "instruction": "Vendredi, 18 h. Le marketing appuie sur le bouton. Simule la ruée toi-même — dans le **Terminal** de `web`, passe **300 commandes** :\n\n```bash\nfor i in $(seq 1 300); do curl -s localhost/order > /dev/null; done\n```\n\nChacune acceptée en quelques millisecondes — le checkout n'a pas cillé. C'est la machine à promesses qui fait son travail. Maintenant regarde la *tenue* : rafraîchis le pupitre. `backlog: 280`... `279`... qui tombe d'**exactement un par seconde**, parce que c'est ton débit : un worker, un reçu par seconde. Tu regardes la **backpressure** — l'admission est instantanée, le traitement non, et la file est l'endroit où la différence s'empile. À ce rythme, le reçu du dernier client arrive dans environ cinq minutes.\n\n**Appuie sur Validate tout de suite et lis les échecs** — pas de flotte de workers, un backlog à trois chiffres. La file a absorbé le pic, donc rien n'a cassé ; absorber n'est pas suivre.\n\nRépare comme un opérateur : quand la file est longue, on ne sermonne pas le caissier pour qu'il accélère — **on ouvre d'autres caisses.** Les workers sont volontairement stateless et identiques, ce qui en fait la chose la plus facile à multiplier de toute ton architecture :\n\n1. Glisse un **Auto Scaling Group** dans le subnet et nomme-le `worker-asg`.\n2. **Les portes d'abord, la flotte ensuite** — les clones doivent être productifs dès leur premier souffle. Sur `queue`, ajoute une règle entrante **ALLOW TCP 6379** avec Source **`worker-asg`** ; sur `archive`, une règle entrante **ALLOW TCP 5432** avec Source **`worker-asg`**. Chaque règle couvre *tous* les replicas du groupe, maintenant et après chaque auto-réparation.\n3. Clique **Inspect** sur `worker-asg`. Dans *Design & Scaling settings* : Template Server **`worker-1`**, coche ton subnet comme cible de déploiement, capacité Min **1** / Desired **3** / Max **6** → **Save & Deploy**. Torollo prend un instantané de `worker-1` — Python, `/root/worker.py`, et la ligne de boot que tu as gravée — et démarre trois clones qui se réveillent déjà en train de consommer.\n4. Rafraîchis le pupitre et regarde le backlog **fondre quatre fois plus vite** — quatre consommateurs sur une file, aucune coordination, aucun reçu en double : Redis remet à chaque `BRPOP` exactement un job, et cette passe atomique est tout le contrat. Pour la preuve, ouvre le **SQL Shell** d'`archive` et lance `SELECT worker, COUNT(*) FROM receipts GROUP BY worker;` : **quatre hostnames différents**, chacun avec sa part d'une même file de travail.\n\nQuand le pupitre affiche `backlog: 0`, valide à nouveau — mêmes vérifications, vendredi très différent.",
+      "hints": [
+        "Ajoute les deux règles `worker-asg` **avant** Save & Deploy : les replicas démarrent en quelques secondes et appellent la file immédiatement — déploie d'abord et le log de la jeune flotte se remplit d'erreurs de connexion jusqu'à l'ouverture des portes.",
+        "Dans le modal ASG : *1. Launch Template Source* → `worker-1` ; *2. VPC Subnet Targets* → coche ton subnet ; *3. Instance Capacity Limits* → Min 1, Desired 3, Max 6 → **Save & Deploy**. Le déploiement prend un moment — Torollo committe le disque de `worker-1` en image dorée avant de démarrer les clones.",
+        "Backlog figé alors que la grille montre des replicas sains ? Les clones n'atteignent pas Redis : vérifie que la règle entrante **ALLOW TCP 6379** sur `queue` a bien Source **worker-asg** (le groupe lui-même, pas un replica). Même logique pour **5432** sur `archive` — sans elle, chaque clone réessaie trois fois et met en dead-letter de vraies commandes.",
+        "La première vérification compte les **replicas en marche** : elle en veut exactement 3, alors laisse l'onglet *Simulation & Live Grid* se poser sur trois clones *Healthy*. Et `worker-1` doit rester en marche — c'est le template et le quatrième consommateur."
+      ],
+      "solution": "Dans le terminal de `web` : `for i in $(seq 1 300); do curl -s localhost/order > /dev/null; done`, puis appuie sur **Validate** et lis l'échec. Ajoute les deux règles de flotte — sur `queue` : entrante **ALLOW TCP 6379**, Source **worker-asg** ; sur `archive` : entrante **ALLOW TCP 5432**, Source **worker-asg**. Glisse un **Auto Scaling Group** nommé `worker-asg` dans le subnet, **Inspect** → Template **worker-1**, coche le subnet, Min **1** / Desired **3** / Max **6** → **Save & Deploy**. Attends que le pupitre affiche `backlog: 0` et valide.",
+      "validators": [
+        {
+          "type": "asg_replicas",
+          "params": {
+            "node": "worker-asg",
+            "count": 3
+          }
+        },
+        {
+          "type": "container_running",
+          "params": {
+            "node": "worker-1"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/",
+            "expectedText": "backlog: 0"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-poison-order",
+      "title": "La commande empoisonnée",
+      "instruction": "Lundi matin. L'intégration d'un partenaire a poussé cette nuit sur ta file quelque chose qui n'aurait jamais dû être envoyé. Toute file finit par en recevoir un — l'industrie appelle ça un **message empoisonné** (*poison message*). Injecte-le toi-même : **Inspect** sur `queue` → onglet **Shell**, et lance :\n\n```\nLPUSH queue:orders corrupted-order-from-partner-api\n```\n\nCe n'est pas du JSON. En quelques secondes, un de tes quatre workers l'attrape, échoue à le parser, et la machinerie construite il y a deux étapes se réveille. Regarde le pupitre : le backlog reste proche de zéro, `dead-lettered` passe à **1**. Rien ne s'est bloqué.\n\nMaintenant lis la trace écrite dans l'**Explorer** de `queue` (icône de rafraîchissement) :\n- `attempts:corrupted-order-from-partner-api` — valeur **3** : trois essais, honnêtement comptés. Le compteur vit *dans Redis*, pas dans la mémoire d'un worker, parce que chaque nouvelle tentative peut être attrapée par un worker **différent** — un décompte privé repartirait de zéro à chaque saut. Le travail partagé exige un état partagé ; tu as déjà appris cette règle avec les reçus.\n- `queue:orders:dead` — une *liste* qui garde le corps, intact, prêt à être inspecté ou rejoué quand le partenaire aura corrigé son bug. Une dead-letter queue est une **boîte de réception, pas une poubelle**.\n\nÇa vaut la peine de s'arrêter sur ce qui n'est *pas* arrivé. Un worker naïf échoue d'une de ces deux façons : il **crashe et bloque la chaîne** — avec une flotte, le poison tue les quatre, un par un — ou il **avale l'erreur et laisse tomber le job** : un reçu promis, jamais émis, aucune trace. Le tien n'a fait ni l'un ni l'autre : il a échoué *bruyamment, trois fois, dans une file que tu peux lire*.\n\nPasse une dernière commande normale sur le pupitre — acceptée, archivée, la routine. Une commande pourrie, et la boutique n'a pas cillé.\n\n**C'est ça, le motif.** Regarde ton canvas : un checkout qui répond en millisecondes quoi que vendredi apporte, une vraie file qui tient les promesses, une flotte stateless qui s'agrandit en glissant un curseur, des reçus dans une archive partagée qui nomment le worker qui les a faits, et une dead-letter queue pour les messages qui mentent. La prochaine fois qu'un interviewer demande *« comment gères-tu une opération lente sur le chemin de la requête ? »* — tu n'as pas seulement lu la réponse : tu as regardé un backlog se vider à un job par seconde, ouvert d'autres caisses, et enterré un message empoisonné avec les honneurs. Si tu ne les as pas encore jouées, les deux autres histoires de Nimbus Books — le lancement résilient et le cache Redis — complètent le tableau.",
+      "hints": [
+        "L'onglet Shell exécute une commande par Execute. Colle exactement `LPUSH queue:orders corrupted-order-from-partner-api` — la valeur ne doit *pas* être du JSON valide, c'est tout l'intérêt.",
+        "`dead-lettered` encore à 0 après ~10 secondes ? Les réessais marquent une pause d'une seconde entre tentatives, le voyage complet prend donc quelques secondes. Toujours rien : lance `LLEN queue:orders:dead` et `KEYS attempts:*` dans le Shell — si les deux sont vides, vérifie que la flotte exécute bien le code worker de l'étape 6 (la logique de retry) et que ton LPUSH a bien visé `queue:orders`.",
+        "Ne t'étonne pas si `tail /root/worker.log` sur `worker-1` ne mentionne jamais le poison — n'importe lequel des quatre workers a pu attraper chaque tentative. Les compteurs Redis sont la vérité partagée ; les logs par machine ne racontent que la version de chaque worker.",
+        "La seconde vérification passe une vraie commande par le checkout — si elle échoue, ton producteur ou ta flotte a un problème plus gros qu'un message empoisonné : vérifie le pupitre à la main."
+      ],
+      "solution": "Dans le **Shell** de `queue` : `LPUSH queue:orders corrupted-order-from-partner-api`. Attends quelques secondes, rafraîchis le pupitre jusqu'à `dead-lettered: 1`, et regarde `attempts:corrupted-order-from-partner-api` (valeur 3) et `queue:orders:dead` dans l'Explorer. Passe une commande normale sur le pupitre, puis valide.",
+      "validators": [
+        {
+          "type": "redis_key_exists",
+          "params": {
+            "node": "queue",
+            "key": "queue:orders:dead"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/order",
+            "expectedText": "accepted"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/roadmaps/redis-queue-workers.json
+++ b/roadmaps/redis-queue-workers.json
@@ -1,0 +1,277 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Derssa/Torollo/main/backend/src/modules/learning/format/roadmap.schema.json",
+  "schemaVersion": 1,
+  "id": "redis-queue-workers",
+  "title": "Workers & the Redis job queue",
+  "description": "Nimbus Books is thriving — and checkout now freezes for two full seconds while each receipt is generated. Meet the pattern behind every busy backend: accept fast, work later. Push orders onto a real Redis queue, hire a worker to consume it, watch a flash sale pile up a backlog, scale the workers into a self-healing fleet — and dead-letter the one corrupted order that would have jammed the line.",
+  "language": "en",
+  "estimatedMinutes": 40,
+  "difficulty": "intermediate",
+  "prerequisites": [
+    "Docker installed and running",
+    "A Torollo project created and open on the canvas (start from an empty one)",
+    "Comfortable running basic commands in a Linux terminal",
+    "Having played \"Deploy a resilient three-tier app\" or \"Cache-aside with Redis\" helps, but this story stands on its own"
+  ],
+  "steps": [
+    {
+      "id": "reopen-the-store",
+      "title": "Reopen the store",
+      "instruction": "Welcome back to **Nimbus Books**. The launch held, the catalog is fast — but tonight's complaint comes from the *other* end of the shop: **checkout**. Every confirmed order must produce a receipt — totals, taxes, a PDF for the customer — and right now the customer stares at a spinner while all of it happens. Marketing, meanwhile, has just scheduled a **flash sale** for Friday. Keep both facts in mind.\n\nNew lab, fresh canvas, same store.\n\n1. From the node library, drag a **Public Subnet** onto the canvas. Five machines will end up living here — grow it to about **3 columns × 2 rows** with the **C / R steppers** on the subnet header.\n2. Drag a **Server** node *into* the subnet (nodes can only live inside a subnet), name it `web`, and create it.\n3. The machine boots as soon as it is created — wait for its status dot to turn green.",
+      "hints": [
+        "The node library is the sidebar panel next to the canvas. Drag **Public Subnet** onto an empty spot first — if you drop a Server outside a subnet, Torollo refuses with \"Nodes must reside within a subnet.\"",
+        "Drop the **Server** tile onto one of the subnet's free cells. A dialog asks for a name: type exactly `web` (the checks in this roadmap find your machines by name). It starts on its own after creation; if you ever stop it, the play button brings it back."
+      ],
+      "solution": "Drag **Public Subnet** onto the canvas and grow it to about 3 × 2 with the C / R steppers. Drag **Server** into one of its cells, name it `web` in the creation dialog, click **Create Node**, and wait for the node's status dot to turn green.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "web"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-slow-checkout",
+      "title": "The two-second checkout",
+      "instruction": "Time to feel what customers feel. Open the **Terminal** of `web` and build the checkout as it exists today.\n\n1. Install Python:\n\n```bash\napt-get update && apt-get install -y python3\n```\n\n2. Write the app. One honest detail before you paste: when an order comes in, this code generates the receipt *inside the request* — totals, taxes, the PDF — about **2 seconds of work** (simulated with a sleep), while the customer waits:\n\n```bash\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport time\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            time.sleep(2)  # the receipt engine: totals, taxes, the PDF\n            elapsed = int((time.monotonic() - started) * 1000)\n            html = (f'<p>Thank you for your order! Your receipt is ready.</p>'\n                    f'<p><i>checkout blocked for {elapsed} ms</i></p>'\n                    f'<p><a href=\"/\">Back to the desk</a></p>')\n        else:\n            html = ('<h2>Fulfillment desk</h2>'\n                    '<p>Orders are confirmed once their receipt is generated.</p>'\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\n```\n\n3. Make the server start whenever this machine boots, then start it now:\n\n```bash\necho '(python3 /root/server.py >/dev/null 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```\n\n4. Open the shop's door: on `web`, add an inbound **ALLOW TCP 80** rule from **Anywhere (0.0.0.0/0)**, and click the `http://localhost:...` link that appears below this instruction.\n5. Now *place a test order*. And another. **Two full seconds, every single time** — and Python's built-in server handles one request at a time, so while one customer checks out, the next one isn't even loading the page. Multiply by Friday's flash sale. (The checks below place an order each — they feel it too.)",
+      "hints": [
+        "Click the **Terminal** button on the `web` node and paste the commands one block at a time (the `cat << 'EOF' ... EOF` block is a single paste, including the EOF lines).",
+        "No `http://localhost:...` link under the instruction? Add the inbound **ALLOW TCP 80** from **Anywhere (0.0.0.0/0)** rule on `web` (shield icon) — without it the firewall keeps the shop closed.",
+        "Page not loading at all? Make sure the server is running: `nohup python3 /root/server.py >/dev/null 2>&1 &` in `web`'s terminal, then refresh."
+      ],
+      "solution": "In `web`'s terminal, paste this whole block:\n\n```bash\napt-get update && apt-get install -y python3\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport time\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            time.sleep(2)  # the receipt engine: totals, taxes, the PDF\n            elapsed = int((time.monotonic() - started) * 1000)\n            html = (f'<p>Thank you for your order! Your receipt is ready.</p>'\n                    f'<p><i>checkout blocked for {elapsed} ms</i></p>'\n                    f'<p><a href=\"/\">Back to the desk</a></p>')\n        else:\n            html = ('<h2>Fulfillment desk</h2>'\n                    '<p>Orders are confirmed once their receipt is generated.</p>'\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\necho '(python3 /root/server.py >/dev/null 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```\n\nThen on `web`'s security group (shield icon): Direction **Inbound**, Action **ALLOW**, Protocol **TCP**, Port **80**, Source **Anywhere (0.0.0.0/0)** → **Add Rule**.",
+      "validators": [
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/",
+            "expectedText": "Nimbus Books"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/order",
+            "expectedText": "Thank you"
+          }
+        }
+      ]
+    },
+    {
+      "id": "enter-the-queue",
+      "title": "Enter the queue",
+      "instruction": "The fix is not a faster receipt engine. The fix is realizing the customer doesn't need to *watch*: they need a promise — \"order taken, receipt on its way\" — and someone in the back room to keep it. That is **asynchronous work**, and the piece of infrastructure between the promise and the keeping is a **queue**.\n\nA Redis **list** is the classic starter queue: the checkout will push order after order onto one end, and workers will pull from the other. First in, first out — like the line at a real store.\n\n1. Drag a **Redis** node into the subnet and name it `queue` — it starts on creation.\n2. Least privilege, day one: only the checkout has any business talking to it for now. On `queue`, add an inbound rule **ALLOW TCP 6379** with Source **`web`** (6379 is Redis's port; pick the node in the Source dropdown, *not* Anywhere).\n3. **Inspect** `queue` and open the **Explorer** tab. Torollo seeds a few demo keys — notice `queue:emails`, type *list*: someone here already uses Redis exactly this way. Ours will be **`queue:orders`**; the prefix keeps a shared Redis readable.",
+      "hints": [
+        "Drop the **Redis** tile onto a free cell of the subnet and name it exactly `queue`. No free cell? Grow the subnet with the C / R steppers on its header.",
+        "The 6379 rule goes on **`queue`**'s security group (shield icon on the queue node): Direction **Inbound**, Action **ALLOW**, Protocol **TCP**, Port **6379**, Source **web** (from the Nodes group of the dropdown) → **Add Rule**.",
+        "After the rule is added, a green edge appears from `web` to `queue` — the visual echo of your rule, and exactly what the second check looks for."
+      ],
+      "solution": "Drop a **Redis** node named `queue` into the subnet. On its security group (shield icon): Direction **Inbound**, Action **ALLOW**, Protocol **TCP**, Port **6379**, Source **web** → **Add Rule**.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "queue"
+          }
+        },
+        {
+          "type": "edge_exists",
+          "params": {
+            "source": "web",
+            "target": "queue",
+            "port": 6379
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-producer",
+      "title": "The producer",
+      "instruction": "Rewrite the checkout as a **producer**: instead of doing the work, it *records that the work exists* — one `LPUSH` onto `queue:orders` — and answers immediately. The front page becomes your operations desk, reading live counters straight out of Redis.\n\nIn `web`'s **Terminal**:\n\n1. Install the Redis client:\n\n```bash\napt-get install -y python3-redis\n```\n\n2. Rewrite the app:\n\n```bash\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport json, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=1)\n\nCATALOG = ['The Pragmatic Programmer', 'Clean Code',\n           'Designing Data-Intensive Applications', 'Release It!']\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            try:\n                n = r.incr('stats:orders')\n                job = {'id': f'or-{n}', 'title': CATALOG[n % len(CATALOG)]}\n                r.lpush('queue:orders', json.dumps(job))\n                elapsed = int((time.monotonic() - started) * 1000)\n                html = (f'<p>Thank you for your order! Order <b>{job[\"id\"]}</b> '\n                        f'accepted in {elapsed} ms &mdash; your receipt is on its way.</p>'\n                        f'<p><a href=\"/\">Back to the desk</a></p>')\n            except Exception as e:\n                html = f'<p>We could not reach our queue: {str(e)}</p>'\n        else:\n            try:\n                stats = (f'<p>orders accepted: {r.get(\"stats:orders\") or 0}</p>'\n                         f'<p>backlog: {r.llen(\"queue:orders\")}</p>'\n                         f'<p>receipts issued: {r.get(\"stats:receipts\") or 0}</p>'\n                         f'<p>dead-lettered: {r.llen(\"queue:orders:dead\")}</p>')\n            except Exception as e:\n                stats = f'<p>We could not reach our queue: {str(e)}</p>'\n            html = ('<h2>Fulfillment desk</h2>' + stats +\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\n```\n\n3. Replace the running server:\n\n```bash\npkill -f server.py\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```\n\n4. Place an order: **accepted in a few milliseconds.** The two-second checkout is gone. Place two or three more, then look at the desk page: `orders accepted` climbs... and so does `backlog`, while `receipts issued` stays at **0**.\n\nBe honest about what just happened: you didn't make the work disappear — **you made a promise that nobody is keeping yet.** Every order you \"accepted\" is a receipt you still owe. Open `queue`'s **Explorer**: there it is, `queue:orders`, a *list* holding every unkept promise. (Two counters on the desk — `receipts issued` and `dead-lettered` — will earn their names before the end.)\n\nOne more thing, because you may remember the cache story's golden rule: unlike a cache, this queue is **not** an optimization you can shrug off. It now holds your customers' orders. The desk survives a dead queue (the `try/except` keeps it answering), but checkout stops accepting — a queue is a dependency you *chose*, trading two seconds of latency for the machinery you're about to build.",
+      "hints": [
+        "Paste the blocks one at a time in `web`'s terminal. Only `python3-redis` is new — Python is already there from the previous step.",
+        "Old page still showing, or \"Address already in use\"? The old server still holds port 80: run `pkill -f server.py`, then the `nohup python3 /root/server.py >/dev/null 2>&1 &` line again.",
+        "\"We could not reach our queue\"? Check the previous step: the node must be named exactly `queue`, be running, and carry the inbound **ALLOW TCP 6379** rule with Source **web**.",
+        "The first check places an order through your new code — if it stays red, the running server is probably still the old version (kill and restart it)."
+      ],
+      "solution": "In `web`'s terminal, paste this whole block:\n\n```bash\napt-get install -y python3-redis\ncat << 'EOF' > /root/server.py\nfrom http.server import SimpleHTTPRequestHandler, HTTPServer\nimport json, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=1)\n\nCATALOG = ['The Pragmatic Programmer', 'Clean Code',\n           'Designing Data-Intensive Applications', 'Release It!']\n\nclass Handler(SimpleHTTPRequestHandler):\n    def do_GET(self):\n        started = time.monotonic()\n        if self.path.startswith('/order'):\n            try:\n                n = r.incr('stats:orders')\n                job = {'id': f'or-{n}', 'title': CATALOG[n % len(CATALOG)]}\n                r.lpush('queue:orders', json.dumps(job))\n                elapsed = int((time.monotonic() - started) * 1000)\n                html = (f'<p>Thank you for your order! Order <b>{job[\"id\"]}</b> '\n                        f'accepted in {elapsed} ms &mdash; your receipt is on its way.</p>'\n                        f'<p><a href=\"/\">Back to the desk</a></p>')\n            except Exception as e:\n                html = f'<p>We could not reach our queue: {str(e)}</p>'\n        else:\n            try:\n                stats = (f'<p>orders accepted: {r.get(\"stats:orders\") or 0}</p>'\n                         f'<p>backlog: {r.llen(\"queue:orders\")}</p>'\n                         f'<p>receipts issued: {r.get(\"stats:receipts\") or 0}</p>'\n                         f'<p>dead-lettered: {r.llen(\"queue:orders:dead\")}</p>')\n            except Exception as e:\n                stats = f'<p>We could not reach our queue: {str(e)}</p>'\n            html = ('<h2>Fulfillment desk</h2>' + stats +\n                    '<p><a href=\"/order\">Place a test order</a></p>')\n        page = f'<html><body><h1>Nimbus Books</h1>{html}</body></html>'\n        self.send_response(200)\n        self.send_header('Content-type', 'text/html')\n        self.end_headers()\n        self.wfile.write(bytes(page, 'utf8'))\n\nHTTPServer(('', 80), Handler).serve_forever()\nEOF\npkill -f server.py\nnohup python3 /root/server.py >/dev/null 2>&1 &\n```",
+      "validators": [
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/order",
+            "expectedText": "accepted"
+          }
+        },
+        {
+          "type": "redis_key_exists",
+          "params": {
+            "node": "queue",
+            "key": "stats:orders"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-first-worker",
+      "title": "The first worker",
+      "instruction": "The back room hires its first employee. A **worker** is the plainest program in distributed systems: an infinite loop — *take a job, do the work, mark it done, repeat.* No web server, no routes; just the loop.\n\n1. Drag a second **Server** into the subnet and name it `worker-1`.\n2. Open the queue's door for it: on `queue`, add a second inbound rule — **ALLOW TCP 6379**, Source **`worker-1`**. Two machines, two precise rules.\n3. In `worker-1`'s **Terminal**, install what it needs and write the loop:\n\n```bash\napt-get update && apt-get install -y python3 python3-redis\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n        if item is None:\n            continue  # queue empty — go right back to listening\n        job = json.loads(item[1])\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        with open('/root/receipts.log', 'a') as f:\n            f.write(f'{job[\"id\"]}: receipt for \"{job[\"title\"]}\"\\n')\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} done', flush=True)\n    except Exception as e:\n        print(f'[{WORKER}] error: {e}', flush=True)\n        time.sleep(1)\nEOF\n```\n\nRead the loop before running it — two details are the whole trade:\n- **`BRPOP` blocks.** The worker doesn't poll in a busy loop; it sleeps *inside Redis* until a job arrives, then wakes instantly. The producer `LPUSH`es on the left, the worker `BRPOP`s from the right: first in, first out.\n- **The receipt engine moved here.** Same 1-second-per-receipt cost as before — it didn't get cheaper, it got *out of the customer's way*.\n\n4. Make it start on boot — one line, and any future *clone* of this machine wakes up already working (remember this on Friday) — then start it and watch it live:\n\n```bash\necho '(python3 /root/worker.py >> /root/worker.log 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\ntail -f /root/worker.log\n```\n\nWithin seconds the backlog from the previous step drains, one `done` per second (`Ctrl+C` leaves the tail; the worker keeps running). Check the desk page: `backlog: 0`, and `receipts issued` finally counting. `cat /root/receipts.log` — every promise, kept.",
+      "hints": [
+        "Two things before the code: the node must be named exactly `worker-1`, and **`queue`**'s security group needs the new inbound **ALLOW TCP 6379** rule with Source **worker-1** — without it, the worker's `BRPOP` can't reach Redis and the log fills with errors.",
+        "Paste the `cat << 'EOF' ... EOF` block as a single paste, then the boot/start block. The worker writes its life story to `/root/worker.log` — `tail -f` it whenever something looks stuck.",
+        "Backlog not moving? `tail -20 /root/worker.log`: connection errors mean the 6379 rule is missing or the node name isn't `worker-1`; no output at all means the worker isn't running — start it again with the `nohup` line.",
+        "The last check wants the desk to show `backlog: 0` — give the worker a few seconds to finish draining before you validate."
+      ],
+      "solution": "Create a **Server** named `worker-1` in the subnet. On `queue`'s security group: Direction **Inbound**, Action **ALLOW**, Protocol **TCP**, Port **6379**, Source **worker-1** → **Add Rule**. Then in `worker-1`'s terminal, paste:\n\n```bash\napt-get update && apt-get install -y python3 python3-redis\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n        if item is None:\n            continue  # queue empty — go right back to listening\n        job = json.loads(item[1])\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        with open('/root/receipts.log', 'a') as f:\n            f.write(f'{job[\"id\"]}: receipt for \"{job[\"title\"]}\"\\n')\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} done', flush=True)\n    except Exception as e:\n        print(f'[{WORKER}] error: {e}', flush=True)\n        time.sleep(1)\nEOF\necho '(python3 /root/worker.py >> /root/worker.log 2>&1 &)' >> /root/.bashrc\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\n```\n\nWait for the desk page to show `backlog: 0`, then validate.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "worker-1"
+          }
+        },
+        {
+          "type": "edge_exists",
+          "params": {
+            "source": "worker-1",
+            "target": "queue",
+            "port": 6379
+          }
+        },
+        {
+          "type": "redis_key_exists",
+          "params": {
+            "node": "queue",
+            "key": "stats:receipts"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/",
+            "expectedText": "backlog: 0"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-receipt-archive",
+      "title": "The receipt archive",
+      "instruction": "Audit calls: *\"Send us the receipt for order or-3.\"* It's in `/root/receipts.log`... on `worker-1`'s local disk. Fine today. But you're about to hire more workers, and then every receipt would live on whichever machine happened to grab the order — scattered across private disks that **die with their machines**. The rule that fixes it is worth an interview answer on its own: **workers stay stateless; anything worth keeping goes to a shared store.** Receipts belong in the company's books — a job for **PostgreSQL**.\n\n1. Drag a **SQL Database** node (PostgreSQL) into the subnet and name it `archive` — it starts on creation.\n2. On `archive`, add an inbound rule **ALLOW TCP 5432** with Source **`worker-1`** (5432 is PostgreSQL's port).\n3. In `worker-1`'s **Terminal**, install the PostgreSQL driver and rewrite the loop:\n\n```bash\napt-get install -y python3-psycopg2\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport psycopg2\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nMAX_ATTEMPTS = 3\n\ndef archive_receipt(job):\n    conn = psycopg2.connect(host='archive', database='postgres', user='postgres',\n                            password='postgres', connect_timeout=2)\n    cur = conn.cursor()\n    cur.execute('CREATE TABLE IF NOT EXISTS receipts '\n                '(id SERIAL PRIMARY KEY, order_id TEXT, title TEXT, worker TEXT, status TEXT)')\n    cur.execute('INSERT INTO receipts (order_id, title, worker, status) VALUES (%s, %s, %s, %s)',\n                (job['id'], job['title'], WORKER, 'issued'))\n    conn.commit()\n    cur.close(); conn.close()\n\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n    except Exception as e:\n        print(f'[{WORKER}] queue unreachable: {e}', flush=True)\n        time.sleep(1)\n        continue\n    if item is None:\n        continue  # queue empty — go right back to listening\n    raw = item[1]\n    try:\n        job = json.loads(raw)\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        archive_receipt(job)\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} archived', flush=True)\n    except Exception as e:\n        # One bad order must never kill the worker or jam the line.\n        # Count its attempts in Redis (shared with every other worker),\n        # give it MAX_ATTEMPTS tries, then park it in the dead-letter queue.\n        attempts = r.incr('attempts:' + raw[:64])\n        if attempts < MAX_ATTEMPTS:\n            print(f'[{WORKER}] job failed ({e}) — retry {attempts}/{MAX_ATTEMPTS}', flush=True)\n            time.sleep(1)\n            r.lpush('queue:orders', raw)\n        else:\n            print(f'[{WORKER}] job dead-lettered after {attempts} attempts: {raw[:60]}', flush=True)\n            r.rpush('queue:orders:dead', raw)\nEOF\npkill -f worker.py\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\n```\n\nRead the new `except` branch before moving on: a job that fails goes *back on the queue* with an attempt counter, and after three strikes it is parked in `queue:orders:dead` instead of being retried forever — or worse, silently dropped. It looks paranoid today. It earns its keep before the end of this story.\n\n4. Place an order on the desk page, watch `archived` appear in `tail -5 /root/worker.log`, then **Inspect** `archive` → **Database Explorer** tab: there's your `receipts` table (among a few demo tables like `users` and `products` that Torollo seeds — ignore those). Open it and look at the `worker` column: it names the machine that did the work. *Remember that column.*\n\n5. The last check below is already thinking ahead: it verifies `web` can **not** reach the archive. The front desk writes promises to the queue; only workers write receipts. If that check fails, a rule on `archive` is broader than Source `worker-1` — tighten it.",
+      "hints": [
+        "The 5432 rule goes on **`archive`**'s security group: Direction **Inbound**, Action **ALLOW**, Protocol **TCP**, Port **5432**, Source **worker-1** (from the Nodes group) → **Add Rule**.",
+        "The rewrite is a single `cat << 'EOF' ... EOF` paste, then `pkill -f worker.py` and the `nohup` line — same restart dance as the producer. `tail -5 /root/worker.log` should greet you with `ready, waiting for orders...`.",
+        "No `receipts` table in the Database Explorer? It appears with the *first archived order*: place one on the desk page, wait a second or two, then use the refresh icon in the modal header. If the log shows `retry 1/3` instead, the worker can't reach PostgreSQL — check the 5432 rule and that the node is named exactly `archive`.",
+        "Last check red? Open `archive`'s security group: its only inbound rule must have Source **worker-1** — not Anywhere (0.0.0.0/0), and not `web`."
+      ],
+      "solution": "Drop a **SQL Database** node named `archive` into the subnet. On its security group: Direction **Inbound**, Action **ALLOW**, Protocol **TCP**, Port **5432**, Source **worker-1** → **Add Rule**. In `worker-1`'s terminal, paste this whole block:\n\n```bash\napt-get install -y python3-psycopg2\ncat << 'EOF' > /root/worker.py\nimport json, socket, time\nimport psycopg2\nimport redis\n\nr = redis.Redis(host='queue', port=6379, decode_responses=True,\n                socket_connect_timeout=1, socket_timeout=5)\nWORKER = socket.gethostname()\nMAX_ATTEMPTS = 3\n\ndef archive_receipt(job):\n    conn = psycopg2.connect(host='archive', database='postgres', user='postgres',\n                            password='postgres', connect_timeout=2)\n    cur = conn.cursor()\n    cur.execute('CREATE TABLE IF NOT EXISTS receipts '\n                '(id SERIAL PRIMARY KEY, order_id TEXT, title TEXT, worker TEXT, status TEXT)')\n    cur.execute('INSERT INTO receipts (order_id, title, worker, status) VALUES (%s, %s, %s, %s)',\n                (job['id'], job['title'], WORKER, 'issued'))\n    conn.commit()\n    cur.close(); conn.close()\n\nprint(f'[{WORKER}] ready, waiting for orders...', flush=True)\n\nwhile True:\n    try:\n        item = r.brpop('queue:orders', timeout=3)\n    except Exception as e:\n        print(f'[{WORKER}] queue unreachable: {e}', flush=True)\n        time.sleep(1)\n        continue\n    if item is None:\n        continue  # queue empty — go right back to listening\n    raw = item[1]\n    try:\n        job = json.loads(raw)\n        time.sleep(1)  # the receipt engine: totals, taxes, the PDF\n        archive_receipt(job)\n        r.incr('stats:receipts')\n        print(f'[{WORKER}] {job[\"id\"]} archived', flush=True)\n    except Exception as e:\n        # One bad order must never kill the worker or jam the line.\n        # Count its attempts in Redis (shared with every other worker),\n        # give it MAX_ATTEMPTS tries, then park it in the dead-letter queue.\n        attempts = r.incr('attempts:' + raw[:64])\n        if attempts < MAX_ATTEMPTS:\n            print(f'[{WORKER}] job failed ({e}) — retry {attempts}/{MAX_ATTEMPTS}', flush=True)\n            time.sleep(1)\n            r.lpush('queue:orders', raw)\n        else:\n            print(f'[{WORKER}] job dead-lettered after {attempts} attempts: {raw[:60]}', flush=True)\n            r.rpush('queue:orders:dead', raw)\nEOF\npkill -f worker.py\nnohup python3 /root/worker.py >> /root/worker.log 2>&1 &\n```\n\nPlace an order on the desk page and validate once `archived` shows in the worker log.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": {
+            "node": "archive"
+          }
+        },
+        {
+          "type": "edge_exists",
+          "params": {
+            "source": "worker-1",
+            "target": "archive",
+            "port": 5432
+          }
+        },
+        {
+          "type": "table_exists",
+          "params": {
+            "node": "archive",
+            "table": "receipts"
+          }
+        },
+        {
+          "type": "port_denied",
+          "params": {
+            "source": "web",
+            "target": "archive",
+            "port": 5432
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-flash-sale",
+      "title": "The flash sale",
+      "instruction": "Friday, 6 p.m. Marketing flips the switch. Simulate the stampede yourself — in `web`'s **Terminal**, place **300 orders**:\n\n```bash\nfor i in $(seq 1 300); do curl -s localhost/order > /dev/null; done\n```\n\nEvery one of them accepted in milliseconds — checkout never blinked. That's the promise machine doing its job. Now watch the *keeping*: refresh the desk page. `backlog: 280`... `279`... falling by **exactly one per second**, because that is your throughput: one worker, one receipt per second. You are watching **backpressure** — intake is instant, processing is not, and the queue is where the difference piles up. At this rate the last customer's receipt lands in about five minutes.\n\n**Press Validate right now and read the failures** — no worker fleet, a backlog in the hundreds. The queue absorbed the spike so nothing broke; absorbing is not the same as keeping up.\n\nFix it like an operator: when the line is long, you don't lecture the cashier to hurry — **you open more registers.** The workers are deliberately stateless and identical, which makes them the easiest thing in your architecture to multiply:\n\n1. Drag an **Auto Scaling Group** into the subnet and name it `worker-asg`.\n2. **Doors first, fleet second** — clones must be productive from their first breath. On `queue`, add inbound **ALLOW TCP 6379** with Source **`worker-asg`**; on `archive`, add inbound **ALLOW TCP 5432** with Source **`worker-asg`**. Each rule covers *every* replica the group runs, now and after any self-healing.\n3. Click **Inspect** on `worker-asg`. In *Design & Scaling settings*: Template Server **`worker-1`**, tick your subnet as the deployment target, capacity Min **1** / Desired **3** / Max **6** → **Save & Deploy**. Torollo snapshots `worker-1` — Python, `/root/worker.py`, and the boot line you baked in — and boots three clones that wake up already consuming.\n4. Refresh the desk and watch the backlog **melt four times faster** — four consumers on one queue, no coordination, no duplicate receipts: Redis hands each `BRPOP` exactly one job, and that atomic hand-off is the whole contract. For the proof, open `archive`'s **SQL Shell** and run `SELECT worker, COUNT(*) FROM receipts GROUP BY worker;` — **four different hostnames**, each with its share of one line of work.\n\nWhen the desk shows `backlog: 0`, validate again — same checks, very different Friday.",
+      "hints": [
+        "Add the two `worker-asg` rules **before** Save & Deploy: replicas boot within seconds and start calling the queue immediately — deploy first and the young fleet's log fills with connection errors until the doors open.",
+        "In the ASG modal: *1. Launch Template Source* → `worker-1`; *2. VPC Subnet Targets* → tick your subnet; *3. Instance Capacity Limits* → Min 1, Desired 3, Max 6 → **Save & Deploy**. The deploy takes a moment — Torollo is committing `worker-1`'s disk into a golden image before booting the clones.",
+        "Backlog stuck while the grid shows healthy replicas? The clones can't reach Redis: check the inbound **ALLOW TCP 6379** rule on `queue` has Source **worker-asg** (the group itself, not a replica). Same logic for **5432** on `archive` — without it, every clone retries three times and dead-letters real orders.",
+        "The first check counts **running replicas**: it wants exactly 3, so let the *Simulation & Live Grid* tab settle on three *Healthy* clones. And `worker-1` itself must stay running — it's the template and the fourth consumer."
+      ],
+      "solution": "In `web`'s terminal: `for i in $(seq 1 300); do curl -s localhost/order > /dev/null; done`, then press **Validate** and read the failure. Add the two fleet rules — on `queue`: inbound **ALLOW TCP 6379**, Source **worker-asg**; on `archive`: inbound **ALLOW TCP 5432**, Source **worker-asg**. Drag an **Auto Scaling Group** named `worker-asg` into the subnet, **Inspect** → Template **worker-1**, tick the subnet, Min **1** / Desired **3** / Max **6** → **Save & Deploy**. Wait for the desk page to show `backlog: 0` and validate.",
+      "validators": [
+        {
+          "type": "asg_replicas",
+          "params": {
+            "node": "worker-asg",
+            "count": 3
+          }
+        },
+        {
+          "type": "container_running",
+          "params": {
+            "node": "worker-1"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/",
+            "expectedText": "backlog: 0"
+          }
+        }
+      ]
+    },
+    {
+      "id": "the-poison-order",
+      "title": "The poison order",
+      "instruction": "Monday morning. A partner's integration pushed something onto your queue overnight that should never have been sent. Every queue eventually receives one — the industry name is a **poison message**. Inject it yourself: **Inspect** `queue` → **Shell** tab, and run:\n\n```\nLPUSH queue:orders corrupted-order-from-partner-api\n```\n\nThat's not JSON. Within a few seconds one of your four workers grabs it, fails to parse it, and the machinery you built two steps ago wakes up. Watch the desk page: the backlog stays near zero, `dead-lettered` ticks to **1**. Nothing jammed.\n\nNow read the paper trail in `queue`'s **Explorer** (refresh icon):\n- `attempts:corrupted-order-from-partner-api` — value **3**: three tries, honestly counted. The counter lives *in Redis*, not in a worker's memory, because each retry may be caught by a **different** worker — a private tally would reset on every hop. Shared work needs shared state; you already learned that rule with the receipts.\n- `queue:orders:dead` — a *list* holding the corpse, intact, ready to be inspected or replayed once the partner fixes their bug. A dead-letter queue is an **inbox, not a trash can**.\n\nWorth pausing on what did *not* happen. A naive worker fails one of two ways: it **crashes and jams the line** — with a fleet, the poison kills all four, one by one — or it **swallows the error and drops the job**: a receipt promised, never issued, no trace. Yours did neither: it failed *loudly, three times, into a queue you can read*.\n\nPlace one last normal order on the desk — accepted, archived, business as usual. One rotten order and the store never blinked.\n\n**That's the pattern.** Look at your canvas: a checkout that answers in milliseconds no matter what Friday brings, a real queue holding the promises, a stateless fleet that scales by dragging a slider, receipts in a shared archive naming the worker that made them, and a dead-letter queue for the messages that lie. Next time an interviewer asks *\"how would you handle a slow operation in the request path?\"* — you haven't just read about queues and workers: you watched a backlog drain at one job per second, opened more registers, and buried a poison message with full honors. If you haven't played them yet, the other two Nimbus Books stories — the resilient launch and the Redis cache — complete the picture.",
+      "hints": [
+        "The Shell tab runs one command per Execute. Paste exactly `LPUSH queue:orders corrupted-order-from-partner-api` — the value must *not* be valid JSON, that's the point.",
+        "`dead-lettered` still 0 after ~10 seconds? Retries pause one second between attempts, so the full journey takes a few seconds. Still nothing: run `LLEN queue:orders:dead` and `KEYS attempts:*` in the Shell — if both are empty, check the fleet is running the step-6 worker code (the retry logic) and that your LPUSH hit `queue:orders` exactly.",
+        "Don't be surprised if `tail /root/worker.log` on `worker-1` never mentions the poison — any of the four workers may have caught each attempt. The Redis counters are the shared truth; the per-machine logs are only each worker's side of the story.",
+        "The second check places a real order through checkout — if it fails, your producer or fleet has a problem bigger than one poison message: check the desk page by hand."
+      ],
+      "solution": "In `queue`'s **Shell**: `LPUSH queue:orders corrupted-order-from-partner-api`. Wait a few seconds, refresh the desk page until `dead-lettered: 1`, and look at `attempts:corrupted-order-from-partner-api` (value 3) and `queue:orders:dead` in the Explorer. Place one normal order on the desk page, then validate.",
+      "validators": [
+        {
+          "type": "redis_key_exists",
+          "params": {
+            "node": "queue",
+            "key": "queue:orders:dead"
+          }
+        },
+        {
+          "type": "http_get_contains",
+          "params": {
+            "node": "web",
+            "port": 80,
+            "path": "/order",
+            "expectedText": "accepted"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of Changes

Adds the third catalog roadmap, **“Workers & the Redis job queue”** (`redis-queue-workers`, EN + FR, 8 steps, ~40 min, intermediate) in the Nimbus Books universe. The learner feels a 2-second synchronous checkout, decouples it with a producer pushing orders onto a real Redis list, writes a blocking `BRPOP` worker, archives receipts into PostgreSQL (stateless workers / shared state), floods the queue with a 300-order flash sale to watch backpressure live, scales consumption with an auto-scaling group cloned from the worker (a security-group rule with the ASG node as Source covers every replica), and finishes with a poison message handled by retry counters shared in Redis plus a dead-letter queue. Step 7 is an explicit "validate before fixing" beat, and every validator was chosen to remain stable when earlier steps are re-validated after completion.

Uses existing validators only: `container_running`, `http_get_contains`, `edge_exists`, `redis_key_exists`, `table_exists`, `port_denied`, `asg_replicas`.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass) — backend 400/400

### Manual Verification

`npm run roadmap:validate` OK for both language files; a script asserts EN/FR ids and validators are strictly identical.

Played the full roadmap against real Docker with an API driver that mirrors the canvas exactly (network config with default subnet routes, per-node security groups, ASG deploy via the same endpoints as the modal) and executes in the containers the exact code blocks extracted from the roadmap JSON. Result: **34/34 checks green** —
- every step validated **fail first, then pass** (e.g. the producer step fails while the old synchronous code runs; the flash-sale step fails during the flood, before the ASG);
- flash sale: 300 orders queued in seconds, backlog drained to 0 by worker-1 + 3 ASG replicas; `SELECT worker, COUNT(*) FROM receipts GROUP BY worker` shows 4 distinct container hostnames (67/99/67/68);
- poison message: 3 shared-counter retries then parked in `queue:orders:dead`, checkout still accepting;
- **revisit stability**: all 8 steps re-validated green after completion;
- **kill & restart mid-journey**: `web` then `worker-1` stopped/restarted one at a time (canvas-style) — servers revive via the baked boot line and all 8 steps re-validate green;
- catalog lists both language variants.

### Adjacent findings (not addressed here, per scope rules)

1. The `derssa/backend-lab-mongo:v1` image is currently unusable on a Fedora 44 / kernel 7.0.9 host: mongod silently segfaults (exit 139) 30–90 s after boot, including a bare `docker run` outside Torollo (reproduced 3×). This is why the receipt archive uses PostgreSQL (`table_exists`) instead of the originally considered Mongo (`mongo_collection_exists` stays unexercised by the catalog). The image likely needs a rebuild on a newer mongod.
2. Stopping **two containers simultaneously** and restarting them can reshuffle their subnet IPs; peer containers' firewall rules then keep the stale source IPs even after a config re-save (the persisted `nodeIpMap` wins over live state), silently breaking cross-node traffic. A single-container stop/start (the canvas gesture) keeps its IP and re-wires correctly — verified. Worth a backlog entry.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing