### PR TITLE
test: cover computeSemanticRules and enforcementPlanner

### DIFF
--- a/backend/src/modules/learning/engine/types.ts
+++ b/backend/src/modules/learning/engine/types.ts
@@ -1,6 +1,6 @@
 import { ContainerInfo } from '../../../infrastructure/docker/providers/containerProvider';
 import { DockerErrorCode } from '../../../infrastructure/docker/dockerErrors';
-import { SemanticRule } from '../../network/models/networkPolicy';
+import { NetworkConfigInput, SemanticRule } from '../../network/models/networkPolicy';
 import { InterSubnetStatus } from '../../network/services/interSubnetHealth';
 
 export type ValidatorStatus = 'pass' | 'fail' | 'error';
@@ -45,17 +45,15 @@ export interface ValidatorOutcome {
 }
 
 /**
- * Local view of a project's network config — only the fields validators read.
- * The canonical shape lives in the frontend package (`shared/types/network.ts`);
- * the backend never imports it (package boundary), so this mirrors just the
- * subset needed here. `ProjectService.getNetworkConfig` remains untyped at
- * its own boundary — this interface is where the engine starts trusting it.
+ * Local view of a project's network config — the connectivity fields the
+ * network module already types, plus the one only validators read. The
+ * canonical shape lives in the frontend package (`shared/types/network.ts`);
+ * the backend never imports it (package boundary).
+ * `ProjectService.getNetworkConfig` remains untyped at its own boundary —
+ * this interface is where the engine starts trusting it.
  */
-export interface ValidatorNetworkConfig {
-  nodeSubnetMap?: Record<string, string>;
-  nodeSecurityGroups?: Record<string, unknown[]>;
+export interface ValidatorNetworkConfig extends NetworkConfigInput {
   loadBalancerTargets?: Record<string, string[]>;
-  asgs?: Record<string, { parentId: string }>;
 }
 
 /** Per-run context shared by every validator of a step. */

--- a/backend/src/modules/learning/engine/validators/testSupport.ts
+++ b/backend/src/modules/learning/engine/validators/testSupport.ts
@@ -47,40 +47,5 @@ export function makeContext(overrides: ContextOverrides = {}): ValidatorContext 
   };
 }
 
-export interface SecurityGroupRuleFixture {
-  type: 'inbound' | 'outbound';
-  action: 'ALLOW' | 'DENY';
-  protocol: string;
-  port: string;
-  source: string;
-}
-
-/**
- * The default security group every node gets when dropped on the canvas —
- * mirror of `createDefaultRules` (frontend `CanvasPage/utils/securityRules.ts`):
- * deny all inbound, allow all outbound.
- */
-export function makeDefaultSgRules(): SecurityGroupRuleFixture[] {
-  return [
-    { type: 'inbound', action: 'DENY', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
-    { type: 'outbound', action: 'ALLOW', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
-  ];
-}
-
-/**
- * A realistic applied network config: every node sits in a subnet and carries
- * the default security group, with the learner's rules prepended — the UI
- * always inserts new rules at the top (highest first-match priority).
- */
-export function makeNetworkConfig(
-  nodeIds: string[],
-  learnerRules: Record<string, SecurityGroupRuleFixture[]> = {}
-): ValidatorNetworkConfig {
-  const nodeSubnetMap: Record<string, string> = {};
-  const nodeSecurityGroups: Record<string, SecurityGroupRuleFixture[]> = {};
-  for (const nodeId of nodeIds) {
-    nodeSubnetMap[nodeId] = 'subnet-public-1';
-    nodeSecurityGroups[nodeId] = [...(learnerRules[nodeId] ?? []), ...makeDefaultSgRules()];
-  }
-  return { nodeSubnetMap, nodeSecurityGroups };
-}
+/** Network-config fixtures live with the config shape, in the network module. */
+export { makeDefaultSgRules, makeNetworkConfig } from '../../../network/testSupport';

--- a/backend/src/modules/network/mapper/virtualNetworkMapper.test.ts
+++ b/backend/src/modules/network/mapper/virtualNetworkMapper.test.ts
@@ -32,4 +32,22 @@ describe('VirtualNetworkMapper', () => {
     expect(endpoints[0].containerName).toBe('akal-lab-p-123-node123');
     expect(endpoints[1].containerName).toBe('akal-lab-p-123-node_nametest');
   });
+
+  it('should return no endpoints for a project with no placed node', () => {
+    expect(VirtualNetworkMapper.mapNodesToEndpoints('p-123', [])).toEqual([]);
+  });
+
+  it('should leave an already-safe node id untouched', () => {
+    const [endpoint] = VirtualNetworkMapper.mapNodesToEndpoints('p-123', ['web_db-1']);
+    expect(endpoint!.containerName).toBe('akal-lab-p-123-web_db-1');
+  });
+
+  it('should not disambiguate two node ids that sanitize to the same name', () => {
+    // Documented behaviour: sanitization can collide. Node ids are generated
+    // (uuid-like), so this never happens in practice — but nothing guards it.
+    const endpoints = VirtualNetworkMapper.mapNodesToEndpoints('p-123', ['node.1', 'node/1']);
+
+    expect(endpoints[0]!.containerName).toBe(endpoints[1]!.containerName);
+    expect(endpoints[0]!.nodeId).not.toBe(endpoints[1]!.nodeId);
+  });
 });

