### PR TITLE
feat(learning): import local roadmap packs into the catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Current catalogue (English and French):
 | Cache-aside with Redis | intermediate | 30 min | Caching strategy, TTLs, invalidation, measuring hit rates |
 | Workers & the Redis job queue | intermediate | 40 min | Async decoupling, queues, scaling workers under load, poison messages |
 
-**Roadmaps are plain JSON — no code.** The format is open and documented in the [Roadmap Authoring Reference](docs/roadmap-format.md); drop a valid file into `roadmaps/` and it appears in the catalogue. Community-authored roadmaps are very welcome. The validation HTTP API is documented in [learning-api.md](docs/learning-api.md).
+**Roadmaps are plain JSON — no code.** The format is open and documented in the [Roadmap Authoring Reference](docs/roadmap-format.md); drop a valid file into `roadmaps/` — or import any roadmap file or `.zip` pack from the Learning page, no repo checkout needed ([how it works](docs/local-roadmaps.md)) — and it appears in the catalogue. Community-authored roadmaps are very welcome. The validation HTTP API is documented in [learning-api.md](docs/learning-api.md).
 
 ---
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/adm-zip": "^0.5.8",
+        "adm-zip": "^0.6.0",
         "ajv": "^8.20.0",
         "cors": "^2.8.6",
         "dockerode": "^5.0.0",
@@ -2139,6 +2141,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3067,6 +3078,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@types/adm-zip": "^0.5.8",
+    "adm-zip": "^0.6.0",
     "ajv": "^8.20.0",
     "cors": "^2.8.6",
     "dockerode": "^5.0.0",

--- a/backend/src/modules/learning/controllers/learningController.test.ts
+++ b/backend/src/modules/learning/controllers/learningController.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import express from 'express';
 import learningRouter from '../routes/learningRoutes';
 import { RoadmapService } from '../services/roadmapService';
+import { RoadmapImportService, ImportReport } from '../services/roadmapImportService';
 import { ProgressService } from '../services/progressService';
 import { runStepValidators } from '../engine/engine';
 import { ValidatorResult } from '../engine/types';
@@ -9,6 +10,7 @@ import { ProjectService } from '../../projects/services/projectService';
 import { Roadmap } from '../format/roadmapTypes';
 
 jest.mock('../services/roadmapService');
+jest.mock('../services/roadmapImportService');
 jest.mock('../services/progressService');
 jest.mock('../engine/engine');
 jest.mock('../../projects/services/projectService');
@@ -96,6 +98,95 @@ describe('LearningController', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.code).toBe('ROADMAP_NOT_FOUND');
+    });
+  });
+
+  describe('POST /api/learning/roadmaps/import', () => {
+    const importedReport: ImportReport = {
+      imported: [
+        { file: 'pack-roadmap.json', id: 'pack-roadmap', language: 'en', title: 'Pack', updated: false },
+      ],
+      rejected: [],
+      ignored: [],
+    };
+
+    it('hands the raw bytes and file name to the import service and returns its report', async () => {
+      (RoadmapImportService.importUpload as jest.Mock).mockReturnValue(importedReport);
+
+      const res = await request(app)
+        .post('/api/learning/roadmaps/import?filename=pack.zip')
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from('zip-bytes'));
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(importedReport);
+      expect(RoadmapImportService.importUpload).toHaveBeenCalledWith(
+        Buffer.from('zip-bytes'),
+        'pack.zip'
+      );
+    });
+
+    it('defaults the file name when none is given', async () => {
+      (RoadmapImportService.importUpload as jest.Mock).mockReturnValue(importedReport);
+
+      await request(app)
+        .post('/api/learning/roadmaps/import')
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from('x'));
+
+      expect(RoadmapImportService.importUpload).toHaveBeenCalledWith(expect.any(Buffer), 'upload');
+    });
+
+    it('returns 422 with the report when nothing could be imported', async () => {
+      const rejectedReport: ImportReport = {
+        imported: [],
+        rejected: [{ file: 'broken.json', errors: ['not valid JSON: oops'] }],
+        ignored: [],
+      };
+      (RoadmapImportService.importUpload as jest.Mock).mockReturnValue(rejectedReport);
+
+      const res = await request(app)
+        .post('/api/learning/roadmaps/import')
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from('{nope'));
+
+      expect(res.status).toBe(422);
+      expect(res.body).toEqual(rejectedReport);
+    });
+
+    it('returns 400 on an empty body', async () => {
+      const res = await request(app)
+        .post('/api/learning/roadmaps/import')
+        .set('Content-Type', 'application/octet-stream')
+        .send();
+
+      expect(res.status).toBe(400);
+      expect(RoadmapImportService.importUpload).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when another body parser ate the bytes (application/json upload)', async () => {
+      const res = await request(app)
+        .post('/api/learning/roadmaps/import')
+        .set('Content-Type', 'application/json')
+        .send({ schemaVersion: 1 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('application/octet-stream');
+      expect(RoadmapImportService.importUpload).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when the import service throws', async () => {
+      (RoadmapImportService.importUpload as jest.Mock).mockImplementation(() => {
+        throw new Error('disk full');
+      });
+
+      const res = await request(app)
+        .post('/api/learning/roadmaps/import')
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from('x'));
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('disk full');
     });
   });
 

--- a/backend/src/modules/learning/controllers/learningController.ts
+++ b/backend/src/modules/learning/controllers/learningController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { RoadmapService } from '../services/roadmapService';
+import { RoadmapImportService } from '../services/roadmapImportService';
 import { ProgressService } from '../services/progressService';
 import { runStepValidators } from '../engine/engine';
 import { ValidatorResult } from '../engine/types';
@@ -43,6 +44,32 @@ export class LearningController {
         return;
       }
       res.json(roadmap);
