### PR TITLE
feat(learning): roadmap completion screen with share post and next-roadmap flow

### DIFF
--- a/backend/src/modules/learning/services/progressService.test.ts
+++ b/backend/src/modules/learning/services/progressService.test.ts
@@ -62,6 +62,36 @@ describe('ProgressService', () => {
     expect(progress.steps['step-a']).toEqual({ passed: false, attempts: 0, revealedHints: 3 });
   });
 
+  it('stamps startedAt when the play-through begins and never moves it', () => {
+    ProgressService.recordValidation('project-1', 'roadmap-1', 'step-a', false, '2026-07-16T10:00:00.000Z', file);
+    const startedAt = ProgressService.getProgress('project-1', 'roadmap-1', file).startedAt;
+    expect(typeof startedAt).toBe('string');
+
+    ProgressService.recordValidation('project-1', 'roadmap-1', 'step-b', true, '2026-07-16T11:00:00.000Z', file);
+    ProgressService.recordRevealedHints('project-1', 'roadmap-1', 'step-a', 1, file);
+
+    expect(ProgressService.getProgress('project-1', 'roadmap-1', file).startedAt).toBe(startedAt);
+  });
+
+  it('leaves startedAt absent on entries written before the field existed', () => {
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            projectId: 'project-1',
+            roadmapId: 'roadmap-1',
+            updatedAt: '2026-07-16T10:00:00.000Z',
+            steps: { 'step-a': { passed: true, attempts: 1, revealedHints: 0 } },
+          },
+        ],
+      })
+    );
+
+    expect(ProgressService.getProgress('project-1', 'roadmap-1', file).startedAt).toBeUndefined();
+  });
+
   it('keys steps by stable id, independent of any ordering', () => {
     ProgressService.recordValidation('project-1', 'roadmap-1', 'step-c', true, '2026-07-16T10:00:00.000Z', file);
     ProgressService.recordValidation('project-1', 'roadmap-1', 'step-a', true, '2026-07-16T10:01:00.000Z', file);

--- a/backend/src/modules/learning/services/progressService.ts
+++ b/backend/src/modules/learning/services/progressService.ts
@@ -18,6 +18,8 @@ export interface StepProgress {
 export interface ProgressEntry {
   projectId: string;
   roadmapId: string;
+  /** ISO timestamp of the entry's creation — when the play-through began. Absent on entries written before it existed. */
+  startedAt?: string;
   updatedAt: string;
   steps: Record<string, StepProgress>;
 }
@@ -45,6 +47,8 @@ export interface ProgressEntrySummary {
 export interface RoadmapProgressResponse {
   projectId: string;
   roadmapId: string;
+  /** When this play-through began — absent when it hasn't started, or predates the field. */
+  startedAt?: string;
   steps: Record<string, StepProgress>;
   /** Present (true) once after an unreadable store was moved aside — the UI should tell the user. */
   storeRecovered?: boolean;
@@ -85,6 +89,9 @@ export class ProgressService {
     const store = this.readStore(filePath);
     const entry = store.entries.find(e => e.projectId === projectId && e.roadmapId === roadmapId);
     const response: RoadmapProgressResponse = { projectId, roadmapId, steps: entry?.steps ?? {} };
+    if (entry?.startedAt) {
+      response.startedAt = entry.startedAt;
+    }
     if (this.storeRecovered) {
       response.storeRecovered = true;
       this.storeRecovered = false;
@@ -165,7 +172,7 @@ export class ProgressService {
   ): StepProgress {
     let entry = store.entries.find(e => e.projectId === projectId && e.roadmapId === roadmapId);
     if (!entry) {
-      entry = { projectId, roadmapId, updatedAt: '', steps: {} };
+      entry = { projectId, roadmapId, startedAt: new Date().toISOString(), updatedAt: '', steps: {} };
       store.entries.push(entry);
     }
     entry.updatedAt = new Date().toISOString();

--- a/docs/learning-api.md
+++ b/docs/learning-api.md
@@ -99,6 +99,7 @@ Roadmap progression is persisted locally in `~/.torollo/progress.json`, next to 
     {
       "projectId": "project-1751883322290",
       "roadmapId": "resilient-three-tier",
+      "startedAt": "2026-07-16T19:42:03.000Z",
       "updatedAt": "2026-07-16T20:11:00.000Z",
       "steps": {
         "first-server": {
@@ -113,7 +114,7 @@ Roadmap progression is persisted locally in `~/.torollo/progress.json`, next to 
 }
 ```
 
-`passed` is the verdict of the **latest** validation (same semantics as the player's in-session display); `attempts` counts the validation runs that reached evaluation; `revealedHints` is the absolute number of revealed rungs on the step's hint ladder `[...hints, solution?]`. Validator results are deliberately **not** persisted — they describe a past container state; only the verdict survives. The top-level `version` is the migration contract: a reader that finds an unknown version (or an unparseable file) must not guess — the server moves the file aside as `progress.json.corrupt`, starts fresh, and reports it once via `storeRecovered` on the next progress read so the UI can tell the user. Writes are write-then-rename, so a crash mid-write cannot truncate the store. Deleting a project deletes its progress entries.
+`passed` is the verdict of the **latest** validation (same semantics as the player's in-session display); `attempts` counts the validation runs that reached evaluation; `revealedHints` is the absolute number of revealed rungs on the step's hint ladder `[...hints, solution?]`; `startedAt` is stamped when the entry is created — i.e. on the play-through's first recorded activity — and never moves (absent on entries written before the field existed). Validator results are deliberately **not** persisted — they describe a past container state; only the verdict survives. The top-level `version` is the migration contract: a reader that finds an unknown version (or an unparseable file) must not guess — the server moves the file aside as `progress.json.corrupt`, starts fresh, and reports it once via `storeRecovered` on the next progress read so the UI can tell the user. Writes are write-then-rename, so a crash mid-write cannot truncate the store. Deleting a project deletes its progress entries.
 
 ### `GET /api/learning/progress`
 
@@ -121,7 +122,7 @@ Returns `{ "entries": [ { "projectId", "roadmapId", "updatedAt", "completedSteps
 
 ### `GET /api/learning/progress/:projectId/:roadmapId`
 
-Returns `{ projectId, roadmapId, steps }` — `steps` is the per-step record above, `{}` when nothing was ever recorded. `storeRecovered: true` is present once after a corrupt/unknown-version store was discarded. The player calls this when opening a roadmap and resumes on the first step whose `passed` is not true.
+Returns `{ projectId, roadmapId, steps }` — `steps` is the per-step record above, `{}` when nothing was ever recorded. `startedAt` is present when the entry exists and carries the field. `storeRecovered: true` is present once after a corrupt/unknown-version store was discarded. The player calls this when opening a roadmap and resumes on the first step whose `passed` is not true.
 
 ### `PUT /api/learning/progress/:projectId/:roadmapId/hints`
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import CanvasPage from '../pages/CanvasPage/CanvasPage';
 import TerminalModal from '../features/terminal/components/TerminalModal';
 import ProjectsPage from '../pages/ProjectsPage/ProjectsPage';
-import type { LearningIntent, ProjectInfo, TerminalInfo } from '../shared/types';
+import type { LearningExit, LearningIntent, ProjectInfo, TerminalInfo } from '../shared/types';
 
 function App() {
   const [activeProject, setActiveProject] = useState<ProjectInfo | null>(() => {
@@ -17,6 +17,9 @@ function App() {
   // Session-only, deliberately not persisted: a reload must never replay
   // an "open the learning panel" intent from a past navigation.
   const [learningIntent, setLearningIntent] = useState<LearningIntent | null>(null);
+  // Reverse direction, same rule: where the home shell should land when the
+  // completion screen sends the learner out of the canvas.
+  const [learningExit, setLearningExit] = useState<LearningExit | null>(null);
 
   const handleSelectProject = (project: ProjectInfo | null) => {
     setActiveProject(project);
@@ -31,6 +34,8 @@ function App() {
     <div style={{ height: '100vh', width: '100vw', display: 'flex', flexDirection: 'column' }}>
       {!activeProject ? (
         <ProjectsPage
+          initialLearning={learningExit}
+          onInitialLearningConsumed={() => setLearningExit(null)}
           onSelectProject={(id, name, intent) => {
             setLearningIntent(intent ?? null);
             handleSelectProject({ id, name });
@@ -43,6 +48,11 @@ function App() {
           initialLearning={learningIntent}
           onLearningIntentConsumed={() => setLearningIntent(null)}
           onBackToProjects={() => {
+            handleSelectProject(null);
+            setActiveTerminal(null);
+          }}
+          onExitToLearning={target => {
+            setLearningExit(target);
             handleSelectProject(null);
             setActiveTerminal(null);
           }}

--- a/frontend/src/features/learning/components/LearningPanel.tsx
+++ b/frontend/src/features/learning/components/LearningPanel.tsx
@@ -4,14 +4,18 @@ import { GraduationCap, X } from 'lucide-react';
 import { useLearningPlayer } from '../hooks/useLearningPlayer';
 import RoadmapCatalog from './RoadmapCatalog';
 import RoadmapPlayer from './RoadmapPlayer';
-import type { ContainerData } from '../../../shared/types';
+import type { ContainerData, LearningExit } from '../../../shared/types';
 import type { NetworkConfig } from '../../../shared/types/network';
 
 interface LearningPanelProps {
   projectId: string;
+  /** Name of the project — shown on the completion receipt. */
+  projectName?: string;
   /** Deep-link from the landing page: open directly on this roadmap. One-shot, consumed on mount. */
   initialRoadmap?: { id: string; language: string } | null;
   onClose: () => void;
+  /** Leave the canvas for the home shell (completion screen's navigation). */
+  onExit?: (target: LearningExit) => void;
   containers?: ContainerData[];
   networkConfig?: NetworkConfig;
 }
@@ -23,8 +27,10 @@ interface LearningPanelProps {
  */
 export default function LearningPanel({
   projectId,
+  projectName,
   initialRoadmap,
   onClose,
+  onExit,
   containers = [],
   networkConfig = {
     vpcConfig: { name: '', cidr: '' },
@@ -65,6 +71,8 @@ export default function LearningPanel({
             player={player}
             containers={containers}
             networkConfig={networkConfig}
+            projectName={projectName}
+            onExit={onExit}
           />
         ) : player.roadmapLoading ? (
           <div style={styles.loading}>{t('learning.player.loading')}</div>

--- a/frontend/src/features/learning/components/RoadmapCompletionScreen.test.tsx
+++ b/frontend/src/features/learning/components/RoadmapCompletionScreen.test.tsx
@@ -1,0 +1,178 @@
+import '../../../i18n';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RoadmapCompletionScreen from './RoadmapCompletionScreen';
+import type { Roadmap, RoadmapSummary } from '../../../shared/types/roadmap';
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as Response;
+}
+
+const roadmap: Roadmap = {
+  schemaVersion: 1,
+  id: 'example-first-architecture',
+  title: 'Your first architecture',
+  description: 'Build a minimal two-tier architecture.',
+  language: 'en',
+  steps: [
+    {
+      id: 'create-web-server',
+      title: 'Create the web server',
+      instruction: 'Drag an Ubuntu node named `web` onto the canvas.',
+      validators: [{ type: 'container_running', params: { node: 'web' } }],
+    },
+    {
+      id: 'add-database',
+      title: 'Add the database',
+      instruction: 'Add a Postgres node named `db`.',
+      validators: [{ type: 'table_exists', params: { node: 'db', table: 'invoices' } }],
+    },
+  ],
+};
+
+const currentSummary: RoadmapSummary = {
+  id: roadmap.id,
+  title: roadmap.title,
+  description: roadmap.description,
+  language: 'en',
+  stepCount: 2,
+};
+
+const otherSummary: RoadmapSummary = {
+  id: 'resilient-three-tier',
+  title: 'Deploy a resilient three-tier app',
+  description: 'LB, app fleet, database.',
+  language: 'en',
+  stepCount: 10,
+};
+
+describe('RoadmapCompletionScreen', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let writeText: ReturnType<typeof vi.fn>;
+
+  function mockApi({
+    summaries = [currentSummary, otherSummary],
+    entries = [] as unknown[],
+  } = {}) {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/api/learning/progress')) {
+        return Promise.resolve(jsonResponse(true, { entries }));
+      }
+      if (url.includes('/api/learning/roadmaps')) {
+        return Promise.resolve(jsonResponse(true, summaries));
+      }
+      return Promise.resolve(jsonResponse(true, {}));
+    });
+  }
+
+  function renderScreen({ onDismiss = vi.fn(), onExit = vi.fn() } = {}) {
+    render(
+      <RoadmapCompletionScreen
+        roadmap={roadmap}
+        projectName="My first lab"
+        runTimes={{ startedAt: '2026-07-15T09:00:00.000Z', finishedAt: '2026-07-15T09:45:00.000Z' }}
+        onDismiss={onDismiss}
+        onExit={onExit}
+      />
+    );
+    return { onDismiss, onExit };
+  }
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the celebration: title, run receipt, steps recap and derived skills', async () => {
+    mockApi();
+    renderScreen();
+
+    expect(screen.getByText('Your first architecture')).toBeInTheDocument();
+    expect(
+      screen.getByText('Every step passed against your running containers.')
+    ).toBeInTheDocument();
+
+    // The receipt states the real run, not a paraphrase.
+    expect(screen.getByText('roadmap: example-first-architecture')).toBeInTheDocument();
+    expect(screen.getByText('project: My first lab')).toBeInTheDocument();
+    expect(screen.getByText('steps: 2/2 passed')).toBeInTheDocument();
+    expect(screen.getByText(/^started: /)).toBeInTheDocument();
+    expect(screen.getByText(/^finished: /)).toBeInTheDocument();
+
+    // Every step, with its position — the recap is the roadmap's own outline.
+    expect(screen.getByText('Create the web server')).toBeInTheDocument();
+    expect(screen.getByText('Add the database')).toBeInTheDocument();
+
+    // Skills come off the validators (container_running → Containers, table_exists → SQL).
+    expect(screen.getByText('Containers')).toBeInTheDocument();
+    expect(screen.getByText('SQL')).toBeInTheDocument();
+
+    expect(await screen.findByText('Next roadmap')).toBeInTheDocument();
+  });
+
+  it('copies a share post that can be pasted as-is', async () => {
+    mockApi();
+    renderScreen();
+
+    fireEvent.click(screen.getByText('Copy share post'));
+
+    expect(writeText).toHaveBeenCalledWith(
+      'I just completed “Your first architecture” on Torollo — 2/2 steps verified against real Docker containers running on my machine. Free and open source: torollo.app'
+    );
+    expect(await screen.findByText('Copied — paste it anywhere')).toBeInTheDocument();
+  });
+
+  it('routes "Next roadmap" to the first unstarted roadmap of the catalogue', async () => {
+    mockApi();
+    const { onExit } = renderScreen();
+
+    fireEvent.click(await screen.findByText('Next roadmap'));
+
+    expect(onExit).toHaveBeenCalledWith({ kind: 'roadmap', summary: otherSummary });
+  });
+
+  it('skips roadmaps already finished and prefers an unstarted one', async () => {
+    const third: RoadmapSummary = { ...otherSummary, id: 'redis-queue-workers', title: 'Queue it' };
+    mockApi({
+      summaries: [currentSummary, otherSummary, third],
+      entries: [
+        // otherSummary is finished (10/10) — the next win is the untouched one.
+        { projectId: 'p1', roadmapId: otherSummary.id, updatedAt: '2026-07-15T09:00:00.000Z', completedSteps: 10 },
+      ],
+    });
+    const { onExit } = renderScreen();
+
+    fireEvent.click(await screen.findByText('Next roadmap'));
+
+    expect(onExit).toHaveBeenCalledWith({ kind: 'roadmap', summary: third });
+  });
+
+  it('falls back to the catalogue with a note when every roadmap is done', async () => {
+    mockApi({ summaries: [currentSummary] });
+    const { onExit } = renderScreen();
+
+    expect(
+      await screen.findByText(/That's every roadmap in the catalogue for now/)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('All roadmaps'));
+    expect(onExit).toHaveBeenCalledWith({ kind: 'catalog' });
+  });
+
+  it('returns to the canvas through the keep-building link', async () => {
+    mockApi();
+    const { onDismiss } = renderScreen();
+
+    fireEvent.click(screen.getByText('Keep building'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/features/learning/components/RoadmapCompletionScreen.tsx
+++ b/frontend/src/features/learning/components/RoadmapCompletionScreen.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Info, X } from 'lucide-react';
+import Modal from '../../../shared/components/Modal';
+import Button from '../../../shared/components/Button';
+import Skeleton from '../../../shared/components/Skeleton';
+import Receipt from '../../../shared/components/Receipt';
+import { deriveTopology } from '../roadmapTopology';
+import { filterByUiLanguage } from '../roadmapLanguage';
+import { useRoadmaps } from '../hooks/useRoadmaps';
+import { useLearningProgressSummaries } from '../hooks/useLearningProgressSummaries';
+import type { RunTimes } from '../hooks/useLearningPlayer';
+import type { LearningExit } from '../../../shared/types';
+import type { Roadmap, RoadmapSummary } from '../../../shared/types/roadmap';
+
+interface RoadmapCompletionScreenProps {
+  roadmap: Roadmap;
+  /** Name of the project the run was validated against, when known. */
+  projectName?: string;
+  runTimes: RunTimes;
+  /** Back to the canvas — the learner's containers keep running. */
+  onDismiss: () => void;
+  /** Leave the canvas for the home shell: next roadmap's briefing or the catalogue. */
+  onExit: (target: LearningExit) => void;
+}
+
+/**
+ * The celebration at the end of a roadmap, and the only screen built for
+ * leaving Torollo: everything on it is something the learner can carry out —
+ * a receipt of the real run, a share post to paste as-is, the next roadmap.
+ * All facts are read off the roadmap file and the persisted run; the skills
+ * come from the same validator derivation as the briefing page.
+ */
+export default function RoadmapCompletionScreen({
+  roadmap,
+  projectName,
+  runTimes,
+  onDismiss,
+  onExit,
+}: RoadmapCompletionScreenProps) {
+  const { t, i18n } = useTranslation();
+  const catalogue = useRoadmaps();
+  const progress = useLearningProgressSummaries();
+  const [shareCopied, setShareCopied] = useState(false);
+  const shareResetRef = useRef<number | undefined>(undefined);
+
+  const fetchRoadmaps = catalogue.fetchRoadmaps;
+  const fetchProgress = progress.fetchProgress;
+  useEffect(() => {
+    fetchRoadmaps();
+    fetchProgress();
+  }, [fetchRoadmaps, fetchProgress]);
+  useEffect(() => () => window.clearTimeout(shareResetRef.current), []);
+
+  const skills = useMemo(() => deriveTopology(roadmap).skills, [roadmap]);
+
+  // "Next" follows the catalogue's curated order: the first roadmap the
+  // learner hasn't started, then the first they haven't finished. Progress is
+  // a garnish — if its fetch failed, every candidate just counts as fresh.
+  const nextResolved = !catalogue.loading && !progress.loading;
+  const nextRoadmap: RoadmapSummary | undefined = useMemo(() => {
+    const candidates = filterByUiLanguage(catalogue.summaries, i18n.language).filter(
+      summary => summary.id !== roadmap.id
+    );
+    return (
+      candidates.find(summary => !progress.byRoadmapId[summary.id]) ??
+      candidates.find(
+        summary => (progress.byRoadmapId[summary.id]?.completedSteps ?? 0) < summary.stepCount
+      )
+    );
+  }, [catalogue.summaries, progress.byRoadmapId, i18n.language, roadmap.id]);
+
+  const formatWhen = (iso: string): string | null => {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return null;
+    return new Intl.DateTimeFormat(i18n.language, {
+      day: 'numeric',
+      month: 'short',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(date);
+  };
+
+  const total = roadmap.steps.length;
+  const startedWhen = runTimes.startedAt ? formatWhen(runTimes.startedAt) : null;
+  const finishedWhen = runTimes.finishedAt ? formatWhen(runTimes.finishedAt) : null;
+  const receiptLines = [
+    t('learning.player.completion.runLineRoadmap', { id: roadmap.id }),
+    ...(projectName ? [t('learning.player.completion.runLineProject', { name: projectName })] : []),
+    t('learning.player.completion.runLineSteps', { total }),
+    ...(startedWhen ? [t('learning.player.completion.runLineStarted', { when: startedWhen })] : []),
+    ...(finishedWhen ? [t('learning.player.completion.runLineFinished', { when: finishedWhen })] : []),
+  ];
+
+  const handleCopyShare = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        t('learning.player.completion.shareText', { title: roadmap.title, total })
+      );
+      setShareCopied(true);
+      window.clearTimeout(shareResetRef.current);
+      shareResetRef.current = window.setTimeout(() => setShareCopied(false), 2000);
+    } catch {
+      // Clipboard access denied — the button simply stays in its idle state.
+    }
+  };
+
+  // Column-major like a printed checklist: steps 1..k down the left column,
+  // the rest down the right, so the recap reads in roadmap order.
+  const recapRows = Math.ceil(total / 2);
+
+  return (
+    <Modal onClose={onDismiss} width="608px">
+      <div style={styles.screen}>
+        <div style={styles.eyebrowRow}>
+          <span style={styles.eyebrow}>{t('learning.player.completion.eyebrow')}</span>
+          <button
+            onClick={onDismiss}
+            style={styles.closeBtn}
+            aria-label={t('learning.player.dismissNotice')}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div style={styles.titleRow}>
+          <h2 style={styles.title}>{roadmap.title}</h2>
+          <span style={styles.titleDisc} role="img" aria-label={t('learning.player.completion.eyebrow')}>
+            <Check size={13} color="#FFFFFF" strokeWidth={3} />
+          </span>
+        </div>
+        <p style={styles.subtitle}>{t('learning.player.completion.subtitle')}</p>
+
+        <Receipt
+          label={t('learning.player.completion.runLabel')}
+          lines={receiptLines}
+          copyText={receiptLines.join('\n')}
+        />
+
+        <div style={styles.section}>
+          <span style={styles.sectionLabel}>{t('learning.player.completion.stepsRecap')}</span>
+          <div
+            style={{
+              ...styles.recapGrid,
+              gridTemplateRows: `repeat(${recapRows}, auto)`,
+            }}
+          >
+            {roadmap.steps.map((step, index) => (
+              <div key={step.id} style={styles.recapItem}>
+                <Check size={12} strokeWidth={2.5} color="var(--color-success)" style={styles.recapGlyph} />
+                <span style={styles.recapIndex}>{index + 1}.</span>
+                <span style={styles.recapTitle}>{step.title}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {skills.length > 0 && (
+          <div style={styles.section}>
+            <span style={styles.sectionLabel}>{t('learning.player.completion.skills')}</span>
+            <div style={styles.skillRow}>
+              {skills.map(skill => (
+                <span key={skill} style={styles.skillChip}>
+                  {t(`learning.detail.skill.${skill}`)}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {nextResolved && !nextRoadmap && (
+          <div style={styles.noteBox}>
+            <Info size={13} color="var(--color-text-muted)" style={{ flexShrink: 0, marginTop: 2 }} />
+            <span style={styles.noteText}>{t('learning.player.completion.catalogueDone')}</span>
+          </div>
+        )}
+
+        <div style={styles.footer}>
+          <Button variant="primary" onClick={handleCopyShare}>
+            {shareCopied
+              ? t('learning.player.completion.copiedShare')
+              : t('learning.player.completion.copyShare')}
+          </Button>
+          {nextResolved ? (
+            <Button
+              onClick={() =>
+                nextRoadmap
+                  ? onExit({ kind: 'roadmap', summary: nextRoadmap })
+                  : onExit({ kind: 'catalog' })
+              }
+            >
+              {nextRoadmap
+                ? t('learning.player.completion.nextRoadmap')
+                : t('learning.player.completion.allRoadmaps')}
+            </Button>
+          ) : (
+            <Skeleton height="36px" width="132px" />
+          )}
+          <div style={styles.keepBuilding}>
+            <button onClick={onDismiss} style={styles.keepBuildingLink}>
+              {t('learning.player.completion.keepBuilding')}
+            </button>
+            <span style={styles.keepBuildingHint}>
+              {t('learning.player.completion.keepBuildingHint')}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  screen: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-4)',
+  },
+  eyebrowRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  eyebrow: {
+    fontSize: 'var(--text-xs)',
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: '0.8px',
+    color: 'var(--color-text-muted)',
+  },
+  closeBtn: {
+    display: 'flex',
+    padding: '4px',
+    margin: '-4px -4px 0 0',
+    border: 'none',
+    background: 'none',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+  },
+  titleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--space-3)',
+  },
+  title: {
+    margin: 0,
+    fontSize: 'var(--text-2xl)',
+    fontWeight: 700,
+    color: 'var(--color-text-primary)',
+    letterSpacing: '-0.3px',
+    lineHeight: 1.25,
+  },
+  titleDisc: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '22px',
+    height: '22px',
+    borderRadius: '50%',
+    backgroundColor: 'var(--color-success)',
+    flexShrink: 0,
+  },
+  subtitle: {
+    margin: 'calc(-1 * var(--space-2)) 0 0',
+    fontSize: 'var(--text-md)',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.5,
+  },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-2)',
+  },
+  sectionLabel: {
+    fontSize: 'var(--text-xs)',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+    color: 'var(--color-text-muted)',
+  },
+  recapGrid: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridAutoFlow: 'column',
+    columnGap: 'var(--space-5)',
+    rowGap: 'var(--space-1)',
+  },
+  recapItem: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: 'var(--space-2)',
+    minWidth: 0,
+  },
+  recapGlyph: {
+    alignSelf: 'center',
+    flexShrink: 0,
+  },
+  recapIndex: {
+    fontSize: 'var(--text-sm)',
+    color: 'var(--color-text-muted)',
+    fontVariantNumeric: 'tabular-nums',
+    flexShrink: 0,
+  },
+  recapTitle: {
+    fontSize: 'var(--text-sm)',
+    color: 'var(--color-text-primary)',
+    lineHeight: 1.6,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  skillRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 'var(--space-1)',
+  },
+  skillChip: {
+    fontSize: 'var(--text-xs)',
+    fontWeight: 600,
+    color: 'var(--color-text-secondary)',
+    background: 'var(--bg-subtle)',
+    border: '1px solid var(--border-color)',
+    borderRadius: 'var(--radius-sm)',
+    padding: '2px var(--space-2)',
+  },
+  noteBox: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: 'var(--space-2)',
+    padding: 'var(--space-3)',
+    background: 'var(--bg-subtle)',
+    border: '1px solid var(--border-color)',
+    borderRadius: 'var(--radius-sm)',
+  },
+  noteText: {
+    fontSize: 'var(--text-sm)',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.5,
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--space-3)',
+    marginTop: 'var(--space-2)',
+  },
+  keepBuilding: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    gap: '2px',
+    marginLeft: 'auto',
+    minWidth: 0,
+  },
+  keepBuildingLink: {
+    padding: 0,
+    border: 'none',
+    background: 'none',
+    fontSize: 'var(--text-sm)',
+    fontWeight: 600,
+    color: 'var(--color-accent)',
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+  },
+  keepBuildingHint: {
+    fontSize: 'var(--text-xs)',
+    color: 'var(--color-text-muted)',
+  },
+};

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, ArrowLeft, ChevronLeft, ChevronRight, Globe, RotateCcw, X } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Check, ChevronLeft, ChevronRight, Globe, RotateCcw, X } from 'lucide-react';
 import ValidationToast from './ValidationToast';
+import RoadmapCompletionScreen from './RoadmapCompletionScreen';
 import StepHints from './StepHints';
 import { renderInstruction } from './InstructionMarkdown';
 import ProgressBar from '../../../shared/components/ProgressBar';
 import type { useLearningPlayer } from '../hooks/useLearningPlayer';
-import type { ContainerData } from '../../../shared/types';
+import type { ContainerData, LearningExit } from '../../../shared/types';
 import type { NetworkConfig } from '../../../shared/types/network';
 import type { StepValidationResponse } from '../../../shared/types/roadmap';
 
@@ -14,6 +15,10 @@ interface RoadmapPlayerProps {
   player: ReturnType<typeof useLearningPlayer>;
   containers: ContainerData[];
   networkConfig: NetworkConfig;
+  /** Name of the project the canvas belongs to — shown on the completion receipt. */
+  projectName?: string;
+  /** Leave the canvas for the home shell (completion screen's navigation). */
+  onExit?: (target: LearningExit) => void;
 }
 
 export default function RoadmapPlayer({
@@ -24,7 +29,9 @@ export default function RoadmapPlayer({
     subnets: [],
     nodeSubnetMap: {},
     nodeSecurityGroups: {}
-  } as unknown as NetworkConfig
+  } as unknown as NetworkConfig,
+  projectName,
+  onExit,
 }: RoadmapPlayerProps) {
   const { t } = useTranslation();
   const {
@@ -45,6 +52,11 @@ export default function RoadmapPlayer({
     resetProgress,
     resetting,
     resetError,
+    roadmapCompleted,
+    completionOpen,
+    dismissCompletion,
+    reopenCompletion,
+    runTimes,
   } = player;
 
   // Restarting the roadmap forgets persisted progress, so it sits behind the
@@ -57,6 +69,14 @@ export default function RoadmapPlayer({
   const [dismissedByStepId, setDismissedByStepId] = useState<
     Record<string, StepValidationResponse>
   >({});
+  // The celebration consumes the verdict that triggered it: once the screen
+  // has opened, the step toast underneath is stale news and must not resurface
+  // when the learner comes back to the canvas.
+  useEffect(() => {
+    if (!completionOpen) return;
+    setDismissedByStepId(prev => ({ ...prev, ...resultsByStepId }));
+  }, [completionOpen, resultsByStepId]);
+
   const handleValidate = () => {
     setDismissedByStepId(prev => {
       const next = { ...prev };
@@ -124,6 +144,16 @@ export default function RoadmapPlayer({
           })}
         </span>
       </div>
+
+      {roadmapCompleted && !completionOpen && (
+        <div style={styles.completedRow}>
+          <Check size={13} color="var(--color-success)" strokeWidth={2.5} style={{ flexShrink: 0 }} />
+          <span style={styles.completedText}>{t('learning.player.completion.completeBadge')}</span>
+          <button onClick={reopenCompletion} style={styles.viewSummaryBtn}>
+            {t('learning.player.completion.viewSummary')}
+          </button>
+        </div>
+      )}
 
       {resetError !== null && (
         <div style={styles.errorBox}>
@@ -241,11 +271,13 @@ export default function RoadmapPlayer({
         </div>
       )}
 
-      {resultsByStepId[currentStep.id] &&
+      {/* The completion screen supersedes the toast: when the verdict that
+          finished the roadmap opens it, the celebration is the answer. */}
+      {!completionOpen &&
+        resultsByStepId[currentStep.id] &&
         dismissedByStepId[currentStep.id] !== resultsByStepId[currentStep.id] && (
           <ValidationToast
             response={resultsByStepId[currentStep.id]}
-            isLastStep={atLastStep}
             onDismiss={() =>
               setDismissedByStepId(prev => ({
                 ...prev,
@@ -254,6 +286,16 @@ export default function RoadmapPlayer({
             }
           />
         )}
+
+      {completionOpen && (
+        <RoadmapCompletionScreen
+          roadmap={roadmap}
+          projectName={projectName}
+          runTimes={runTimes}
+          onDismiss={dismissCompletion}
+          onExit={target => onExit?.(target)}
+        />
+      )}
     </div>
   );
 }
@@ -333,6 +375,27 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     flexDirection: 'column',
     gap: '5px',
+  },
+  completedRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+  },
+  completedText: {
+    fontSize: '11px',
+    fontWeight: 600,
+    color: 'var(--color-success)',
+  },
+  viewSummaryBtn: {
+    marginLeft: 'auto',
+    padding: 0,
+    border: 'none',
+    background: 'none',
+    color: 'var(--color-accent)',
+    fontSize: '11px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
   },
   currentStep: {
     display: 'flex',

--- a/frontend/src/features/learning/components/ValidationToast.test.tsx
+++ b/frontend/src/features/learning/components/ValidationToast.test.tsx
@@ -38,11 +38,8 @@ function buildResponse(results: ValidatorResult[]): StepValidationResponse {
   };
 }
 
-function renderToast(
-  response: StepValidationResponse,
-  { isLastStep = false, onDismiss = vi.fn() } = {}
-) {
-  render(<ValidationToast response={response} isLastStep={isLastStep} onDismiss={onDismiss} />);
+function renderToast(response: StepValidationResponse, { onDismiss = vi.fn() } = {}) {
+  render(<ValidationToast response={response} onDismiss={onDismiss} />);
   return { onDismiss };
 }
 
@@ -52,14 +49,6 @@ describe('ValidationToast', () => {
 
     expect(screen.getByText('Validation passed')).toBeInTheDocument();
     expect(screen.getByText('The container "web" is running.')).toBeInTheDocument();
-  });
-
-  it('celebrates the roadmap on the last step', () => {
-    renderToast(buildResponse([passResult]), { isLastStep: true });
-
-    expect(
-      screen.getByText('Validation passed — that was the last step. Roadmap complete!')
-    ).toBeInTheDocument();
   });
 
   it('shows a failure as the verdict plus the first failing message only', () => {

--- a/frontend/src/features/learning/components/ValidationToast.tsx
+++ b/frontend/src/features/learning/components/ValidationToast.tsx
@@ -6,7 +6,6 @@ import type { StepValidationResponse } from '../../../shared/types/roadmap';
 
 interface ValidationToastProps {
   response: StepValidationResponse;
-  isLastStep: boolean;
   onDismiss: () => void;
 }
 
@@ -17,11 +16,7 @@ interface ValidationToastProps {
  * one verdict and a single detail line — the full instruction, hints and
  * navigation live in the sidebar, the toast only answers "did it work?".
  */
-export default function ValidationToast({
-  response,
-  isLastStep,
-  onDismiss,
-}: ValidationToastProps) {
+export default function ValidationToast({ response, onDismiss }: ValidationToastProps) {
   const { t } = useTranslation();
   const outcome = stepOutcome(response);
 
@@ -37,7 +32,7 @@ export default function ValidationToast({
   if (outcome === 'passed') {
     disc = { backgroundColor: 'var(--color-success)' };
     DiscIcon = Check;
-    title = isLastStep ? t('learning.player.roadmapComplete') : t('learning.player.stepPassed');
+    title = t('learning.player.stepPassed');
     titleColor = 'var(--color-success)';
     detail = response.results[0]?.message;
   } else if (outcome === 'error') {

--- a/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
@@ -435,6 +435,95 @@ describe('useLearningPlayer', () => {
     });
   });
 
+  describe('completion', () => {
+    const completedProgress: RoadmapProgressResponse = {
+      ...emptyProgress,
+      startedAt: '2026-07-15T09:00:00.000Z',
+      steps: {
+        'create-web-server': { passed: true, attempts: 1, revealedHints: 0, lastCheckedAt: '2026-07-15T09:30:00.000Z' },
+        'add-database': { passed: true, attempts: 1, revealedHints: 0, lastCheckedAt: '2026-07-15T09:45:00.000Z' },
+      },
+    };
+
+    it('opens the completion screen when a validation turns the last missing step green', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock, {
+        ...emptyProgress,
+        steps: { 'create-web-server': { passed: true, attempts: 1, revealedHints: 0 } },
+      });
+      expect(result.current.completionOpen).toBe(false);
+      expect(result.current.roadmapCompleted).toBe(false);
+
+      // The validate POST, then the startedAt refetch it triggers.
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(true, { ...passResponse, stepId: 'add-database' })
+      );
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(true, { ...emptyProgress, startedAt: '2026-07-15T09:00:00.000Z' })
+      );
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+
+      expect(result.current.roadmapCompleted).toBe(true);
+      expect(result.current.completionOpen).toBe(true);
+      expect(result.current.runTimes).toEqual({
+        startedAt: '2026-07-15T09:00:00.000Z',
+        finishedAt: passResponse.checkedAt,
+      });
+    });
+
+    it('does not reopen a dismissed screen when re-validating an already complete roadmap', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock, completedProgress);
+      expect(result.current.completionOpen).toBe(true);
+
+      act(() => result.current.dismissCompletion());
+      expect(result.current.completionOpen).toBe(false);
+
+      act(() => result.current.goToStep(0));
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, passResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+
+      expect(result.current.roadmapCompleted).toBe(true);
+      expect(result.current.completionOpen).toBe(false);
+    });
+
+    it('replays the celebration when opening an already-finished roadmap', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock, completedProgress);
+
+      expect(result.current.roadmapCompleted).toBe(true);
+      expect(result.current.completionOpen).toBe(true);
+      // startedAt comes from the entry, finishedAt from the latest recorded check.
+      expect(result.current.runTimes).toEqual({
+        startedAt: '2026-07-15T09:00:00.000Z',
+        finishedAt: '2026-07-15T09:45:00.000Z',
+      });
+
+      act(() => result.current.dismissCompletion());
+      act(() => result.current.reopenCompletion());
+      expect(result.current.completionOpen).toBe(true);
+    });
+
+    it('closes the screen and forgets the run times on restart', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock, completedProgress);
+      expect(result.current.completionOpen).toBe(true);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, {}));
+      await act(async () => {
+        await result.current.resetProgress();
+      });
+
+      expect(result.current.completionOpen).toBe(false);
+      expect(result.current.roadmapCompleted).toBe(false);
+      expect(result.current.runTimes).toEqual({});
+    });
+  });
+
   describe('closeRoadmap', () => {
     it('returns to the catalogue state and drops in-memory results', async () => {
       const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));

--- a/frontend/src/features/learning/hooks/useLearningPlayer.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.ts
@@ -19,6 +19,24 @@ function ladderLength(step: RoadmapStep): number {
   return (step.hints?.length ?? 0) + (step.solution ? 1 : 0);
 }
 
+/** Start/end timestamps of a play-through, for the completion receipt. */
+export interface RunTimes {
+  /** When the backend created the progress entry — absent for runs that predate the field. */
+  startedAt?: string;
+  /** Latest recorded validation once the roadmap is complete. */
+  finishedAt?: string;
+}
+
+/** Most recent validation across the persisted steps, ISO-comparable strings. */
+function latestCheck(steps: RoadmapStep[], progressSteps: Record<string, StepProgress>): string | undefined {
+  let latest: string | undefined;
+  for (const step of steps) {
+    const checkedAt = progressSteps[step.id]?.lastCheckedAt;
+    if (checkedAt && (!latest || checkedAt > latest)) latest = checkedAt;
+  }
+  return latest;
+}
+
 /**
  * State of one roadmap play-through: the opened roadmap, the current step,
  * and the validation results per step.
@@ -51,6 +69,11 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
   const [progressNotice, setProgressNotice] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
+  // The completion screen is an explicit screen state, not a derived one:
+  // it opens on the two celebration moments (a validation that completes the
+  // roadmap, opening an already-finished roadmap) and stays dismissable.
+  const [completionOpen, setCompletionOpen] = useState(false);
+  const [runTimes, setRunTimes] = useState<RunTimes>({});
   // React state updates are async, so `validating` alone cannot stop two
   // synchronous clicks — the ref is the actual double-submit guard.
   const validatingRef = useRef(false);
@@ -91,12 +114,14 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
         // player opens directly on the restored step — no blank-state flash.
         // Progress is a convenience: if it can't be read, open fresh anyway.
         let progressSteps: Record<string, StepProgress> = {};
+        let startedAt: string | undefined;
         let recovered = false;
         try {
           const progressRes = await fetch(progressUrl(data.id));
           if (progressRes.ok) {
             const progress: RoadmapProgressResponse = await progressRes.json();
             progressSteps = progress.steps ?? {};
+            startedAt = progress.startedAt;
             recovered = progress.storeRecovered === true;
           } else {
             console.error('Failed to load roadmap progress: HTTP', progressRes.status);
@@ -120,15 +145,24 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
           }
         }
         const firstIncomplete = steps.findIndex(step => !completed[step.id]);
+        // Revisiting a finished roadmap replays the celebration: the screen
+        // is where "next roadmap" and the share action live, so it must stay
+        // reachable after the win — not be a one-shot.
+        const allComplete = firstIncomplete === -1;
 
         setRoadmap(data);
-        setCurrentStepIndex(firstIncomplete === -1 ? steps.length - 1 : firstIncomplete);
+        setCurrentStepIndex(allComplete ? steps.length - 1 : firstIncomplete);
         setResultsByStepId({});
         setRevealedHintsByStepId(revealed);
         setCompletedStepIds(completed);
         setProgressNotice(recovered);
         setValidationError(null);
         setResetError(null);
+        setCompletionOpen(allComplete);
+        setRunTimes({
+          startedAt,
+          finishedAt: allComplete ? latestCheck(steps, progressSteps) : undefined,
+        });
       } catch (err) {
         console.error('Failed to load roadmap:', err);
         if (seq === openSeqRef.current) setRoadmapError('');
@@ -149,6 +183,8 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
     setProgressNotice(false);
     setValidationError(null);
     setResetError(null);
+    setCompletionOpen(false);
+    setRunTimes({});
   }, []);
 
   const goToStep = useCallback(
@@ -196,6 +232,30 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
       }
       const response: StepValidationResponse = await res.json();
       setResultsByStepId(prev => ({ ...prev, [currentStep.id]: response }));
+
+      // Fresh completion — this verdict turned the last missing step green.
+      // Only the transition celebrates: re-validating a step of an already
+      // complete roadmap must not reopen the screen over the learner's work.
+      const stepDone = (step: RoadmapStep) =>
+        completedStepIds[step.id] || resultsByStepId[step.id]?.stepPassed;
+      const wasComplete = roadmap.steps.every(stepDone);
+      const nowComplete =
+        response.stepPassed && roadmap.steps.every(step => step.id === currentStep.id || stepDone(step));
+      if (nowComplete && !wasComplete) {
+        setCompletionOpen(true);
+        setRunTimes(prev => ({ ...prev, finishedAt: response.checkedAt }));
+        // The run may have started this session, after the open-time
+        // hydration: the validate call just persisted the entry, so a
+        // refetch is guaranteed to know when the play-through began.
+        fetch(progressUrl(roadmap.id))
+          .then(progressRes => (progressRes.ok ? progressRes.json() : null))
+          .then((progress: RoadmapProgressResponse | null) => {
+            if (progress?.startedAt) {
+              setRunTimes(prev => ({ ...prev, startedAt: progress.startedAt }));
+            }
+          })
+          .catch(err => console.error('Failed to refresh roadmap progress:', err));
+      }
     } catch (err) {
       console.error('Failed to validate step:', err);
       setValidationError('');
@@ -203,7 +263,7 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
       validatingRef.current = false;
       setValidating(false);
     }
-  }, [projectId, roadmap, currentStep]);
+  }, [projectId, roadmap, currentStep, completedStepIds, resultsByStepId, progressUrl]);
 
   /** Forgets this roadmap's persisted progress and restarts it from step 1. */
   const resetProgress = useCallback(async () => {
@@ -222,6 +282,8 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
       setCompletedStepIds({});
       setProgressNotice(false);
       setValidationError(null);
+      setCompletionOpen(false);
+      setRunTimes({});
     } catch (err) {
       console.error('Failed to reset roadmap progress:', err);
       setResetError('');
@@ -231,6 +293,15 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
   }, [resetting, roadmap, progressUrl]);
 
   const dismissProgressNotice = useCallback(() => setProgressNotice(false), []);
+
+  const dismissCompletion = useCallback(() => setCompletionOpen(false), []);
+  const reopenCompletion = useCallback(() => setCompletionOpen(true), []);
+
+  // Achievement, not navigation: true as soon as every step is green, whether
+  // it was earned this session or restored from persisted progress.
+  const roadmapCompleted =
+    roadmap !== null &&
+    roadmap.steps.every(step => completedStepIds[step.id] || resultsByStepId[step.id]?.stepPassed);
 
   return {
     roadmap,
@@ -253,5 +324,10 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
     resetProgress,
     resetting,
     resetError,
+    roadmapCompleted,
+    completionOpen,
+    dismissCompletion,
+    reopenCompletion,
+    runTimes,
   };
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -43,7 +43,6 @@
       "stepErrorDocker": "Docker wasn't running, so the checks couldn't run. Start Docker and validate again.",
       "moreChecks_one": "+{{count}} more check to fix",
       "moreChecks_other": "+{{count}} more checks to fix",
-      "roadmapComplete": "Validation passed — that was the last step. Roadmap complete!",
       "hintLabel": "hint {{n}}/{{total}}",
       "showHint": "Show hint ({{n}}/{{total}})",
       "solutionLabel": "solution",
@@ -53,7 +52,29 @@
       "resetProgressConfirm": "Sure? Click again to restart",
       "resetProgressError": "Could not reset the progress. Nothing was changed — try again.",
       "progressRecovered": "Your saved progress could not be read and had to be reset. Sorry — this roadmap starts fresh.",
-      "dismissNotice": "Dismiss"
+      "dismissNotice": "Dismiss",
+      "completion": {
+        "eyebrow": "Roadmap complete",
+        "subtitle": "Every step passed against your running containers.",
+        "runLabel": "Your run",
+        "runLineRoadmap": "roadmap: {{id}}",
+        "runLineProject": "project: {{name}}",
+        "runLineSteps": "steps: {{total}}/{{total}} passed",
+        "runLineStarted": "started: {{when}}",
+        "runLineFinished": "finished: {{when}}",
+        "stepsRecap": "Steps recap",
+        "skills": "Skills you practiced",
+        "catalogueDone": "That's every roadmap in the catalogue for now — new ones land regularly. Your canvas stays yours to push further.",
+        "copyShare": "Copy share post",
+        "copiedShare": "Copied — paste it anywhere",
+        "shareText": "I just completed “{{title}}” on Torollo — {{total}}/{{total}} steps verified against real Docker containers running on my machine. Free and open source: torollo.app",
+        "nextRoadmap": "Next roadmap",
+        "allRoadmaps": "All roadmaps",
+        "keepBuilding": "Keep building",
+        "keepBuildingHint": "Your containers keep running.",
+        "completeBadge": "Roadmap complete",
+        "viewSummary": "View summary"
+      }
     },
     "landing": {
       "title": "Learning",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -43,7 +43,6 @@
       "stepErrorDocker": "Docker n'était pas démarré, les vérifications n'ont pas pu s'exécuter. Démarrez Docker puis validez à nouveau.",
       "moreChecks_one": "+{{count}} autre vérification à corriger",
       "moreChecks_other": "+{{count}} autres vérifications à corriger",
-      "roadmapComplete": "Validation réussie — c'était la dernière étape. Roadmap terminée !",
       "hintLabel": "indice {{n}}/{{total}}",
       "showHint": "Voir un indice ({{n}}/{{total}})",
       "solutionLabel": "solution",
@@ -53,7 +52,29 @@
       "resetProgressConfirm": "Sûr ? Cliquez à nouveau pour recommencer",
       "resetProgressError": "Impossible de réinitialiser la progression. Rien n'a été modifié — réessayez.",
       "progressRecovered": "Votre progression sauvegardée était illisible et a dû être réinitialisée. Désolé — cette roadmap repart de zéro.",
-      "dismissNotice": "Fermer"
+      "dismissNotice": "Fermer",
+      "completion": {
+        "eyebrow": "Roadmap terminée",
+        "subtitle": "Chaque étape a été validée sur vos conteneurs en cours d'exécution.",
+        "runLabel": "Votre parcours",
+        "runLineRoadmap": "roadmap : {{id}}",
+        "runLineProject": "projet : {{name}}",
+        "runLineSteps": "étapes : {{total}}/{{total}} validées",
+        "runLineStarted": "début : {{when}}",
+        "runLineFinished": "fin : {{when}}",
+        "stepsRecap": "Récap des étapes",
+        "skills": "Compétences travaillées",
+        "catalogueDone": "C'est toute l'étendue du catalogue pour l'instant — de nouvelles roadmaps arrivent régulièrement. Votre canvas reste à vous pour aller plus loin.",
+        "copyShare": "Copier le post de partage",
+        "copiedShare": "Copié — collez-le où vous voulez",
+        "shareText": "Je viens de terminer « {{title}} » sur Torollo — {{total}}/{{total}} étapes vérifiées sur de vrais conteneurs Docker, sur ma machine. Gratuit et open source : torollo.app",
+        "nextRoadmap": "Roadmap suivante",
+        "allRoadmaps": "Toutes les roadmaps",
+        "keepBuilding": "Continuer à construire",
+        "keepBuildingHint": "Vos conteneurs tournent toujours.",
+        "completeBadge": "Roadmap terminée",
+        "viewSummary": "Voir le récap"
+      }
     },
     "landing": {
       "title": "Apprentissage",

--- a/frontend/src/pages/CanvasPage/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage/CanvasPage.tsx
@@ -28,7 +28,7 @@ import CanvasModals from './components/CanvasModals';
 import type { InspectorState } from './components/CanvasModals';
 import ButtonEdge from './components/ButtonEdge';
 import { API_BASE } from '../../shared/types';
-import type { LearningIntent } from '../../shared/types';
+import type { LearningExit, LearningIntent } from '../../shared/types';
 import { useNetworkConfig } from './hooks/useNetworkConfig';
 import { useCanvasDragDrop } from './hooks/useCanvasDragDrop';
 import { positionToCell, resolveSubnetChildPosition, subnetSize } from './utils/canvasGeometry';
@@ -49,6 +49,8 @@ interface CanvasPageProps {
   /** Called once on mount so the owner can clear the one-shot intent. */
   onLearningIntentConsumed?: () => void;
   onBackToProjects: () => void;
+  /** Leave for the home shell's learning views (the completion screen's navigation). */
+  onExitToLearning?: (target: LearningExit) => void;
   onTerminalOpen: (id: string, name: string) => void;
 }
 
@@ -70,6 +72,7 @@ export default function CanvasPage({
   initialLearning,
   onLearningIntentConsumed,
   onBackToProjects,
+  onExitToLearning,
   onTerminalOpen,
 }: CanvasPageProps) {
   const { t } = useTranslation();
@@ -621,8 +624,10 @@ export default function CanvasPage({
         {showLearning && (
           <LearningPanel
             projectId={projectId}
+            projectName={projectName}
             initialRoadmap={initialRoadmapRef.current}
             onClose={() => setShowLearning(false)}
+            onExit={onExitToLearning}
             containers={containers}
             networkConfig={networkConfig}
           />

--- a/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -13,10 +13,14 @@ import RoadmapDetailPage from './components/learning/detail/RoadmapDetailPage';
 import { filterByUiLanguage } from '../../features/learning/roadmapLanguage';
 import { markLearningPitchSeen } from '../../features/learning/onboarding';
 import { API_BASE } from '../../shared/types';
-import type { LearningIntent, Project } from '../../shared/types';
+import type { LearningExit, LearningIntent, Project } from '../../shared/types';
 import type { ProgressEntrySummary, RoadmapSummary } from '../../shared/types/roadmap';
 
 interface ProjectsPageProps {
+  /** Arrival from the canvas (the completion screen's navigation): land on the
+   *  learning catalogue or one roadmap's briefing. One-shot, consumed on mount. */
+  initialLearning?: LearningExit | null;
+  onInitialLearningConsumed?: () => void;
   onSelectProject: (id: string, name: string, intent?: LearningIntent) => void;
 }
 
@@ -30,10 +34,26 @@ type HomeRoute =
   | { kind: 'learning' }
   | { kind: 'roadmap'; summary: RoadmapSummary; progress?: ProgressEntrySummary };
 
-export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
+export default function ProjectsPage({
+  initialLearning,
+  onInitialLearningConsumed,
+  onSelectProject,
+}: ProjectsPageProps) {
   const { t, i18n } = useTranslation();
-  // Which home view the side rail is on; session-only, Projects first.
-  const [route, setRoute] = useState<HomeRoute>({ kind: 'projects' });
+  // Which home view the side rail is on; session-only, Projects first —
+  // unless the canvas sent the learner here (completion screen's navigation).
+  const [route, setRoute] = useState<HomeRoute>(() => {
+    if (!initialLearning) return { kind: 'projects' };
+    return initialLearning.kind === 'roadmap'
+      ? { kind: 'roadmap', summary: initialLearning.summary }
+      : { kind: 'learning' };
+  });
+  // One-shot: the owner clears its copy right away so a later remount of the
+  // home shell can never replay the arrival.
+  const initialLearningConsumedRef = useRef(onInitialLearningConsumed);
+  useEffect(() => {
+    initialLearningConsumedRef.current?.();
+  }, []);
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -39,6 +39,15 @@ export interface LearningIntent {
   roadmap?: { id: string; language: string };
 }
 
+/**
+ * Reverse of LearningIntent: where the completion screen sends the learner
+ * when they leave the canvas — the learning catalogue, or one roadmap's
+ * briefing. Session-only for the same reason.
+ */
+export type LearningExit =
+  | { kind: 'catalog' }
+  | { kind: 'roadmap'; summary: import('./roadmap').RoadmapSummary };
+
 /** API base URL for the backend */
 export const API_BASE = import.meta.env.DEV
   ? 'http://localhost:23233'

--- a/frontend/src/shared/types/roadmap.ts
+++ b/frontend/src/shared/types/roadmap.ts
@@ -115,6 +115,8 @@ export interface StepProgress {
 export interface RoadmapProgressResponse {
   projectId: string;
   roadmapId: string;
+  /** When this play-through began — absent when it hasn't started, or predates the field. */
+  startedAt?: string;
   steps: Record<string, StepProgress>;
   /** Present (true) once after an unreadable store was moved aside — tell the user. */
   storeRecovered?: boolean;


### PR DESCRIPTION
## Summary of Changes

Finishing a roadmap now opens a completion screen over the canvas instead of a plain toast. It celebrates the run with facts read off the real play-through and turns it into something the learner can carry out of the app:

- **Run receipt** (single mono block, copyable): roadmap id, project, steps passed, started/finished timestamps. The progress store now stamps `startedAt` when a play-through's entry is created (backend + `docs/learning-api.md` updated).
- **Steps recap** in two columns and **skills chips** derived from the validators — same `deriveTopology` source as the briefing page, no parallel derivation.
- **Copy share post** (primary action): a sober, paste-ready post for X/LinkedIn/Reddit, EN/FR.
- **Next roadmap**: resolves the first unstarted (then first unfinished) roadmap of the catalogue in the UI language and lands on its briefing page in the home shell — new `LearningExit` intent mirroring `LearningIntent`, consumed one-shot by `ProjectsPage`. Falls back to "All roadmaps" plus a catalogue-complete note when nothing is left.
- **Keep building** link dismisses back to the canvas (containers keep running); the player then shows a quiet "Roadmap complete — View summary" row so the screen stays replayable, and reopening an already-finished roadmap replays it.
- The completion detection lives in `useLearningPlayer` (fresh completion = the verdict that turned the last missing step green; deduplicated so re-validating a complete roadmap never reopens the screen). The step toast is suppressed/consumed when the celebration opens, and its "last step" title special-case is gone — it claimed "roadmap complete" even when earlier steps were skipped.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: 448 tests (incl. new `startedAt` cases). Frontend: 290 tests (new `RoadmapCompletionScreen` suite, completion cases in `useLearningPlayer`, updated `ValidationToast`).

### Manual Verification

Playwright recipe against the dev server with every backend call mocked via `page.route()` (progress = all steps but the last passed), run in EN and FR:
- Validate on the last step → completion screen opens with the receipt (`started`/`finished` from the store), 10-step recap, skills chips.
- "Copy share post" → clipboard holds the exact paste-ready post (asserted via `clipboard-read` permission).
- "Keep building" → back on the canvas with no stale step toast; "View summary" reopens the screen.
- "Next roadmap" → home shell lands directly on the cache-aside briefing page.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)