--- a/backend/src/modules/network/models/networkPolicy.ts
+++ b/backend/src/modules/network/models/networkPolicy.ts
@@ -8,6 +8,33 @@ export interface SemanticRule {
   ownerNodeId: string;
 }
 
+/**
+ * A security-group rule exactly as the canvas persists it: casing is free and
+ * most fields are optional — `computeSemanticRules` is what normalizes them.
+ */
+export interface SecurityGroupRuleInput {
+  type: 'inbound' | 'outbound';
+  action?: 'ALLOW' | 'DENY';
+  protocol?: string;
+  port?: string;
+  source: string; // '0.0.0.0/0', a 'subnet-…' id, or a node id
+}
+
+/**
+ * Backend view of a project's persisted network config (`~/.torollo/projects.json`).
+ * Partial mirror of the canonical `NetworkConfig` in the frontend package
+ * (`frontend/src/shared/types/network.ts`), which the backend never imports.
+ * The index signature keeps the remaining fields (`subnets`, `vpcConfig`, the
+ * load-balancer maps…) flowing untouched to the Docker provider, which still
+ * reads them untyped.
+ */
+export interface NetworkConfigInput {
+  nodeSubnetMap?: Record<string, string>;
+  nodeSecurityGroups?: Record<string, SecurityGroupRuleInput[]>;
+  asgs?: Record<string, { parentId: string }>;
+  [key: string]: unknown;
+}
+
 export interface NetworkPolicy {
   projectId: string;
   rules: SemanticRule[];

--- a/backend/src/modules/network/planner/enforcementPlanner.test.ts
+++ b/backend/src/modules/network/planner/enforcementPlanner.test.ts
@@ -1,0 +1,73 @@
+import { EnforcementPlanner } from './enforcementPlanner';
+import { SemanticRule } from '../models/networkPolicy';
+
+const rule = (overrides: Partial<SemanticRule> = {}): SemanticRule => ({
+  sourceNodeId: 'web',
+  targetNodeId: 'db',
+  protocol: 'tcp',
+  port: '5432',
+  action: 'ALLOW',
+  direction: 'inbound',
+  ownerNodeId: 'db',
+  ...overrides,
+});
+
+describe('EnforcementPlanner', () => {
+  it('compiles an ALLOW rule into an ALLOW_CONNECTION intent, field for field', () => {
+    const intents = EnforcementPlanner.plan('project-1', [rule()]);
+
+    expect(intents[0]).toEqual({
+      type: 'ALLOW_CONNECTION',
+      sourceNodeId: 'web',
+      targetNodeId: 'db',
+      protocol: 'tcp',
+      port: '5432',
+      direction: 'inbound',
+      ownerNodeId: 'db',
+    });
+  });
+
+  it('compiles a DENY rule into a DENY_CONNECTION intent', () => {
+    const intents = EnforcementPlanner.plan('project-1', [rule({ action: 'DENY' })]);
+
+    expect(intents[0]).toMatchObject({ type: 'DENY_CONNECTION', port: '5432' });
+  });
+
+  it('treats anything that is not exactly ALLOW as a denial (fail closed)', () => {
+    const intents = EnforcementPlanner.plan('project-1', [rule({ action: 'allow' as SemanticRule['action'] })]);
+
+    expect(intents[0]!.type).toBe('DENY_CONNECTION');
+  });
+
+  it('always appends the terminal zero-trust DENY_ALL last', () => {
+    const intents = EnforcementPlanner.plan('project-1', [rule(), rule({ action: 'DENY' })]);
+
+    expect(intents).toHaveLength(3);
+    expect(intents[intents.length - 1]).toEqual({ type: 'DENY_ALL' });
+  });
+
+  it('plans a DENY_ALL even with no rules at all', () => {
+    expect(EnforcementPlanner.plan('project-1', [])).toEqual([{ type: 'DENY_ALL' }]);
+  });
+
+  it('preserves rule order — the plan is walked first-match-wins downstream', () => {
+    const intents = EnforcementPlanner.plan('project-1', [
+      rule({ action: 'DENY', port: '6379' }),
+      rule({ action: 'ALLOW', port: 'ALL' }),
+    ]);
+
+    expect(intents.map((i) => `${i.type}/${i.port ?? '-'}`)).toEqual([
+      'DENY_CONNECTION/6379',
+      'ALLOW_CONNECTION/ALL',
+      'DENY_ALL/-',
+    ]);
+  });
+
+  it('keeps outbound rules distinguishable from inbound ones', () => {
+    const intents = EnforcementPlanner.plan('project-1', [
+      rule({ direction: 'outbound', ownerNodeId: 'web' }),
+    ]);
+
+    expect(intents[0]).toMatchObject({ direction: 'outbound', ownerNodeId: 'web' });
+  });
+});

--- a/backend/src/modules/network/services/networkService.test.ts
+++ b/backend/src/modules/network/services/networkService.test.ts
@@ -1,0 +1,390 @@
+import { NetworkService } from './networkService';
+import { NetworkConfigInput, SecurityGroupRuleInput, SemanticRule } from '../models/networkPolicy';
+import { DockerContainerFixture, makeDockerContainer, makeNetworkConfig } from '../testSupport';
+
+// `computeSemanticRules` lists containers to resolve ASG replicas. A plain
+// async function reading a mutable array, not a `jest.fn()`: `resetMocks`
+// would wipe a `mockResolvedValue` between tests.
+let mockDockerContainers: DockerContainerFixture[] = [];
+jest.mock('../../../infrastructure/docker/DockerClient', () => ({
+  __esModule: true,
+  default: { listContainers: async () => mockDockerContainers },
+}));
+
+beforeEach(() => {
+  mockDockerContainers = [];
+});
+
+const compute = (config: NetworkConfigInput): Promise<SemanticRule[]> =>
+  NetworkService.computeSemanticRules('project-1', config);
+
+/** Compact, order-sensitive projection: `web→db tcp/5432 ALLOW inbound (owner db)`. */
+const fmt = (r: SemanticRule): string =>
+  `${r.sourceNodeId}→${r.targetNodeId} ${r.protocol}/${r.port} ${r.action} ${r.direction} (owner ${r.ownerNodeId})`;
+
+const ownedBy = (rules: SemanticRule[], nodeId: string): string[] =>
+  rules.filter((r) => r.ownerNodeId === nodeId).map(fmt);
+
+/**
+ * The rules a node's own security group produced, in order, for one direction.
+ * The UI prepends new rules, so the learner's rules open the block and the two
+ * default ones close it.
+ */
+const blockOf = (rules: SemanticRule[], nodeId: string, direction: 'inbound' | 'outbound'): string[] =>
+  rules.filter((r) => r.ownerNodeId === nodeId && r.direction === direction).map(fmt);
+
+describe('computeSemanticRules — default security groups', () => {
+  it('expands the two default rules of every node into a pairwise matrix', async () => {
+    const rules = await compute(makeNetworkConfig(['web', 'db']));
+
+    // Per node: one outbound block (allow all, + its icmp twin) then one
+    // inbound block (deny all, + its icmp twin), against every other node.
+    expect(rules.map(fmt)).toEqual([
+      'web→db all/ALL ALLOW outbound (owner web)',
+      'web→db icmp/ALL ALLOW outbound (owner web)',
+      'db→web all/ALL DENY inbound (owner web)',
+      'db→web icmp/ALL DENY inbound (owner web)',
+      'db→web all/ALL ALLOW outbound (owner db)',
+      'db→web icmp/ALL ALLOW outbound (owner db)',
+      'web→db all/ALL DENY inbound (owner db)',
+      'web→db icmp/ALL DENY inbound (owner db)',
+    ]);
+  });
+
+  it('emits every ordered pair when more than two nodes share a subnet', async () => {
+    const rules = await compute(makeNetworkConfig(['web', 'db', 'cache']));
+
+    // 3 nodes × 2 peers × 2 directions × 2 (rule + icmp twin).
+    expect(rules).toHaveLength(24);
+    expect(rules.some((r) => r.sourceNodeId === r.targetNodeId)).toBe(false);
+  });
+
+  it('never makes a node a peer of itself on a 0.0.0.0/0 rule', async () => {
+    const rules = await compute(makeNetworkConfig(['web']));
+
+    expect(rules).toEqual([]);
+  });
+});
+
+describe('computeSemanticRules — normalization', () => {
+  const withDbRule = (rule: SecurityGroupRuleInput) =>
+    compute(makeNetworkConfig(['web', 'db'], { db: [rule] }));
+
+  const learnerRule = (rules: SemanticRule[]): string[] => blockOf(rules, 'db', 'inbound').slice(0, 1);
+
+  it('lowercases the protocol', async () => {
+    const rules = await withDbRule({ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'web' });
+
+    expect(learnerRule(rules)).toEqual(['web→db tcp/5432 ALLOW inbound (owner db)']);
+  });
+
+  it('defaults a missing action to ALLOW and a missing protocol to all', async () => {
+    const rules = await withDbRule({ type: 'inbound', port: '5432', source: 'web' });
+
+    expect(learnerRule(rules)).toEqual(['web→db all/5432 ALLOW inbound (owner db)']);
+  });
+
+  it('normalizes a missing port and any casing of "all" to ALL', async () => {
+    const missing = await withDbRule({ type: 'inbound', action: 'ALLOW', protocol: 'TCP', source: 'web' });
+    const lowercase = await withDbRule({ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: 'all', source: 'web' });
+
+    expect(learnerRule(missing)).toEqual(['web→db tcp/ALL ALLOW inbound (owner db)']);
+    expect(learnerRule(lowercase)).toEqual(['web→db tcp/ALL ALLOW inbound (owner db)']);
+  });
+
+  it('forces ICMP rules to port ALL even when the canvas carried a port', async () => {
+    const rules = await withDbRule({ type: 'inbound', action: 'ALLOW', protocol: 'ICMP', port: '8080', source: 'web' });
+
+    expect(learnerRule(rules)).toEqual(['web→db icmp/ALL ALLOW inbound (owner db)']);
+  });
+});
+
+describe('computeSemanticRules — the ICMP twin', () => {
+  it('duplicates an all/ALL rule into an icmp twin placed right after it', async () => {
+    const rules = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        db: [{ type: 'inbound', action: 'ALLOW', protocol: 'ALL', port: 'ALL', source: 'web' }],
+      })
+    );
+
+    expect(blockOf(rules, 'db', 'inbound').slice(0, 2)).toEqual([
+      'web→db all/ALL ALLOW inbound (owner db)',
+      'web→db icmp/ALL ALLOW inbound (owner db)',
+    ]);
+  });
+
+  it('emits no twin when the rule names a protocol or a port', async () => {
+    const scopedProtocol = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        db: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: 'ALL', source: 'web' }],
+      })
+    );
+    const scopedPort = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        db: [{ type: 'inbound', action: 'ALLOW', protocol: 'ALL', port: '5432', source: 'web' }],
+      })
+    );
+
+    // The default DENY all/ALL that follows is what carries the only twin here.
+    expect(blockOf(scopedProtocol, 'db', 'inbound').slice(0, 2)).toEqual([
+      'web→db tcp/ALL ALLOW inbound (owner db)',
+      'web→db all/ALL DENY inbound (owner db)',
+    ]);
+    expect(blockOf(scopedPort, 'db', 'inbound').slice(0, 2)).toEqual([
+      'web→db all/5432 ALLOW inbound (owner db)',
+      'web→db all/ALL DENY inbound (owner db)',
+    ]);
+  });
+});
+
+describe('computeSemanticRules — source expansion', () => {
+  const twoSubnets = (learnerRules: Record<string, SecurityGroupRuleInput[]>) =>
+    makeNetworkConfig(['web', 'api', 'db'], learnerRules, {
+      web: 'subnet-public',
+      api: 'subnet-public',
+      db: 'subnet-private',
+    });
+
+  it('expands a subnet source to every node of that subnet', async () => {
+    const rules = await compute(
+      twoSubnets({ db: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'subnet-public' }] })
+    );
+
+    expect(blockOf(rules, 'db', 'inbound').slice(0, 2)).toEqual([
+      'web→db tcp/5432 ALLOW inbound (owner db)',
+      'api→db tcp/5432 ALLOW inbound (owner db)',
+    ]);
+  });
+
+  it('includes the owner itself when it sits in the subnet it names (unlike 0.0.0.0/0)', async () => {
+    const rules = await compute(
+      twoSubnets({ web: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '80', source: 'subnet-public' }] })
+    );
+
+    // The 0.0.0.0/0 branch skips self; the subnet branch does not.
+    expect(blockOf(rules, 'web', 'inbound').slice(0, 2)).toEqual([
+      'web→web tcp/80 ALLOW inbound (owner web)',
+      'api→web tcp/80 ALLOW inbound (owner web)',
+    ]);
+  });
+
+  it('matches subnets exactly, never across subnets', async () => {
+    const rules = await compute(
+      twoSubnets({ web: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '80', source: 'subnet-private' }] })
+    );
+
+    expect(blockOf(rules, 'web', 'inbound').slice(0, 1)).toEqual(['db→web tcp/80 ALLOW inbound (owner web)']);
+  });
+
+  it('treats a subnet id without the "subnet-" prefix as a node id', async () => {
+    // Real configs exist with bare subnet ids ('public'/'private'): they fall
+    // into the node-id branch and produce a single rule against a node that
+    // does not exist, silently matching nothing at enforcement time.
+    const rules = await compute(
+      makeNetworkConfig(['web', 'db'], { db: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'public' }] },
+        { web: 'public', db: 'private' })
+    );
+
+    expect(blockOf(rules, 'db', 'inbound').slice(0, 1)).toEqual(['public→db tcp/5432 ALLOW inbound (owner db)']);
+  });
+
+  it('keeps a rule pointing at an unknown node id as-is', async () => {
+    const rules = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        db: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'deleted-node' }],
+      })
+    );
+
+    expect(blockOf(rules, 'db', 'inbound').slice(0, 1)).toEqual(['deleted-node→db tcp/5432 ALLOW inbound (owner db)']);
+  });
+
+  it('ignores security groups of nodes that are not placed in a subnet', async () => {
+    const config = makeNetworkConfig(['web', 'db']);
+    config.nodeSecurityGroups!['orphan'] = [
+      { type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '22', source: 'web' },
+    ];
+
+    const rules = await compute(config);
+
+    // `nodeSubnetMap` is the node inventory: an unplaced node is never an owner.
+    expect(ownedBy(rules, 'orphan')).toEqual([]);
+  });
+
+  it('expands an outbound rule the same way as an inbound one, with the owner as source', async () => {
+    const rules = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        web: [{ type: 'outbound', action: 'DENY', protocol: 'TCP', port: '5432', source: 'db' }],
+      })
+    );
+
+    expect(blockOf(rules, 'web', 'outbound').slice(0, 1)).toEqual(['web→db tcp/5432 DENY outbound (owner web)']);
+  });
+});
+
+describe('computeSemanticRules — rule order is rule priority', () => {
+  // Enforcement (append-only iptables + final REJECT) and both connectivity
+  // validators walk these rules first-match-wins, so the output order IS the
+  // policy. The UI prepends new rules, hence the DENY-above-ALLOW shape here.
+  const shadowedConfig = makeNetworkConfig(['web', 'cache'], {
+    cache: [
+      { type: 'inbound', action: 'DENY', protocol: 'TCP', port: '6379', source: 'web' },
+      { type: 'inbound', action: 'ALLOW', protocol: 'ALL', port: 'ALL', source: 'web' },
+    ],
+  });
+
+  it('preserves the security group order, so a narrow DENY shadows a later broad ALLOW', async () => {
+    const rules = await compute(shadowedConfig);
+
+    expect(blockOf(rules, 'cache', 'inbound')).toEqual([
+      'web→cache tcp/6379 DENY inbound (owner cache)',
+      'web→cache all/ALL ALLOW inbound (owner cache)',
+      'web→cache icmp/ALL ALLOW inbound (owner cache)',
+      'web→cache all/ALL DENY inbound (owner cache)',
+      'web→cache icmp/ALL DENY inbound (owner cache)',
+    ]);
+  });
+
+  it('places the DENY on 6379 before the ALLOW that would otherwise open it', async () => {
+    const rules = await compute(shadowedConfig);
+    const inbound = rules.filter((r) => r.direction === 'inbound' && r.targetNodeId === 'cache');
+
+    const deny = inbound.findIndex((r) => r.action === 'DENY' && r.port === '6379');
+    const allow = inbound.findIndex((r) => r.action === 'ALLOW' && r.port === 'ALL');
+
+    expect(deny).toBeGreaterThanOrEqual(0);
+    expect(allow).toBeGreaterThan(deny);
+  });
+
+  it('emits a node\'s whole outbound block before its inbound block', async () => {
+    const rules = await compute(makeNetworkConfig(['web', 'db']));
+    const web = rules.filter((r) => r.ownerNodeId === 'web');
+
+    expect(web.findIndex((r) => r.direction === 'inbound')).toBe(
+      web.filter((r) => r.direction === 'outbound').length
+    );
+  });
+});
+
+describe('computeSemanticRules — ASG replicas', () => {
+  const replicaConfig = (): NetworkConfigInput => {
+    const config = makeNetworkConfig(['web', 'replica-a', 'replica-b']);
+    // Rules are authored on the ASG's parent node, which is not itself placed.
+    config.nodeSecurityGroups!['asg-parent'] = [
+      { type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '80', source: 'web' },
+    ];
+    config.asgs = { 'asg-1': { parentId: 'asg-parent' } };
+    return config;
+  };
+
+  it('makes a replica inherit the security group of its ASG parent node', async () => {
+    mockDockerContainers = [
+      makeDockerContainer({ Id: 'replica-a', Labels: { 'akal.asg.id': 'asg-1' } }),
+      makeDockerContainer({ Id: 'replica-b', Labels: { 'akal.asg.id': 'asg-1' } }),
+    ];
+
+    const rules = await compute(replicaConfig());
+
+    expect(ownedBy(rules, 'replica-a')).toEqual(['web→replica-a tcp/80 ALLOW inbound (owner replica-a)']);
+    expect(ownedBy(rules, 'replica-b')).toEqual(['web→replica-b tcp/80 ALLOW inbound (owner replica-b)']);
+  });
+
+  it('matches a replica listed under its short container id', async () => {
+    const config = replicaConfig();
+    config.nodeSubnetMap = { web: 'subnet-public-1', '0123456789ab': 'subnet-public-1' };
+    mockDockerContainers = [
+      makeDockerContainer({ Id: '0123456789abcdef', Labels: { 'akal.asg.id': 'asg-1' } }),
+    ];
+
+    const rules = await compute(config);
+
+    expect(ownedBy(rules, '0123456789ab')).toEqual([
+      'web→0123456789ab tcp/80 ALLOW inbound (owner 0123456789ab)',
+    ]);
+  });
+
+  it('falls back to the default group when the replica has no matching ASG config', async () => {
+    const config = replicaConfig();
+    config.asgs = {}; // scaled while the config was stale
+    mockDockerContainers = [makeDockerContainer({ Id: 'replica-a', Labels: { 'akal.asg.id': 'asg-1' } })];
+
+    const rules = await compute(config);
+
+    // Its own (default) group applies: deny all inbound, allow all outbound.
+    expect(ownedBy(rules, 'replica-a')).toContain('replica-a→web all/ALL ALLOW outbound (owner replica-a)');
+    expect(ownedBy(rules, 'replica-a')).toContain('web→replica-a all/ALL DENY inbound (owner replica-a)');
+  });
+
+  it('inherits the parent group when the ASG boundary node itself is placed on the canvas', async () => {
+    const config = makeNetworkConfig(['web', 'asg-1']);
+    config.nodeSecurityGroups!['asg-parent'] = [
+      { type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '80', source: 'web' },
+    ];
+    config.asgs = { 'asg-1': { parentId: 'asg-parent' } };
+
+    const rules = await compute(config);
+
+    expect(ownedBy(rules, 'asg-1')).toEqual(['web→asg-1 tcp/80 ALLOW inbound (owner asg-1)']);
+  });
+
+  it('expands a rule targeting an ASG into one rule per running replica', async () => {
+    mockDockerContainers = [
+      makeDockerContainer({ Id: 'replica-a', Labels: { 'akal.asg.id': 'asg-1' } }),
+      makeDockerContainer({ Id: 'replica-b', Labels: { 'akal.asg.id': 'asg-1' } }),
+    ];
+
+    const rules = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        db: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'asg-1' }],
+      })
+    );
+
+    expect(blockOf(rules, 'db', 'inbound').slice(0, 2)).toEqual([
+      'replica-a→db tcp/5432 ALLOW inbound (owner db)',
+      'replica-b→db tcp/5432 ALLOW inbound (owner db)',
+    ]);
+  });
+
+  it('leaves stopped replicas out of the expansion', async () => {
+    mockDockerContainers = [
+      makeDockerContainer({ Id: 'replica-a', Labels: { 'akal.asg.id': 'asg-1' } }),
+      makeDockerContainer({ Id: 'replica-b', State: 'exited', Labels: { 'akal.asg.id': 'asg-1' } }),
+    ];
+
+    const rules = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        db: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'asg-1' }],
+      })
+    );
+
+    expect(blockOf(rules, 'db', 'inbound').slice(0, 1)).toEqual(['replica-a→db tcp/5432 ALLOW inbound (owner db)']);
+  });
+
+  it('falls back to the ASG id itself when the group has scaled down to zero', async () => {
+    const rules = await compute(
+      makeNetworkConfig(['web', 'db'], {
+        db: [{ type: 'inbound', action: 'ALLOW', protocol: 'TCP', port: '5432', source: 'asg-1' }],
+      })
+    );
+
+    expect(blockOf(rules, 'db', 'inbound').slice(0, 1)).toEqual(['asg-1→db tcp/5432 ALLOW inbound (owner db)']);
+  });
+});
+
+describe('computeSemanticRules — degenerate configs', () => {
+  it('returns nothing for an empty config', async () => {
+    expect(await compute({})).toEqual([]);
+  });
+
+  it('returns nothing when nodes are placed but carry no security group', async () => {
+    expect(await compute({ nodeSubnetMap: { web: 'subnet-public-1', db: 'subnet-public-1' } })).toEqual([]);
+  });
+
+  it('returns nothing when the security groups are empty arrays', async () => {
+    expect(
+      await compute({
+        nodeSubnetMap: { web: 'subnet-public-1', db: 'subnet-public-1' },
+        nodeSecurityGroups: { web: [], db: [] },
+      })
+    ).toEqual([]);
+  });
+});