+    } catch (err: unknown) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  public static async importRoadmaps(req: Request, res: Response): Promise<void> {
+    try {
+      // The route mounts express.raw(), so a correctly sent upload is a Buffer.
+      // Anything else means the client let another body parser eat the bytes
+      // (e.g. a .json file sent with an application/json Content-Type).
+      if (!Buffer.isBuffer(req.body) || req.body.length === 0) {
+        res.status(400).json({
+          error:
+            'Send the roadmap file (.json or .zip archive) as the raw request body ' +
+            'with Content-Type: application/octet-stream.',
+        });
+        return;
+      }
+      const { filename } = req.query;
+      const report = RoadmapImportService.importUpload(
+        req.body,
+        typeof filename === 'string' && filename.length > 0 ? filename : 'upload'
+      );
+      // 422 when nothing was installed: the upload as a whole failed, and the
+      // per-file errors in the report say why.
+      res.status(report.imported.length > 0 ? 200 : 422).json(report);
     } catch (err: unknown) {
       res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
     }

--- a/backend/src/modules/learning/routes/learningRoutes.ts
+++ b/backend/src/modules/learning/routes/learningRoutes.ts
@@ -1,9 +1,17 @@
-import { Router } from 'express';
+import express, { Router } from 'express';
 import { LearningController } from '../controllers/learningController';
 
 const router = Router();
 
 router.get('/roadmaps', LearningController.listRoadmaps);
+// Raw body, whatever the Content-Type: the upload is a .json file or a .zip
+// archive and the service decides from the bytes. Registered before
+// /roadmaps/:id so "import" is never read as a roadmap id.
+router.post(
+  '/roadmaps/import',
+  express.raw({ type: () => true, limit: '25mb' }),
+  LearningController.importRoadmaps
+);
 router.get('/roadmaps/:id', LearningController.getRoadmap);
 router.post('/validate', LearningController.validate);
 router.get('/progress', LearningController.listProgress);

--- a/backend/src/modules/learning/services/__fixtures__/user-roadmaps/imported-roadmap.json
+++ b/backend/src/modules/learning/services/__fixtures__/user-roadmaps/imported-roadmap.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "imported-roadmap",
+  "title": "Imported roadmap",
+  "description": "A user-imported roadmap used by roadmapService tests.",
+  "language": "en",
+  "estimatedMinutes": 5,
+  "difficulty": "advanced",
+  "steps": [
+    {
+      "id": "start-cache",
+      "title": "Start the cache",
+      "instruction": "Create a node named `cache` and start it.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "cache" }
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/modules/learning/services/__fixtures__/user-roadmaps/shadows-builtin.json
+++ b/backend/src/modules/learning/services/__fixtures__/user-roadmaps/shadows-builtin.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "id": "fixture-roadmap",
+  "title": "Shadowing attempt",
+  "description": "Same (id, language) as the shipped fixture — the loader must ignore this file.",
+  "language": "en",
+  "steps": [
+    {
+      "id": "evil-step",
+      "title": "Should never be served",
+      "instruction": "If you can read this in a test failure, the builtin-wins rule broke.",
+      "validators": [
+        {
+          "type": "container_running",
+          "params": { "node": "evil" }
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/modules/learning/services/roadmapImportService.test.ts
+++ b/backend/src/modules/learning/services/roadmapImportService.test.ts
@@ -1,0 +1,203 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import AdmZip from 'adm-zip';
+import { RoadmapImportService } from './roadmapImportService';
+import { RoadmapService } from './roadmapService';
+
+const BUILTIN_DIR = path.resolve(__dirname, '__fixtures__/roadmaps');
+
+function roadmapJson(id: string, language = 'en', title = `Roadmap ${id}`): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    id,
+    title,
+    description: `Description of ${id}.`,
+    language,
+    steps: [
+      {
+        id: 'start-web',
+        title: 'Start the web server',
+        instruction: 'Create a node named `web` and start it.',
+        validators: [{ type: 'container_running', params: { node: 'web' } }],
+      },
+    ],
+  });
+}
+
+describe('RoadmapImportService', () => {
+  let userDir: string;
+  let dirs: { dir: string; userDir: string };
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    userDir = fs.mkdtempSync(path.join(os.tmpdir(), 'torollo-import-'));
+    dirs = { dir: BUILTIN_DIR, userDir };
+  });
+
+  afterEach(() => {
+    fs.rmSync(userDir, { recursive: true, force: true });
+  });
+
+  it('imports a single valid .json upload and the catalogue serves it', () => {
+    const report = RoadmapImportService.importUpload(
+      Buffer.from(roadmapJson('my-pack-roadmap')),
+      'my-pack-roadmap.json',
+      dirs
+    );
+
+    expect(report).toEqual({
+      imported: [
+        {
+          file: 'my-pack-roadmap.json',
+          id: 'my-pack-roadmap',
+          language: 'en',
+          title: 'Roadmap my-pack-roadmap',
+          updated: false,
+        },
+      ],
+      rejected: [],
+      ignored: [],
+    });
+    expect(fs.existsSync(path.join(userDir, 'my-pack-roadmap.en.json'))).toBe(true);
+    expect(RoadmapService.listRoadmaps(dirs)).toContainEqual(
+      expect.objectContaining({ id: 'my-pack-roadmap', source: 'imported' })
+    );
+  });
+
+  it('rejects a file that is not JSON, without writing anything', () => {
+    const report = RoadmapImportService.importUpload(Buffer.from('{nope'), 'broken.json', dirs);
+
+    expect(report.imported).toEqual([]);
+    expect(report.rejected).toEqual([
+      { file: 'broken.json', errors: [expect.stringContaining('not valid JSON')] },
+    ]);
+    expect(fs.readdirSync(userDir)).toEqual([]);
+  });
+
+  it('rejects a schema-invalid roadmap with the field-level errors', () => {
+    const invalid = JSON.stringify({ schemaVersion: 1, id: 'x-roadmap', language: 'en', steps: [] });
+    const report = RoadmapImportService.importUpload(Buffer.from(invalid), 'invalid.json', dirs);
+
+    expect(report.imported).toEqual([]);
+    expect(report.rejected[0].file).toBe('invalid.json');
+    expect(report.rejected[0].errors.join('; ')).toContain('missing required field "title"');
+  });
+
+  it('refuses to shadow a shipped roadmap', () => {
+    const report = RoadmapImportService.importUpload(
+      Buffer.from(roadmapJson('fixture-roadmap')),
+      'fixture-roadmap.json',
+      dirs
+    );
+
+    expect(report.imported).toEqual([]);
+    expect(report.rejected[0].errors[0]).toContain('shipped with Torollo');
+    expect(fs.readdirSync(userDir)).toEqual([]);
+  });
+
+  it('imports each archive file on its own: valid ones install, broken ones report, extras are ignored', () => {
+    const zip = new AdmZip();
+    zip.addFile('pack/roadmap-one.json', Buffer.from(roadmapJson('pack-roadmap-one')));
+    zip.addFile('pack/roadmap-two.json', Buffer.from(roadmapJson('pack-roadmap-two')));
+    zip.addFile('pack/broken.json', Buffer.from('{nope'));
+    zip.addFile('pack/README.md', Buffer.from('# Pack'));
+
+    const report = RoadmapImportService.importUpload(zip.toBuffer(), 'pack.zip', dirs);
+
+    expect(report.imported.map(entry => entry.id).sort()).toEqual([
+      'pack-roadmap-one',
+      'pack-roadmap-two',
+    ]);
+    expect(report.rejected).toEqual([
+      { file: 'broken.json', errors: [expect.stringContaining('not valid JSON')] },
+    ]);
+    expect(report.ignored).toEqual(['README.md']);
+    expect(fs.readdirSync(userDir).sort()).toEqual([
+      'pack-roadmap-one.en.json',
+      'pack-roadmap-two.en.json',
+    ]);
+  });
+
+  it('re-importing the same roadmap updates it in place and says so', () => {
+    RoadmapImportService.importUpload(Buffer.from(roadmapJson('my-pack-roadmap')), 'v1.json', dirs);
+    const report = RoadmapImportService.importUpload(
+      Buffer.from(roadmapJson('my-pack-roadmap', 'en', 'Roadmap v2')),
+      'v2.json',
+      dirs
+    );
+
+    expect(report.imported[0].updated).toBe(true);
+    expect(fs.readdirSync(userDir)).toEqual(['my-pack-roadmap.en.json']);
+    expect(
+      RoadmapService.getRoadmap('my-pack-roadmap', dirs)?.title
+    ).toBe('Roadmap v2');
+  });
+
+  it('rejects a second archive entry with the same (id, language) instead of silently overwriting', () => {
+    const zip = new AdmZip();
+    zip.addFile('a.json', Buffer.from(roadmapJson('pack-roadmap', 'en', 'First')));
+    zip.addFile('b.json', Buffer.from(roadmapJson('pack-roadmap', 'en', 'Second')));
+
+    const report = RoadmapImportService.importUpload(zip.toBuffer(), 'pack.zip', dirs);
+
+    expect(report.imported).toHaveLength(1);
+    expect(report.rejected).toEqual([
+      { file: 'b.json', errors: [expect.stringContaining('same roadmap id and language')] },
+    ]);
+    expect(RoadmapService.getRoadmap('pack-roadmap', dirs)?.title).toBe('First');
+  });
+
+  it('keeps translations of one roadmap in the same archive apart', () => {
+    const zip = new AdmZip();
+    zip.addFile('en.json', Buffer.from(roadmapJson('pack-roadmap', 'en')));
+    zip.addFile('fr.json', Buffer.from(roadmapJson('pack-roadmap', 'fr')));
+
+    const report = RoadmapImportService.importUpload(zip.toBuffer(), 'pack.zip', dirs);
+
+    expect(report.rejected).toEqual([]);
+    expect(fs.readdirSync(userDir).sort()).toEqual([
+      'pack-roadmap.en.json',
+      'pack-roadmap.fr.json',
+    ]);
+  });
+
+  it('rejects an oversized archive entry before parsing it', () => {
+    const zip = new AdmZip();
+    zip.addFile('huge.json', Buffer.alloc(5 * 1024 * 1024 + 1, 0x20));
+
+    const report = RoadmapImportService.importUpload(zip.toBuffer(), 'pack.zip', dirs);
+
+    expect(report.imported).toEqual([]);
+    expect(report.rejected[0].errors[0]).toContain('larger than');
+  });
+
+  it('rejects an archive with no roadmap file at all', () => {
+    const zip = new AdmZip();
+    zip.addFile('README.md', Buffer.from('# Pack'));
+
+    const report = RoadmapImportService.importUpload(zip.toBuffer(), 'pack.zip', dirs);
+
+    expect(report.imported).toEqual([]);
+    expect(report.rejected).toEqual([
+      { file: 'pack.zip', errors: [expect.stringContaining('no .json roadmap file')] },
+    ]);
+  });
+
+  it('reports corrupt zip bytes as one readable rejection', () => {
+    const corrupt = Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.alloc(32, 7)]);
+
+    const report = RoadmapImportService.importUpload(corrupt, 'pack.zip', dirs);
+
+    expect(report.imported).toEqual([]);
+    expect(report.rejected[0].errors[0]).toContain('not a readable zip archive');
+  });
+
+  it('writes the author bytes untouched — formatting and key order survive the import', () => {
+    const source = `{\n  "schemaVersion": 1,\n  "language": "en",\n  "id": "my-pack-roadmap",\n  "title": "T",\n  "description": "D",\n  "steps": [{ "id": "s", "title": "S", "instruction": "I", "validators": [{ "type": "container_running", "params": { "node": "web" } }] }]\n}`;
+
+    RoadmapImportService.importUpload(Buffer.from(source), 'authored.json', dirs);
+
+    expect(fs.readFileSync(path.join(userDir, 'my-pack-roadmap.en.json'), 'utf-8')).toBe(source);
+  });
+});

