### PR TITLE
fix(terminal): broken/unknown characters rendered in terminal shell

### DIFF
--- a/backend/src/infrastructure/docker/TerminalManager.test.ts
+++ b/backend/src/infrastructure/docker/TerminalManager.test.ts
@@ -1,0 +1,41 @@
+import { PassThrough } from 'stream';
+import docker from './DockerClient';
+import { TerminalManager } from './TerminalManager';
+
+jest.mock('./DockerClient', () => ({
+  __esModule: true,
+  default: {
+    getContainer: jest.fn()
+  }
+}));
+
+const mockedDocker = docker as jest.Mocked<typeof docker>;
+
+describe('TerminalManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts an interactive exec as a raw TTY stream', async () => {
+    const stream = new PassThrough();
+    const start = jest.fn((_options, callback) => callback(null, stream));
+    const exec = { start };
+    const createExec = jest.fn().mockResolvedValue(exec);
+    (mockedDocker.getContainer as jest.Mock).mockReturnValue({ exec: createExec });
+
+    const session = await TerminalManager.createTerminalSession('container-1');
+
+    expect(createExec).toHaveBeenCalledWith({
+      Cmd: ['/bin/bash'],
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: true
+    });
+    expect(start).toHaveBeenCalledWith(
+      { hijack: true, stdin: true, Tty: true },
+      expect.any(Function)
+    );
+    expect(session).toEqual({ stream, exec });
+  });
+});

--- a/backend/src/infrastructure/docker/TerminalManager.ts
+++ b/backend/src/infrastructure/docker/TerminalManager.ts
@@ -18,7 +18,7 @@ export class TerminalManager {
     });
 
     const stream = await new Promise<NodeJS.ReadWriteStream>((resolve, reject) => {
-      exec.start({ hijack: true, stdin: true }, (err, execStream) => {
+      exec.start({ hijack: true, stdin: true, Tty: true }, (err, execStream) => {
         if (err || !execStream) return reject(err || new Error('Failed to start terminal stream'));
         resolve(execStream);
       });


### PR DESCRIPTION
## Summary of Changes

An image would describe this best:

<img width="922" height="604" alt="image" src="https://github.com/user-attachments/assets/d2b4715f-3059-4898-a1f8-f5a450728966" />

TTY was enabled on creation but not on startup. Apparently those are treated separately, and thus this behavior occurred. Should not be the case anymore, at least according to my testing.

## Types of Changes

- [ ] New feature / node type addition
- [X] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [ ] Documentation update

## Verification & Testing
### Automated Checks
- [X] Run `npm run lint` successfully with no errors
- [X] Run `npm run build` successfully with no compilation errors
- [X] Run `npm test` successfully (all tests pass)

### Manual Verification

Did same behavior to produce the bug. File rendered correctly on nano.

## Checklist

- [X] My code follows the repository's code style and lint standards
- [ ] I have updated the documentation or instructions if necessary
- [X] All unit and integration tests are passing 