--- a/backend/src/modules/network/services/networkService.ts
+++ b/backend/src/modules/network/services/networkService.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { SemanticRule } from '../models/networkPolicy';
+import { NetworkConfigInput, SemanticRule } from '../models/networkPolicy';
 import { EnforcementPlanner } from '../planner/enforcementPlanner';
 import { VirtualNetworkMapper } from '../mapper/virtualNetworkMapper';
 import { DockerNetworkProvider } from '../providers/dockerNetworkProvider';
@@ -16,7 +16,7 @@ export class NetworkService {
     console.log(`[NetworkService] Cleared policy hash cache for project: ${projectId}`);
   }
 
-  public static applyPolicy(projectId: string, config: any): Promise<void> {
+  public static applyPolicy(projectId: string, config: NetworkConfigInput): Promise<void> {
     const currentQueue = this.taskQueues[projectId] || Promise.resolve();
 
     const nextTask = currentQueue.then(async () => {
@@ -57,7 +57,7 @@ export class NetworkService {
     return nextTask;
   }
 
-  public static async cleanupProjectNetwork(projectId: string, config: any): Promise<void> {
+  public static async cleanupProjectNetwork(projectId: string, config: NetworkConfigInput): Promise<void> {
     const nodeIds = Object.keys(config.nodeSubnetMap || {});
     const endpoints = VirtualNetworkMapper.mapNodesToEndpoints(projectId, nodeIds);
     await this.provider.cleanupProjectPolicies(projectId, endpoints);
@@ -70,9 +70,10 @@ export class NetworkService {
    * X reach Y" — reused by the learning engine's `edge_exists`/`port_denied`
    * validators so they never re-derive connectivity from raw security groups.
    */
-  public static async computeSemanticRules(projectId: string, config: any): Promise<SemanticRule[]> {
+  public static async computeSemanticRules(projectId: string, config: NetworkConfigInput): Promise<SemanticRule[]> {
     const rules: SemanticRule[] = [];
-    const nodeIds = Object.keys(config.nodeSubnetMap || {});
+    const nodeSubnetMap = config.nodeSubnetMap || {};
+    const nodeIds = Object.keys(nodeSubnetMap);
     const sgs = config.nodeSecurityGroups || {};
 
     // Gather all active ASG replica containers and match them to their ASG configurations
@@ -154,7 +155,7 @@ export class NetworkService {
           } else if (sgRule.source.startsWith('subnet-')) {
             // Outbound to subnet
             for (const dstNodeId of nodeIds) {
-              if (config.nodeSubnetMap[dstNodeId] === sgRule.source) {
+              if (nodeSubnetMap[dstNodeId] === sgRule.source) {
                 addOutboundRule(dstNodeId);
               }
             }
@@ -208,7 +209,7 @@ export class NetworkService {
           } else if (sgRule.source.startsWith('subnet-')) {
             // Inbound from subnet
             for (const dstNodeId of nodeIds) {
-              if (config.nodeSubnetMap[dstNodeId] === sgRule.source) {
+              if (nodeSubnetMap[dstNodeId] === sgRule.source) {
                 addInboundRule(dstNodeId);
               }
             }

--- a/backend/src/modules/network/testSupport.ts
+++ b/backend/src/modules/network/testSupport.ts
@@ -1,0 +1,55 @@
+import { NetworkConfigInput, SecurityGroupRuleInput } from './models/networkPolicy';
+
+/**
+ * Shared network fixtures for tests — not a test file itself (no `*.test.ts`
+ * suffix). Lives in the network module because the config shape belongs here;
+ * the learning validators re-export these (`learning/engine/validators/testSupport`).
+ *
+ * Fixtures must stay *realistic*: hand-picked configs that only contain the
+ * rule under test quietly confirm whatever the code does. Every node sits in a
+ * subnet and carries the default security group, exactly like a canvas save.
+ */
+
+/**
+ * The default security group every node gets when dropped on the canvas —
+ * mirror of `createDefaultRules` (frontend `CanvasPage/utils/securityRules.ts`):
+ * deny all inbound, allow all outbound.
+ */
+export function makeDefaultSgRules(): SecurityGroupRuleInput[] {
+  return [
+    { type: 'inbound', action: 'DENY', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
+    { type: 'outbound', action: 'ALLOW', protocol: 'ALL', port: 'ALL', source: '0.0.0.0/0' },
+  ];
+}
+
+/**
+ * A realistic applied network config: every node sits in a subnet and carries
+ * the default security group, with the learner's rules prepended — the UI
+ * always inserts new rules at the top (highest first-match priority).
+ */
+export function makeNetworkConfig(
+  nodeIds: string[],
+  learnerRules: Record<string, SecurityGroupRuleInput[]> = {},
+  subnetOf: Record<string, string> = {}
+): NetworkConfigInput {
+  const nodeSubnetMap: Record<string, string> = {};
+  const nodeSecurityGroups: Record<string, SecurityGroupRuleInput[]> = {};
+  for (const nodeId of nodeIds) {
+    nodeSubnetMap[nodeId] = subnetOf[nodeId] ?? 'subnet-public-1';
+    nodeSecurityGroups[nodeId] = [...(learnerRules[nodeId] ?? []), ...makeDefaultSgRules()];
+  }
+  return { nodeSubnetMap, nodeSecurityGroups };
+}
+
+/** Minimal Dockerode `ContainerInfo` shape, as `computeSemanticRules` reads it. */
+export interface DockerContainerFixture {
+  Id: string;
+  State: string;
+  Labels: Record<string, string>;
+}
+
+export function makeDockerContainer(
+  overrides: Partial<DockerContainerFixture> & { Id: string }
+): DockerContainerFixture {
+  return { State: 'running', Labels: {}, ...overrides };
+}


### PR DESCRIPTION
## Summary of Changes

`NetworkService.computeSemanticRules` is the single source of truth for "can X reach Y": it expands the canvas security groups into pairwise semantic rules, and its output feeds both the real iptables enforcement (`EnforcementPlanner` → `DockerNetworkProvider`) and the learning validators `edge_exists` / `port_denied`. It had no dedicated test; neither did `EnforcementPlanner`.

This PR adds that safety net, with **no behaviour change**:

- **`networkService.test.ts` (34 cases)** — default security groups, normalization (protocol casing, missing port/action, ICMP forcing port `ALL`), the ICMP twin of `ALL/ALL` rules, the three `source` expansion branches (`0.0.0.0/0`, `subnet-…`, node id), nodes not placed in a subnet, ASG replicas (parent-group inheritance, short container ids, running-only expansion, scaled-to-zero fallback), and degenerate configs.
- **Rule order is rule priority.** Enforcement and both validators walk these rules first-match-wins, so the output order *is* the policy. Several cases pin it explicitly (a narrow `DENY` prepended by the UI must shadow a later broad `ALLOW`). Reversing the rule iteration in `computeSemanticRules` makes 15 tests fail.
- **`enforcementPlanner.test.ts` (7 cases)** — 1:1 intent mapping, fail-closed on anything that is not exactly `ALLOW`, field pass-through, order preserved, terminal zero-trust `DENY_ALL` always appended last.
- **`virtualNetworkMapper.test.ts` (+3 cases)** — empty project, already-safe id, and the documented sanitization collision.
- **Fixtures are realistic, never hand-built rules.** Every config puts each node in a subnet with the canvas default group (deny all inbound / allow all outbound) and prepends the learner's rules, like the UI does — self-confirming fixtures have hidden real false-pass bugs before. The existing fixtures (`makeDefaultSgRules`, `makeNetworkConfig`) moved from the learning validators' `testSupport` to a new `modules/network/testSupport.ts`, where the config shape belongs; the learning `testSupport` re-exports them, so no validator test changed.

Typing, along the way and without touching behaviour: new `SecurityGroupRuleInput` / `NetworkConfigInput` in `models/networkPolicy.ts`, applied to the three `config: any` of `NetworkService`; `ValidatorNetworkConfig` now extends `NetworkConfigInput` instead of duplicating it with `unknown[]`. `dockerNetworkProvider.ts` is deliberately left untyped — out of scope here.

## Types of Changes

- [ ] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [x] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

### Manual Verification

- `npm test` (backend): **439 tests / 37 suites green**, up from 395.
- Mutation check: reversing the inbound rule iteration in `computeSemanticRules` fails 15 of the new cases; reverted.
- Non-regression against **real Docker** (no behaviour change to the enforcement path):
  - `npx jest --config jest.integration.config.js src/modules/network/interSubnet.itest.ts` → 5/5 green
  - `npx jest --config jest.integration.config.js src/modules/learning/engine/engine.itest.ts` → 20/20 green

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