--- a/backend/src/modules/learning/services/roadmapImportService.ts
+++ b/backend/src/modules/learning/services/roadmapImportService.ts
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
+import { validateRoadmap } from '../format/validateRoadmap';
+import { RoadmapDirs, RoadmapService, USER_ROADMAPS_DIR } from './roadmapService';
+
+/** One roadmap file the import accepted and installed. */
+export interface ImportedRoadmap {
+  /** Name of the uploaded file or archive entry the roadmap came from. */
+  file: string;
+  id: string;
+  language: string;
+  title: string;
+  /** True when this import replaced a previously imported version. */
+  updated: boolean;
+}
+
+/** One roadmap file the import refused, with the reasons a user can act on. */
+export interface RejectedFile {
+  file: string;
+  errors: string[];
+}
+
+/** Outcome of one upload (POST /api/learning/roadmaps/import). */
+export interface ImportReport {
+  imported: ImportedRoadmap[];
+  rejected: RejectedFile[];
+  /** Archive entries that are not roadmap files (README, images…) — skipped, not an error. */
+  ignored: string[];
+}
+
+// An upload is a couple of hand-written JSON files, possibly zipped. Anything
+// bigger than these caps is not a roadmap pack — refuse it before inflating.
+const MAX_ENTRIES = 200;
+const MAX_ENTRY_BYTES = 5 * 1024 * 1024;
+
+/** Local zip files start with "PK\x03\x04" — content, not file names, decides the path. */
+function isZip(data: Buffer): boolean {
+  return data.length >= 4 && data[0] === 0x50 && data[1] === 0x4b && data[2] === 0x03 && data[3] === 0x04;
+}
+
+interface CandidateFile {
+  /** Base name of the upload or archive entry — used in the report only. */
+  name: string;
+  data: Buffer;
+}
+
+/**
+ * Installs uploaded roadmaps into the user roadmaps directory
+ * (~/.torollo/roadmaps/), where the catalogue picks them up.
+ *
+ * Every file is fully validated against the roadmap format before anything is
+ * written, and each one succeeds or fails on its own: one broken file in an
+ * archive never blocks the others. Installed files are named
+ * `<id>.<language>.json` — both fields are schema-constrained to safe
+ * characters, and the deterministic name is what makes re-importing a fixed
+ * or updated pack an in-place update.
+ */
+export class RoadmapImportService {
+  public static importUpload(
+    data: Buffer,
+    fileName: string,
+    dirs: RoadmapDirs = {}
+  ): ImportReport {
+    const report: ImportReport = { imported: [], rejected: [], ignored: [] };
+    const name = path.basename(fileName || 'upload');
+
+    let candidates: CandidateFile[];
+    if (isZip(data)) {
+      try {
+        candidates = this.unpackArchive(data, report);
+      } catch (err: unknown) {
+        const reason = err instanceof Error ? err.message : String(err);
+        report.rejected.push({ file: name, errors: [`not a readable zip archive: ${reason}`] });
+        return report;
+      }
+      if (candidates.length === 0 && report.rejected.length === 0) {
+        report.rejected.push({ file: name, errors: ['the archive contains no .json roadmap file'] });
+        return report;
+      }
+    } else {
+      candidates = [{ name, data }];
+    }
+
+    const builtinKeys = RoadmapService.builtinKeys(dirs);
+    const userDir = dirs.userDir ?? USER_ROADMAPS_DIR;
+    // Keys already accepted from this same upload: a second file with the same
+    // (id, language) would silently overwrite the first, so it is refused.
+    const accepted = new Map<string, string>();
+
+    for (const candidate of candidates) {
+      const outcome = this.importOne(candidate, { builtinKeys, accepted, userDir });
+      if ('errors' in outcome) {
+        report.rejected.push({ file: candidate.name, errors: outcome.errors });
+      } else {
+        report.imported.push(outcome);
+      }
+    }
+    return report;
+  }
+
+  private static unpackArchive(data: Buffer, report: ImportReport): CandidateFile[] {
+    const entries = new AdmZip(data).getEntries().filter(entry => !entry.isDirectory);
+    if (entries.length > MAX_ENTRIES) {
+      throw new Error(`too many files (${entries.length}, limit ${MAX_ENTRIES})`);
+    }
+
+    const candidates: CandidateFile[] = [];
+    for (const entry of entries) {
+      // Entry names come from the archive: only their base name is ever used,
+      // and only for reporting — the installed file name derives from the
+      // validated roadmap content, so a hostile path can't escape the dir.
+      const name = path.basename(entry.entryName);
+      if (!name.endsWith('.json')) {
+        report.ignored.push(name);
+        continue;
+      }
+      if (entry.header.size > MAX_ENTRY_BYTES) {
+        report.rejected.push({
+          file: name,
+          errors: [`file is larger than the ${MAX_ENTRY_BYTES / 1024 / 1024} MB limit for a roadmap`],
+        });
+        continue;
+      }
+      candidates.push({ name, data: entry.getData() });
+    }
+    return candidates;
+  }
+
+  private static importOne(
+    candidate: CandidateFile,
+    ctx: { builtinKeys: Set<string>; accepted: Map<string, string>; userDir: string }
+  ): ImportedRoadmap | { errors: string[] } {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate.data.toString('utf-8'));
+    } catch (err: unknown) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { errors: [`not valid JSON: ${reason}`] };
+    }
+
+    const result = validateRoadmap(parsed);
+    if (!result.valid) {
+      return { errors: result.errors };
+    }
+
+    const { id, language, title } = result.roadmap;
+    const key = RoadmapService.key(id, language);
+    if (ctx.builtinKeys.has(key)) {
+      return {
+        errors: [
+          `"${id}" (${language}) is a roadmap shipped with Torollo — an import cannot replace it. ` +
+            'Give your roadmap its own id.',
+        ],
+      };
+    }
+    const earlier = ctx.accepted.get(key);
+    if (earlier !== undefined) {
+      return { errors: [`same roadmap id and language as "${earlier}" in this upload`] };
+    }
+
+    const target = path.join(ctx.userDir, `${id}.${language}.json`);
+    const updated = fs.existsSync(target);
+    fs.mkdirSync(ctx.userDir, { recursive: true });
+    // The original bytes, not a re-serialization: the file stays exactly what
+    // its author wrote (formatting, key order).
+    fs.writeFileSync(target, candidate.data);
+
+    ctx.accepted.set(key, candidate.name);
+    return { file: candidate.name, id, language, title, updated };
+  }
+}

--- a/backend/src/modules/learning/services/roadmapService.test.ts
+++ b/backend/src/modules/learning/services/roadmapService.test.ts
@@ -2,6 +2,11 @@ import path from 'path';
 import { CURATED_ROADMAP_ORDER, RoadmapService } from './roadmapService';
 
 const FIXTURES_DIR = path.resolve(__dirname, '__fixtures__/roadmaps');
+const USER_FIXTURES_DIR = path.resolve(__dirname, '__fixtures__/user-roadmaps');
+// The normal state before the first import: the user directory does not exist.
+const NO_USER_DIR = path.resolve(__dirname, '__fixtures__/no-such-user-roadmaps');
+
+const dirs = { dir: FIXTURES_DIR, userDir: NO_USER_DIR };
 
 describe('RoadmapService', () => {
   let warnSpy: jest.SpyInstance;
@@ -12,7 +17,7 @@ describe('RoadmapService', () => {
 
   describe('listRoadmaps', () => {
     it('lists one summary per file — translations appear as separate entries', () => {
-      const summaries = RoadmapService.listRoadmaps(FIXTURES_DIR);
+      const summaries = RoadmapService.listRoadmaps(dirs);
 
       expect(summaries).toEqual([
         {
@@ -24,6 +29,7 @@ describe('RoadmapService', () => {
           difficulty: 'beginner',
           estimatedMinutes: 10,
           stepCount: 2,
+          source: 'builtin',
         },
         {
           id: 'fixture-roadmap',
@@ -33,6 +39,7 @@ describe('RoadmapService', () => {
           difficulty: 'beginner',
           estimatedMinutes: 10,
           stepCount: 2,
+          source: 'builtin',
         },
         {
           id: 'zz-unlisted-roadmap',
@@ -42,19 +49,20 @@ describe('RoadmapService', () => {
           difficulty: 'beginner',
           estimatedMinutes: 5,
           stepCount: 1,
+          source: 'builtin',
         },
       ]);
     });
 
     it('orders roadmaps outside the curated list by id, not by file name', () => {
-      const ids = RoadmapService.listRoadmaps(FIXTURES_DIR).map(summary => summary.id);
+      const ids = RoadmapService.listRoadmaps(dirs).map(summary => summary.id);
 
       // a-unlisted-id.json holds `zz-unlisted-roadmap`: file name first, id last.
       expect(ids).toEqual(['fixture-roadmap', 'fixture-roadmap', 'zz-unlisted-roadmap']);
     });
 
     it('opens the shipped catalogue on the curated order — the first entry is what a first-run user is pitched', () => {
-      const summaries = RoadmapService.listRoadmaps();
+      const summaries = RoadmapService.listRoadmaps({ userDir: NO_USER_DIR });
       const curated = summaries.map(s => s.id).filter(id => CURATED_ROADMAP_ORDER.includes(id));
       // Translations share an id and sit next to each other: collapse the runs.
       const distinct = curated.filter((id, index) => id !== curated[index - 1]);
@@ -64,57 +72,100 @@ describe('RoadmapService', () => {
     });
 
     it('skips invalid roadmap files and warns with the file name', () => {
-      RoadmapService.listRoadmaps(FIXTURES_DIR);
+      RoadmapService.listRoadmaps(dirs);
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid-missing-title.json')
       );
     });
 
-    it('returns an empty list when the directory does not exist', () => {
-      expect(RoadmapService.listRoadmaps(path.join(FIXTURES_DIR, 'nope'))).toEqual([]);
+    it('returns an empty list when the shipped directory does not exist', () => {
+      expect(
+        RoadmapService.listRoadmaps({ dir: path.join(FIXTURES_DIR, 'nope'), userDir: NO_USER_DIR })
+      ).toEqual([]);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+    });
+
+    it('does not warn about a missing user directory — that is the pre-first-import state', () => {
+      RoadmapService.listRoadmaps(dirs);
+
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('no-such-user-roadmaps'));
+    });
+
+    it('merges the user directory into the catalogue, marked as imported', () => {
+      const summaries = RoadmapService.listRoadmaps({ dir: FIXTURES_DIR, userDir: USER_FIXTURES_DIR });
+      const imported = summaries.find(s => s.id === 'imported-roadmap');
+
+      expect(imported).toMatchObject({
+        title: 'Imported roadmap',
+        language: 'en',
+        source: 'imported',
+      });
+    });
+
+    it('lets a shipped roadmap win over an imported file with the same (id, language)', () => {
+      const summaries = RoadmapService.listRoadmaps({ dir: FIXTURES_DIR, userDir: USER_FIXTURES_DIR });
+      const fixtureEn = summaries.filter(s => s.id === 'fixture-roadmap' && s.language === 'en');
+
+      expect(fixtureEn).toEqual([
+        expect.objectContaining({ title: 'Fixture roadmap', source: 'builtin' }),
+      ]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('collides with a shipped roadmap'));
     });
   });
 
   describe('getRoadmap', () => {
     it('returns the full roadmap for a known id', () => {
-      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', { dir: FIXTURES_DIR });
+      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', dirs);
 
       expect(roadmap).not.toBeNull();
       expect(roadmap?.steps.map(s => s.id)).toEqual(['start-web', 'start-db']);
     });
 
     it('picks deterministically (sorted by language) when no language is given', () => {
-      const first = RoadmapService.getRoadmap('fixture-roadmap', { dir: FIXTURES_DIR });
-      const second = RoadmapService.getRoadmap('fixture-roadmap', { dir: FIXTURES_DIR });
+      const first = RoadmapService.getRoadmap('fixture-roadmap', dirs);
+      const second = RoadmapService.getRoadmap('fixture-roadmap', dirs);
 
       expect(first?.language).toBe('en');
       expect(second?.language).toBe('en');
     });
 
     it('returns the exact translation when a language is given', () => {
-      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', {
-        language: 'fr',
-        dir: FIXTURES_DIR,
-      });
+      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', { language: 'fr', ...dirs });
 
       expect(roadmap?.language).toBe('fr');
       expect(roadmap?.title).toBe('Roadmap de test');
     });
 
     it('returns null for a language with no translation — no fallback', () => {
-      expect(
-        RoadmapService.getRoadmap('fixture-roadmap', { language: 'de', dir: FIXTURES_DIR })
-      ).toBeNull();
+      expect(RoadmapService.getRoadmap('fixture-roadmap', { language: 'de', ...dirs })).toBeNull();
     });
 
     it('returns null for an unknown id', () => {
-      expect(RoadmapService.getRoadmap('does-not-exist', { dir: FIXTURES_DIR })).toBeNull();
+      expect(RoadmapService.getRoadmap('does-not-exist', dirs)).toBeNull();
     });
 
     it('never serves a roadmap from an invalid file', () => {
-      expect(RoadmapService.getRoadmap('broken-roadmap', { dir: FIXTURES_DIR })).toBeNull();
+      expect(RoadmapService.getRoadmap('broken-roadmap', dirs)).toBeNull();
+    });
+
+    it('serves an imported roadmap exactly like a shipped one', () => {
+      const roadmap = RoadmapService.getRoadmap('imported-roadmap', {
+        dir: FIXTURES_DIR,
+        userDir: USER_FIXTURES_DIR,
+      });
+
+      expect(roadmap?.steps.map(s => s.id)).toEqual(['start-cache']);
+    });
+
+    it('never serves the imported file when a shipped roadmap has the same (id, language)', () => {
+      const roadmap = RoadmapService.getRoadmap('fixture-roadmap', {
+        language: 'en',
+        dir: FIXTURES_DIR,
+        userDir: USER_FIXTURES_DIR,
+      });
+
+      expect(roadmap?.title).toBe('Fixture roadmap');
     });
   });
 });

--- a/backend/src/modules/learning/services/roadmapService.ts
+++ b/backend/src/modules/learning/services/roadmapService.ts
@@ -1,7 +1,11 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { Roadmap, RoadmapDifficulty } from '../format/roadmapTypes';
 import { validateRoadmap } from '../format/validateRoadmap';
+
+/** Where a catalogue entry comes from: shipped with Torollo, or imported by the user. */
+export type RoadmapSource = 'builtin' | 'imported';
 
 /** What the roadmap catalogue exposes to the frontend (GET /api/learning/roadmaps). */
 export interface RoadmapSummary {
@@ -12,12 +16,19 @@ export interface RoadmapSummary {
   difficulty?: RoadmapDifficulty;
   estimatedMinutes?: number;
   stepCount: number;
+  source: RoadmapSource;
 }
 
 // Resolved from this file, never from process.cwd(): the CLI spawns the server
 // without a cwd, and dist/ mirrors src/ so the same hops work in dev and prod.
 // services/ → learning → modules → src|dist → backend → repo root.
 const ROADMAPS_DIR = path.resolve(__dirname, '../../../../../roadmaps');
+
+// User-imported roadmaps live next to the other per-user state
+// (projects.json, progress.json). Re-scanned on every call like the shipped
+// directory, so dropping a file here by hand works as well as the import
+// endpoint does.
+export const USER_ROADMAPS_DIR = path.join(os.homedir(), '.torollo', 'roadmaps');
 
 /**
  * The catalogue is a suggested path, not a directory listing: this is the order
@@ -26,8 +37,9 @@ const ROADMAPS_DIR = path.resolve(__dirname, '../../../../../roadmaps');
  * fall back to file names — alphabetical, which pitches whichever roadmap
  * happens to sort first.
  *
- * Roadmaps that are not listed here (community files dropped into `roadmaps/`)
- * follow, ordered by id. Ids that no longer exist are simply ignored.
+ * Roadmaps that are not listed here (community files dropped into `roadmaps/`,
+ * imported roadmaps) follow, ordered by id. Ids that no longer exist are
+ * simply ignored.
  */
 export const CURATED_ROADMAP_ORDER = [
   'resilient-three-tier',
@@ -35,18 +47,30 @@ export const CURATED_ROADMAP_ORDER = [
   'redis-queue-workers',
 ];
 
+/** Directories the catalogue reads — overridden in tests only. */
+export interface RoadmapDirs {
+  dir?: string;
+  userDir?: string;
+}
+
+interface SourcedRoadmap {
+  roadmap: Roadmap;
+  source: RoadmapSource;
+}
+
 /**
- * Loads roadmap files (format v1) from the roadmaps/ directory.
+ * Loads roadmap files (format v1) from the shipped roadmaps/ directory and
+ * from the user's import directory (~/.torollo/roadmaps/).
  *
  * Files are re-read on every call — they are a few kB, requested at human
  * frequency, and this gives roadmap authors hot reload for free. A file that
  * is not valid JSON or does not pass the format schema is logged and skipped,
- * never served. The optional `dir` parameter exists for tests only.
+ * never served.
  */
 export class RoadmapService {
-  public static listRoadmaps(dir: string = ROADMAPS_DIR): RoadmapSummary[] {
-    return this.readAll(dir)
-      .map(roadmap => ({
+  public static listRoadmaps(dirs: RoadmapDirs = {}): RoadmapSummary[] {
+    return this.readAll(dirs)
+      .map(({ roadmap, source }) => ({
         id: roadmap.id,
         title: roadmap.title,
         description: roadmap.description,
@@ -54,6 +78,7 @@ export class RoadmapService {
         difficulty: roadmap.difficulty,
         estimatedMinutes: roadmap.estimatedMinutes,
         stepCount: roadmap.steps.length,
+        source,
       }))
       // Curated order first, then unlisted ids by id. Translations of one id
       // compare equal and keep the file-name order readAll() guarantees, so
@@ -75,22 +100,68 @@ export class RoadmapService {
    */
   public static getRoadmap(
     id: string,
-    opts: { language?: string; dir?: string } = {}
+    opts: { language?: string } & RoadmapDirs = {}
   ): Roadmap | null {
-    const candidates = this.readAll(opts.dir ?? ROADMAPS_DIR).filter(roadmap => roadmap.id === id);
+    const candidates = this.readAll(opts)
+      .map(({ roadmap }) => roadmap)
+      .filter(roadmap => roadmap.id === id);
     if (opts.language) {
       return candidates.find(roadmap => roadmap.language === opts.language) ?? null;
     }
     return candidates.sort((a, b) => a.language.localeCompare(b.language))[0] ?? null;
   }
 
-  private static readAll(dir: string): Roadmap[] {
+  /**
+   * (id, language) pairs of the shipped catalogue — what an import must not
+   * collide with (see the shadowing rule in readAll).
+   */
+  public static builtinKeys(dirs: RoadmapDirs = {}): Set<string> {
+    return new Set(
+      this.readDir(dirs.dir ?? ROADMAPS_DIR, 'builtin').map(({ roadmap }) =>
+        this.key(roadmap.id, roadmap.language)
+      )
+    );
+  }
+
+  /** The catalogue key: translations share an id, so (id, language) is the real key. */
+  public static key(id: string, language: string): string {
+    return `${id}::${language}`;
+  }
+
+  private static readAll(dirs: RoadmapDirs): SourcedRoadmap[] {
+    const builtins = this.readDir(dirs.dir ?? ROADMAPS_DIR, 'builtin');
+    const imported = this.readDir(dirs.userDir ?? USER_ROADMAPS_DIR, 'imported');
+
+    // A shipped roadmap always wins over a user file with the same
+    // (id, language): progress is keyed on the id, and letting a local file
+    // shadow the catalogue would silently rewrite what that progress means.
+    const shipped = new Set(builtins.map(({ roadmap }) => this.key(roadmap.id, roadmap.language)));
+    const merged = [...builtins];
+    for (const entry of imported) {
+      const key = this.key(entry.roadmap.id, entry.roadmap.language);
+      if (shipped.has(key)) {
+        console.warn(
+          `[learning] Ignoring imported roadmap "${entry.roadmap.id}" (${entry.roadmap.language}): ` +
+            'it collides with a shipped roadmap'
+        );
+        continue;
+      }
+      merged.push(entry);
+    }
+    return merged;
+  }
+
+  private static readDir(dir: string, source: RoadmapSource): SourcedRoadmap[] {
     if (!fs.existsSync(dir)) {
-      console.warn(`[learning] Roadmaps directory not found: ${dir}`);
+      // The import directory not existing is the normal state until the first
+      // import — only a missing shipped directory is worth a warning.
+      if (source === 'builtin') {
+        console.warn(`[learning] Roadmaps directory not found: ${dir}`);
+      }
       return [];
     }
 
-    const roadmaps: Roadmap[] = [];
+    const roadmaps: SourcedRoadmap[] = [];
     // Sorted: readdir order is filesystem-dependent, and both the catalogue
     // order and the language-less getRoadmap pick must be stable.
     for (const file of fs.readdirSync(dir).sort()) {
@@ -104,7 +175,7 @@ export class RoadmapService {
           console.warn(`[learning] Skipping invalid roadmap file ${file}: ${result.errors.join('; ')}`);
           continue;
         }
-        roadmaps.push(result.roadmap);
+        roadmaps.push({ roadmap: result.roadmap, source });
       } catch (err: unknown) {
         const reason = err instanceof Error ? err.message : String(err);
         console.warn(`[learning] Skipping invalid roadmap file ${file}: ${reason}`);

--- a/docs/learning-api.md
+++ b/docs/learning-api.md
@@ -5,7 +5,7 @@ The learning module is the auto-corrector behind guided roadmaps: it runs the de
 This document is the contract for API consumers (the roadmap player in the frontend). If you are writing roadmap *content*, read [`roadmap-format.md`](./roadmap-format.md) instead.
 
 - Backend module: `backend/src/modules/learning/`
-- Roadmap files are loaded from the `roadmaps/` directory at the repository root (shipped in the published npm package). Files that fail the format schema are logged on the server and excluded — they are never served.
+- Roadmap files are loaded from two places: the `roadmaps/` directory at the repository root (shipped in the published npm package) and the user's local import directory `~/.torollo/roadmaps/` (see [`local-roadmaps.md`](./local-roadmaps.md)). Files that fail the format schema are logged on the server and excluded — they are never served.
 
 ## Endpoints
 
@@ -13,7 +13,9 @@ This document is the contract for API consumers (the roadmap player in the front
 
 Lists the available roadmaps as summaries — **one entry per file**. Translations of the same roadmap share an `id` and differ by `language` (see the format's language model), so they appear as separate catalogue entries; a selection UI should surface the `language` field.
 
-The list is a **suggested path, not a directory listing**: the roadmaps shipped with Torollo come first, in the order they are meant to be taken (`CURATED_ROADMAP_ORDER` in `roadmapService.ts`), and the rest — roadmaps you dropped into `roadmaps/` yourself — follow, ordered by `id`. Clients can rely on that order: the app pitches the first entry to a first-run user.
+The list is a **suggested path, not a directory listing**: the roadmaps shipped with Torollo come first, in the order they are meant to be taken (`CURATED_ROADMAP_ORDER` in `roadmapService.ts`), and the rest — roadmaps you dropped into `roadmaps/` yourself, or imported locally — follow, ordered by `id`. Clients can rely on that order: the app pitches the first entry to a first-run user.
+
+Each summary carries a `source`: `"builtin"` for a roadmap shipped in the `roadmaps/` directory, `"imported"` for one installed in `~/.torollo/roadmaps/`. A shipped roadmap always wins over an imported file with the same `(id, language)` — progression is keyed on the `id`, so a local file is never allowed to shadow the catalogue.
 
 ```json
 [
@@ -24,7 +26,8 @@ The list is a **suggested path, not a directory listing**: the roadmaps shipped 
     "language": "en",
     "difficulty": "intermediate",
     "estimatedMinutes": 40,
-    "stepCount": 10
+    "stepCount": 10,
+    "source": "builtin"
   }
 ]
 ```
@@ -38,6 +41,32 @@ Because translations share an `id`, the real key is `(id, language)`:
 - `?language=<code>` (optional) — return exactly the translation with that `language`, or `404`. **No fallback**: the player only requests pairs the catalogue advertised.
 - Without `language`, the pick among translations is deterministic (sorted by language code), so repeated calls always return the same file.
 - `404 { "error": "...", "code": "ROADMAP_NOT_FOUND" }` if no valid roadmap matches.
+
+### `POST /api/learning/roadmaps/import`
+
+Installs roadmap files into `~/.torollo/roadmaps/`, where the catalogue picks them up (see [`local-roadmaps.md`](./local-roadmaps.md) for the user-facing behaviour and rules).
+
+The request body is the **raw bytes** of either a single roadmap `.json` file or a `.zip` archive of roadmap files, sent with `Content-Type: application/octet-stream` (an `application/json` body would be parsed and re-serialized by the JSON middleware before the endpoint sees it). The optional `?filename=` query parameter is used in the report. The endpoint decides json-vs-zip from the bytes, not the name.
+
+Every file is validated against the format schema **before** anything is written, and each file succeeds or fails on its own — one broken file in an archive never blocks the others. The response is a per-file report:
+
+```json
+{
+  "imported": [
+    { "file": "my-roadmap.json", "id": "my-roadmap", "language": "en", "title": "My roadmap", "updated": false }
+  ],
+  "rejected": [
+    { "file": "broken.json", "errors": ["/steps/0: missing required field \"instruction\""] }
+  ],
+  "ignored": ["README.md"]
+}
+```
+
+- `imported` — installed as `~/.torollo/roadmaps/<id>.<language>.json`; `updated: true` means a previously imported version was replaced (re-importing a fixed pack is the supported update path).
+- `rejected` — refused, with the reasons: invalid JSON, schema errors, a `(id, language)` that collides with a shipped roadmap, or a duplicate within the same upload.
+- `ignored` — archive entries that are not `.json` files (a pack's README, images…).
+
+Status: `200` when at least one file was installed, `422` when nothing was (the report says why per file), `400` when the body is empty or not raw bytes.
 
 ### `POST /api/learning/validate`
 

--- a/docs/local-roadmaps.md
+++ b/docs/local-roadmaps.md
@@ -1,0 +1,28 @@
+# Importing local roadmaps
+
+Roadmaps don't have to live in Torollo's own `roadmaps/` directory. Any roadmap file at the [open format](./roadmap-format.md) — one you wrote, one someone shared with you, a pack you downloaded — can be installed locally and played exactly like a shipped roadmap: same briefing page, same player, same validation against your real containers, same progression and completion screen.
+
+## Two ways to install
+
+**The import button.** On the Learning page, next to the roadmap list, **Import roadmaps** accepts one or more `.json` roadmap files or a `.zip` archive of them. Every file is validated against the format schema before anything is installed, and you get a per-file report: what was installed, and — for any refused file — the exact field-level reasons, so a typo in a hand-written roadmap is a ten-second fix, not a silent failure.
+
+**The folder.** Imported roadmaps are just files in `~/.torollo/roadmaps/` (next to Torollo's other local state). You can drop a valid roadmap file there yourself; the catalogue re-reads the folder on every request, so it appears immediately — no restart. Invalid files are skipped and logged on the backend, never served. To uninstall a roadmap, delete its file.
+
+The equivalent of the button, from a terminal:
+
+```bash
+curl -X POST --data-binary @my-pack.zip \
+  -H 'Content-Type: application/octet-stream' \
+  'http://localhost:23233/api/learning/roadmaps/import?filename=my-pack.zip'
+```
+
+## Rules worth knowing
+
+- **Imported roadmaps are marked in the catalogue** and, unlike shipped ones, are shown whatever your UI language is — you installed them on purpose, so they never silently disappear when the languages don't match. The card shows the roadmap's language.
+- **A local file can never shadow a shipped roadmap.** Your progression is keyed on the roadmap `id`; an import whose `(id, language)` collides with the shipped catalogue is refused with a clear message. Give your roadmap its own id.
+- **Re-importing updates in place.** Installed files are named `<id>.<language>.json`, so importing a fixed or newer version of the same roadmap replaces the previous one (the report says `updated`). Your progression on it is untouched — it lives in `~/.torollo/progress.json`, keyed by id.
+- **Roadmaps are data, not code.** Validators are declarative JSON interpreted by the engine — importing a roadmap never executes anything from the file.
+
+## Writing your own
+
+The format is documented in the [Roadmap Authoring Reference](./roadmap-format.md), and `backend`'s `npm run roadmap:validate <file>` checks a file from the command line. Share the `.json` (or zip several files together, translations included — one language per file, same `id`); anyone can import it with the button above.

--- a/docs/roadmap-format.md
+++ b/docs/roadmap-format.md
@@ -48,6 +48,8 @@ cd backend && npm run roadmap:validate -- ../my-roadmap.json
 
 The validator either prints `OK` or a list of errors, each pointing at the faulty field (`/steps/0: missing required field "id"`). Unknown fields are rejected — that's deliberate, it catches typos like `titel`.
 
+Play it: drop the file into the repo's `roadmaps/` directory, or — without touching the repo — install it with the **Import roadmaps** button on the Learning page (see [Importing local roadmaps](./local-roadmaps.md)). Both are re-read on every request, so edits show up on refresh.
+
 ## Field reference
 
 ### Roadmap (root object)

--- a/frontend/src/features/learning/components/ImportRoadmapsButton.test.tsx
+++ b/frontend/src/features/learning/components/ImportRoadmapsButton.test.tsx
@@ -1,0 +1,99 @@
+import '../../../i18n';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ImportRoadmapsButton from './ImportRoadmapsButton';
+import type { ImportReport } from '../../../shared/types/roadmap';
+
+function mockImportResponses(responses: Array<{ status: number; json: unknown }>) {
+  const fetchMock = vi.fn();
+  responses.forEach(r => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve({ status: r.status, json: () => Promise.resolve(r.json) } as Response)
+    );
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function selectFile(name: string, content = '{}') {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const file = new File([content], name, { type: 'application/octet-stream' });
+  // jsdom's File has no arrayBuffer() — polyfill just for the component call.
+  Object.defineProperty(file, 'arrayBuffer', {
+    value: () => Promise.resolve(new TextEncoder().encode(content).buffer),
+  });
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+const installedReport: ImportReport = {
+  imported: [
+    { file: 'pack-roadmap.json', id: 'pack-roadmap', language: 'en', title: 'Pack roadmap', updated: false },
+  ],
+  rejected: [],
+  ignored: [],
+};
+
+describe('ImportRoadmapsButton', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uploads the picked file as raw bytes and shows what was installed', async () => {
+    const fetchMock = mockImportResponses([{ status: 200, json: installedReport }]);
+    const onImported = vi.fn();
+    render(<ImportRoadmapsButton onImported={onImported} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /import roadmaps/i }));
+    selectFile('pack.zip');
+
+    await waitFor(() => expect(screen.getByText('Pack roadmap')).toBeInTheDocument());
+    expect(screen.getByText('1 roadmap imported')).toBeInTheDocument();
+    expect(onImported).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/learning/roadmaps/import?filename=pack.zip');
+    expect((init as RequestInit).headers).toEqual({ 'Content-Type': 'application/octet-stream' });
+  });
+
+  it('shows the per-file reasons when the upload is refused (422), and does not refetch', async () => {
+    const rejectedReport: ImportReport = {
+      imported: [],
+      rejected: [{ file: 'broken.json', errors: ['/steps: must be an array'] }],
+      ignored: [],
+    };
+    mockImportResponses([{ status: 422, json: rejectedReport }]);
+    const onImported = vi.fn();
+    render(<ImportRoadmapsButton onImported={onImported} />);
+
+    selectFile('broken.json');
+
+    await waitFor(() => expect(screen.getByText('broken.json')).toBeInTheDocument());
+    expect(screen.getByText('1 file not imported')).toBeInTheDocument();
+    expect(screen.getByText('/steps: must be an array')).toBeInTheDocument();
+    expect(onImported).not.toHaveBeenCalled();
+  });
+
+  it('reports a network failure without crashing', async () => {
+    const fetchMock = vi.fn(() => Promise.reject(new Error('down')));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<ImportRoadmapsButton onImported={vi.fn()} />);
+
+    selectFile('pack.zip');
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not be sent/i)).toBeInTheDocument()
+    );
+  });
+
+  it('closes the report modal', async () => {
+    mockImportResponses([{ status: 200, json: installedReport }]);
+    render(<ImportRoadmapsButton onImported={vi.fn()} />);
+
+    selectFile('pack.zip');
+    await waitFor(() => expect(screen.getByText('Pack roadmap')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(screen.queryByText('Pack roadmap')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/learning/components/ImportRoadmapsButton.tsx
+++ b/frontend/src/features/learning/components/ImportRoadmapsButton.tsx
@@ -1,0 +1,226 @@
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CheckCircle2, Upload, XCircle } from 'lucide-react';
+import Button from '../../../shared/components/Button';
+import Modal from '../../../shared/components/Modal';
+import { API_BASE } from '../../../shared/types';
+import type { ImportReport } from '../../../shared/types/roadmap';
+
+interface ImportRoadmapsButtonProps {
+  /** Called after at least one roadmap was installed — the catalogue should refetch. */
+  onImported: () => void;
+}
+
+const EMPTY_REPORT: ImportReport = { imported: [], rejected: [], ignored: [] };
+
+function mergeReports(into: ImportReport, from: ImportReport): ImportReport {
+  return {
+    imported: [...into.imported, ...from.imported],
+    rejected: [...into.rejected, ...from.rejected],
+    ignored: [...into.ignored, ...from.ignored],
+  };
+}
+
+/**
+ * "Import roadmaps" button of the Learning page: picks .json/.zip files,
+ * uploads them to POST /api/learning/roadmaps/import and shows the per-file
+ * report — what was installed, and for every refused file the exact reasons.
+ */
+export default function ImportRoadmapsButton({ onImported }: ImportRoadmapsButtonProps) {
+  const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [report, setReport] = useState<ImportReport | null>(null);
+  const [requestFailed, setRequestFailed] = useState(false);
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setBusy(true);
+    let merged = EMPTY_REPORT;
+    let failed = false;
+    for (const file of Array.from(files)) {
+      try {
+        // Raw bytes on purpose: an application/json Content-Type would get the
+        // body parsed (and re-serialized) before the import endpoint sees it.
+        const res = await fetch(
+          `${API_BASE}/api/learning/roadmaps/import?filename=${encodeURIComponent(file.name)}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/octet-stream' },
+            body: await file.arrayBuffer(),
+          }
+        );
+        // 200 = something installed, 422 = everything refused; both carry the report.
+        if (res.status === 200 || res.status === 422) {
+          merged = mergeReports(merged, (await res.json()) as ImportReport);
+        } else {
+          failed = true;
+        }
+      } catch (err) {
+        console.error('Failed to import roadmaps:', err);
+        failed = true;
+      }
+    }
+    setBusy(false);
+    setRequestFailed(failed);
+    setReport(merged);
+    if (merged.imported.length > 0) {
+      onImported();
+    }
+  };
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".json,.zip,application/json,application/zip"
+        multiple
+        style={{ display: 'none' }}
+        onChange={e => {
+          void handleFiles(e.target.files);
+          // Same file re-selected later must fire change again (fix → retry).
+          e.target.value = '';
+        }}
+      />
+      <Button onClick={() => inputRef.current?.click()} disabled={busy}>
+        <Upload size={14} style={{ marginRight: 6, verticalAlign: '-2px' }} />
+        {busy ? t('learning.import.importing') : t('learning.import.button')}
+      </Button>
+
+      {report && (
+        <Modal onClose={() => setReport(null)} width="520px">
+          <h3 style={styles.title}>{t('learning.import.title')}</h3>
+
+          {report.imported.length > 0 && (
+            <div style={styles.section}>
+              <div style={{ ...styles.sectionTitle, color: 'var(--color-success)' }}>
+                <CheckCircle2 size={14} style={styles.sectionIcon} />
+                {t('learning.import.importedTitle', { count: report.imported.length })}
+              </div>
+              <ul style={styles.list}>
+                {report.imported.map(entry => (
+                  <li key={`${entry.id}-${entry.language}`} style={styles.listItem}>
+                    <span style={styles.itemTitle}>{entry.title}</span>
+                    <span style={styles.itemMeta}>
+                      {entry.language.toUpperCase()}
+                      {entry.updated ? ` · ${t('learning.import.updated')}` : ''}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {report.rejected.length > 0 && (
+            <div style={styles.section}>
+              <div style={{ ...styles.sectionTitle, color: 'var(--color-danger)' }}>
+                <XCircle size={14} style={styles.sectionIcon} />
+                {t('learning.import.rejectedTitle', { count: report.rejected.length })}
+              </div>
+              <ul style={styles.list}>
+                {report.rejected.map((entry, index) => (
+                  <li key={`${entry.file}-${index}`} style={styles.listItem}>
+                    <span style={styles.itemTitle}>{entry.file}</span>
+                    <ul style={styles.errorList}>
+                      {entry.errors.map((error, errorIndex) => (
+                        <li key={errorIndex} style={styles.errorItem}>
+                          {error}
+                        </li>
+                      ))}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {report.ignored.length > 0 && (
+            <p style={styles.ignored}>
+              {t('learning.import.ignored', { files: report.ignored.join(', ') })}
+            </p>
+          )}
+
+          {requestFailed && <p style={styles.requestFailed}>{t('learning.import.requestFailed')}</p>}
+
+          <div style={styles.footer}>
+            <Button variant="primary" onClick={() => setReport(null)}>
+              {t('learning.import.close')}
+            </Button>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  title: {
+    fontSize: 'var(--text-lg)',
+    fontWeight: 700,
+    color: 'var(--color-text-primary)',
+    margin: '0 0 var(--space-4) 0',
+  },
+  section: {
+    marginBottom: 'var(--space-4)',
+  },
+  sectionTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: 'var(--text-sm)',
+    fontWeight: 600,
+    marginBottom: 'var(--space-2)',
+  },
+  sectionIcon: {
+    marginRight: 6,
+    flexShrink: 0,
+  },
+  list: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-2)',
+  },
+  listItem: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  itemTitle: {
+    fontSize: 'var(--text-sm)',
+    color: 'var(--color-text-primary)',
+    fontWeight: 500,
+  },
+  itemMeta: {
+    fontSize: 'var(--text-xs)',
+    color: 'var(--color-text-muted)',
+  },
+  errorList: {
+    margin: '2px 0 0 0',
+    paddingLeft: 'var(--space-4)',
+  },
+  errorItem: {
+    fontSize: 'var(--text-xs)',
+    fontFamily: 'var(--font-mono)',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.5,
+    overflowWrap: 'anywhere',
+  },
+  ignored: {
+    fontSize: 'var(--text-xs)',
+    color: 'var(--color-text-muted)',
+    margin: '0 0 var(--space-3) 0',
+  },
+  requestFailed: {
+    fontSize: 'var(--text-sm)',
+    color: 'var(--color-danger)',
+    margin: '0 0 var(--space-3) 0',
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: 'var(--space-2)',
+  },
+};

--- a/frontend/src/features/learning/roadmapLanguage.test.ts
+++ b/frontend/src/features/learning/roadmapLanguage.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { filterByUiLanguage } from './roadmapLanguage';
+import type { RoadmapSummary } from '../../shared/types/roadmap';
+
+function summary(overrides: Partial<RoadmapSummary>): RoadmapSummary {
+  return {
+    id: 'some-roadmap',
+    title: 'Some roadmap',
+    description: 'Description.',
+    language: 'en',
+    stepCount: 3,
+    source: 'builtin',
+    ...overrides,
+  };
+}
+
+describe('filterByUiLanguage', () => {
+  it('keeps only roadmaps authored in the active UI language', () => {
+    const kept = filterByUiLanguage(
+      [summary({ id: 'a-roadmap', language: 'en' }), summary({ id: 'b-roadmap', language: 'fr' })],
+      'en'
+    );
+
+    expect(kept.map(s => s.id)).toEqual(['a-roadmap']);
+  });
+
+  it('matches on the base subtag — en-US still sees an en roadmap', () => {
+    const kept = filterByUiLanguage([summary({ language: 'en' })], 'en-US');
+
+    expect(kept).toHaveLength(1);
+  });
+
+  it('always keeps imported roadmaps, whatever their language — an import must never silently vanish', () => {
+    const kept = filterByUiLanguage(
+      [
+        summary({ id: 'pack-roadmap', language: 'en', source: 'imported' }),
+        summary({ id: 'shipped-roadmap', language: 'en', source: 'builtin' }),
+      ],
+      'fr'
+    );
+
+    expect(kept.map(s => s.id)).toEqual(['pack-roadmap']);
+  });
+
+  it('treats an absent source as builtin (older payloads)', () => {
+    const kept = filterByUiLanguage([summary({ language: 'en', source: undefined })], 'fr');
+
+    expect(kept).toEqual([]);
+  });
+});

--- a/frontend/src/features/learning/roadmapLanguage.ts
+++ b/frontend/src/features/learning/roadmapLanguage.ts
@@ -4,11 +4,17 @@ import type { RoadmapSummary } from '../../shared/types/roadmap';
  * Only surface roadmaps authored in the active UI language: an English user
  * sees English roadmaps only. Compare on the base subtag so 'en-US' still
  * matches an 'en' roadmap.
+ *
+ * Imported roadmaps are exempt: the user chose to install them, so hiding
+ * one because it isn't authored in the UI language would make an import
+ * silently vanish. Their card shows the language instead.
  */
 export function filterByUiLanguage(
   summaries: RoadmapSummary[],
   uiLanguage: string
 ): RoadmapSummary[] {
   const base = uiLanguage.split('-')[0];
-  return summaries.filter(summary => summary.language.split('-')[0] === base);
+  return summaries.filter(
+    summary => summary.source === 'imported' || summary.language.split('-')[0] === base
+  );
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -25,11 +25,25 @@
       "steps_one": "{{count}} step",
       "steps_other": "{{count}} steps",
       "minutes": "~{{count}} min",
+      "imported": "Imported ({{lang}})",
       "difficulty": {
         "beginner": "Beginner",
         "intermediate": "Intermediate",
         "advanced": "Advanced"
       }
+    },
+    "import": {
+      "button": "Import roadmaps",
+      "importing": "Importing...",
+      "title": "Import roadmaps",
+      "importedTitle_one": "{{count}} roadmap imported",
+      "importedTitle_other": "{{count}} roadmaps imported",
+      "updated": "updated",
+      "rejectedTitle_one": "{{count}} file not imported",
+      "rejectedTitle_other": "{{count}} files not imported",
+      "ignored": "Skipped (not roadmap files): {{files}}",
+      "requestFailed": "Some files could not be sent. Is the backend running?",
+      "close": "Close"
     },
     "player": {
       "backToCatalog": "All roadmaps",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -25,11 +25,25 @@
       "steps_one": "{{count}} étape",
       "steps_other": "{{count}} étapes",
       "minutes": "~{{count}} min",
+      "imported": "Importée ({{lang}})",
       "difficulty": {
         "beginner": "Débutant",
         "intermediate": "Intermédiaire",
         "advanced": "Avancé"
       }
+    },
+    "import": {
+      "button": "Importer des roadmaps",
+      "importing": "Import en cours...",
+      "title": "Importer des roadmaps",
+      "importedTitle_one": "{{count}} roadmap importée",
+      "importedTitle_other": "{{count}} roadmaps importées",
+      "updated": "mise à jour",
+      "rejectedTitle_one": "{{count}} fichier non importé",
+      "rejectedTitle_other": "{{count}} fichiers non importés",
+      "ignored": "Ignorés (pas des fichiers de roadmap) : {{files}}",
+      "requestFailed": "Certains fichiers n'ont pas pu être envoyés. Le backend est-il démarré ?",
+      "close": "Fermer"
     },
     "player": {
       "backToCatalog": "Toutes les roadmaps",

--- a/frontend/src/pages/ProjectsPage/components/learning/LearningSection.tsx
+++ b/frontend/src/pages/ProjectsPage/components/learning/LearningSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { BookOpen, GraduationCap } from 'lucide-react';
 import Button from '../../../../shared/components/Button';
 import { useRoadmaps } from '../../../../features/learning/hooks/useRoadmaps';
+import ImportRoadmapsButton from '../../../../features/learning/components/ImportRoadmapsButton';
 import { useLearningProgressSummaries } from '../../../../features/learning/hooks/useLearningProgressSummaries';
 import { filterByUiLanguage } from '../../../../features/learning/roadmapLanguage';
 import { hasSeenLearningPitch } from '../../../../features/learning/onboarding';
@@ -108,6 +109,9 @@ export default function LearningSection({ onOpenRoadmap }: LearningSectionProps)
             <div style={styles.roadmapsTitleRow}>
               <BookOpen size={16} color="var(--color-text-muted)" />
               <h4 style={styles.roadmapsTitle}>{t('learning.landing.roadmapsTitle')}</h4>
+              <div style={styles.roadmapsActions}>
+                <ImportRoadmapsButton onImported={fetchRoadmaps} />
+              </div>
             </div>
             {loading ? (
               <div style={styles.cardList} aria-busy="true">
@@ -203,6 +207,9 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 700,
     color: 'var(--color-text-primary)',
     margin: 0,
+  },
+  roadmapsActions: {
+    marginLeft: 'auto',
   },
   cardList: {
     display: 'grid',

--- a/frontend/src/pages/ProjectsPage/components/learning/RoadmapShowcaseCard.tsx
+++ b/frontend/src/pages/ProjectsPage/components/learning/RoadmapShowcaseCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { CheckCircle2, ClipboardList, Clock } from 'lucide-react';
+import { CheckCircle2, ClipboardList, Clock, Package } from 'lucide-react';
 import ProgressBar from '../../../../shared/components/ProgressBar';
 import DifficultyChip from '../../../../features/learning/components/DifficultyChip';
 import { roadmapVisual } from './roadmapVisual';
@@ -41,6 +41,12 @@ export default function RoadmapShowcaseCard({ summary, progress, onOpen }: Roadm
           <span style={styles.metaItem}>
             <Clock size={13} />
             {t('learning.catalog.minutes', { count: summary.estimatedMinutes })}
+          </span>
+        )}
+        {summary.source === 'imported' && (
+          <span style={styles.metaItem}>
+            <Package size={13} />
+            {t('learning.catalog.imported', { lang: summary.language.toUpperCase() })}
           </span>
         )}
       </div>

--- a/frontend/src/shared/types/roadmap.ts
+++ b/frontend/src/shared/types/roadmap.ts
@@ -6,6 +6,7 @@
  * API types:     backend/src/modules/learning/engine/types.ts (ValidatorResult),
  *                controllers/learningController.ts (StepValidationResponse),
  *                services/roadmapService.ts (RoadmapSummary),
+ *                services/roadmapImportService.ts (ImportReport and parts),
  *                services/progressService.ts (StepProgress, RoadmapProgressResponse,
  *                ProgressEntrySummary).
  * The duplication is deliberate: backend and frontend are separate npm
@@ -54,6 +55,9 @@ export interface Roadmap {
   steps: RoadmapStep[];
 }
 
+/** Where a catalogue entry comes from: shipped with Torollo, or imported by the user. */
+export type RoadmapSource = 'builtin' | 'imported';
+
 /** One catalogue entry of GET /api/learning/roadmaps — one per file, so translations are separate entries. */
 export interface RoadmapSummary {
   id: string;
@@ -63,6 +67,33 @@ export interface RoadmapSummary {
   difficulty?: RoadmapDifficulty;
   estimatedMinutes?: number;
   stepCount: number;
+  /** Optional so older mocks keep compiling — an absent source means builtin. */
+  source?: RoadmapSource;
+}
+
+/** One roadmap file accepted by POST /api/learning/roadmaps/import. */
+export interface ImportedRoadmap {
+  /** Name of the uploaded file or archive entry the roadmap came from. */
+  file: string;
+  id: string;
+  language: string;
+  title: string;
+  /** True when this import replaced a previously imported version. */
+  updated: boolean;
+}
+
+/** One roadmap file the import refused, with the reasons a user can act on. */
+export interface RejectedFile {
+  file: string;
+  errors: string[];
+}
+
+/** Response of POST /api/learning/roadmaps/import (200 or, when nothing installed, 422). */
+export interface ImportReport {
+  imported: ImportedRoadmap[];
+  rejected: RejectedFile[];
+  /** Archive entries that are not roadmap files (README, images…) — skipped, not an error. */
+  ignored: string[];
 }
 
 export type ValidatorStatus = 'pass' | 'fail' | 'error';


### PR DESCRIPTION
## Summary of Changes

Roadmaps no longer have to live in the repo's `roadmaps/` directory. This PR adds local import of roadmap packs:

- **Catalogue merge**: the learning catalogue now scans two directories on every request — the shipped `roadmaps/` (source `builtin`) and `~/.torollo/roadmaps/` (source `imported`). Dropping a valid file in the user folder makes it appear on refresh, no restart.
- **Import endpoint**: `POST /api/learning/roadmaps/import` accepts a raw `.json` roadmap or a `.zip` archive of them (magic-byte detection, `adm-zip`, entry-count/size caps). Every file is Ajv-validated **before** anything is written and the response is a per-file report (`imported` / `rejected` with exact field-level errors / `ignored`), so a typo in a hand-written roadmap is an actionable message, not a silent failure.
- **No shadowing**: progression is keyed on roadmap `id`, so an import colliding with a shipped `(id, language)` is refused with a clear message — both at import time and at scan time for hand-dropped files. Installed files are named `<id>.<language>.json`, so re-importing a fixed pack updates in place (`updated` in the report).
- **Frontend**: an **Import roadmaps** button on the Learning page with a report modal, an "Imported (EN)" badge on catalogue cards, and imported roadmaps bypass the UI-language filter (an EN-only pack stays visible in a FR UI — you installed it on purpose). i18n EN/FR.
- **Docs**: new `docs/local-roadmaps.md`, plus updates to `docs/learning-api.md`, `docs/roadmap-format.md` and the README.

Roadmaps remain pure data — importing never executes anything from the file.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend: 470 jest tests passing (incl. 12 new import-service tests with real zip archives, 6 controller tests, merged-catalogue service tests). Frontend: 310 vitest tests passing (incl. language-filter bypass and import-button tests). Both builds and lints clean.

### Manual Verification

End-to-end against real Docker, on an isolated backend (`HOME` scratch dir, compiled `dist/`):

- Imported a `.zip` containing a valid roadmap, an invalid one and a README → `200` with 1 imported, 1 rejected with field-level errors, 1 ignored; catalogue then listed the 6 shipped roadmaps in curated order plus the imported entry marked `imported`.
- Played the imported roadmap end to end: fail-first validation on both steps, created the real `ubuntu` + `postgres` containers, both steps passed, replay stable, progression 2/2 persisted, completion reached.
- Collision with shipped `resilient-three-tier` → `422` with the explanatory refusal.
- Real UI (Playwright): import button + report modal, "Imported" badge, re-import shows `updated`, briefing page of the imported roadmap works, and the EN-only imported roadmap stays visible with the UI switched to French.
- Broken upload with a wrong `Content-Type` gets an explicit `400` telling the client to use `application/octet-stream`.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
