### PR TITLE
feat(telemetry): opt-in anonymous boot and learning-funnel events

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,19 +149,25 @@ TOROLLO_ALLOWED_ORIGINS=http://<your-lan-ip>:23232
 
 Torollo can send **anonymous, opt-in** usage events so we can see where the roadmaps lose people. **Nothing is ever sent unless you explicitly enable it** — the app asks once on the home screen, and until you answer (or if you decline) it makes zero telemetry requests.
 
-If you opt in, exactly five events are sent, and nothing else:
+If you opt in, exactly these events are sent, and nothing else:
 
-| Event | Sent when |
-|---|---|
-| `roadmap_started` | you open a roadmap with no saved progress |
-| `step_validated` | a step's validators all pass |
-| `step_failed` | a validation runs and the step doesn't pass (engine errors are not counted) |
-| `roadmap_completed` | the last remaining step of a roadmap passes |
-| `roadmap_abandoned` | you leave a roadmap before finishing it |
+| Event | Sent when | Extra props |
+|---|---|---|
+| `app_started` | the app loads | — |
+| `runtime_check_started` | the app probes whether Docker is reachable (right after `app_started`) | — |
+| `runtime_ready` | that probe finds Docker running | — |
+| `runtime_failed` | that probe fails | `reason`: `backend_unreachable`, `timeout`, `socket_not_found`, `permission_denied`, `connection_refused` or `unknown` |
+| `image_pull_failed` | a node can't be created because its Docker image failed to download | `node`: the node type (`redis`, `postgres`, …) |
+| `first_validator_run` | the very first time this install runs a step validation | `roadmap`, `step` |
+| `roadmap_started` | you open a roadmap with no saved progress | `roadmap` |
+| `step_validated` | a step's validators all pass | `roadmap`, `step` |
+| `step_failed` | a validation runs and the step doesn't pass (engine errors are not counted) | `roadmap`, `step` |
+| `roadmap_completed` | the last remaining step of a roadmap passes | `roadmap` |
+| `roadmap_abandoned` | you leave a roadmap before finishing it | `roadmap`, `step` |
 
-Each event carries only: the roadmap id and step id from the catalogue, the app version, and a random install id generated locally (never derived from your machine). No personal data, no project names, no container contents, no code. You can inspect every payload in your browser's network tab.
+Every event also carries the app version and a random install id generated locally (never derived from your machine). `roadmap` and `step` are the ids from the catalogue; `reason` and `node` are fixed codes. No personal data, no project names, no socket paths, no error messages, no container contents, no code. You can inspect every payload in your browser's network tab.
 
-**Turning it off (or on) later:** click the activity icon in the home-screen header, or clear the `torollo_telemetry_consent` key from the browser's localStorage. Revoking consent also deletes the install id, so re-enabling later starts a fresh anonymous identity.
+**Turning it off (or on) later:** click the activity icon in the home-screen header, or clear the `torollo_telemetry_consent` key from the browser's localStorage. Revoking consent also deletes the install id (and the "first time" markers tied to it), so re-enabling later starts a fresh anonymous identity.
 
 Forks and self-hosters can point events at their own [Plausible](https://plausible.io)-compatible endpoint (or disable telemetry entirely) at build time with `VITE_TELEMETRY_ENDPOINT` and `VITE_TELEMETRY_DOMAIN` (an empty `VITE_TELEMETRY_ENDPOINT` hard-disables it).
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,28 @@ TOROLLO_ALLOWED_ORIGINS=http://<your-lan-ip>:23232
 
 ---
 
+## Telemetry
+
+Torollo can send **anonymous, opt-in** usage events so we can see where the roadmaps lose people. **Nothing is ever sent unless you explicitly enable it** — the app asks once on the home screen, and until you answer (or if you decline) it makes zero telemetry requests.
+
+If you opt in, exactly five events are sent, and nothing else:
+
+| Event | Sent when |
+|---|---|
+| `roadmap_started` | you open a roadmap with no saved progress |
+| `step_validated` | a step's validators all pass |
+| `step_failed` | a validation runs and the step doesn't pass (engine errors are not counted) |
+| `roadmap_completed` | the last remaining step of a roadmap passes |
+| `roadmap_abandoned` | you leave a roadmap before finishing it |
+
+Each event carries only: the roadmap id and step id from the catalogue, the app version, and a random install id generated locally (never derived from your machine). No personal data, no project names, no container contents, no code. You can inspect every payload in your browser's network tab.
+
+**Turning it off (or on) later:** click the activity icon in the home-screen header, or clear the `torollo_telemetry_consent` key from the browser's localStorage. Revoking consent also deletes the install id, so re-enabling later starts a fresh anonymous identity.
+
+Forks and self-hosters can point events at their own [Plausible](https://plausible.io)-compatible endpoint (or disable telemetry entirely) at build time with `VITE_TELEMETRY_ENDPOINT` and `VITE_TELEMETRY_DOMAIN` (an empty `VITE_TELEMETRY_ENDPOINT` hard-disables it).
+
+---
+
 ## Architecture
 
 * **Backend** — Node.js, Express, TypeScript, Socket.IO, Dockerode. The backend is the supervisor: it drives the local Docker daemon, compiles your visual topology into real `iptables` rules applied inside the containers, and persists state in `~/.torollo/projects.json`. Every node image must ship with `iptables` and `iproute2` — see [Required tooling inside every node image](docs/adding-a-node.md#required-tooling-inside-every-node-image).

--- a/backend/src/infrastructure/docker/dockerErrors.test.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.test.ts
@@ -1,4 +1,4 @@
-import { classifyDockerError, sendDockerError, ContainerNotFoundError } from './dockerErrors';
+import { classifyDaemonFailure, classifyDockerError, sendDockerError, ContainerNotFoundError } from './dockerErrors';
 import { InvalidImageReferenceError } from './imageReference';
 
 describe('classifyDockerError', () => {
@@ -123,5 +123,20 @@ describe('sendDockerError', () => {
     });
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+});
+
+describe('classifyDaemonFailure', () => {
+  it.each([
+    ['ENOENT (socket missing, Docker Desktop not started)', { code: 'ENOENT' }, 'socket_not_found'],
+    ['EACCES (user not in the docker group)', { code: 'EACCES' }, 'permission_denied'],
+    ['EPERM', { code: 'EPERM' }, 'permission_denied'],
+    ['ECONNREFUSED', { code: 'ECONNREFUSED' }, 'connection_refused'],
+    ['ETIMEDOUT', { code: 'ETIMEDOUT' }, 'timeout'],
+    ['an error without a code', new Error('boom'), 'unknown'],
+    ['a non-error value', 'nope', 'unknown'],
+    ['undefined', undefined, 'unknown'],
+  ])('maps %s to %s', (_label, err, expected) => {
+    expect(classifyDaemonFailure(err)).toBe(expected);
   });
 });

--- a/backend/src/infrastructure/docker/dockerErrors.ts
+++ b/backend/src/infrastructure/docker/dockerErrors.ts
@@ -24,6 +24,38 @@ interface DockerErrorLike {
 }
 
 /**
+ * Why the daemon could not be reached, at the granularity that matters for
+ * first-run support: a missing socket (Docker Desktop not started, WSL2
+ * integration off), a socket the user cannot open (not in the `docker`
+ * group), a refused connection, or a hang. Deliberately coarse — a code,
+ * never the socket path or the raw message.
+ */
+export type DaemonFailureReason =
+  | 'socket_not_found'
+  | 'permission_denied'
+  | 'connection_refused'
+  | 'timeout'
+  | 'unknown';
+
+export function classifyDaemonFailure(err: unknown): DaemonFailureReason {
+  const e = (err ?? {}) as DockerErrorLike;
+  switch (e.code) {
+    case 'ENOENT':
+      return 'socket_not_found';
+    case 'EACCES':
+    case 'EPERM':
+      return 'permission_denied';
+    case 'ECONNREFUSED':
+      return 'connection_refused';
+    case 'ETIMEDOUT':
+    case 'ESOCKETTIMEDOUT':
+      return 'timeout';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
  * Thrown when a container id/name does not exist OR belongs to another
  * project. Both cases map to the exact same 404 payload as
  * CONTAINER_NOT_FOUND so a caller cannot probe for a container's existence.

--- a/backend/src/modules/health/controllers/healthController.test.ts
+++ b/backend/src/modules/health/controllers/healthController.test.ts
@@ -28,10 +28,9 @@ describe('HealthController', () => {
       });
     });
 
-    it('should return 503 degraded when Docker is unreachable', async () => {
-      (docker.ping as jest.Mock).mockRejectedValue(
-        new Error('connect ENOENT /var/run/docker.sock')
-      );
+    it('should return 503 degraded with a stable reason when Docker is unreachable', async () => {
+      const err = Object.assign(new Error('connect ENOENT /var/run/docker.sock'), { code: 'ENOENT' });
+      (docker.ping as jest.Mock).mockRejectedValue(err);
 
       const res = await request(app).get('/health');
 
@@ -39,9 +38,22 @@ describe('HealthController', () => {
       expect(res.body).toEqual({
         status: 'degraded',
         checks: {
-          docker: { status: 'unreachable', error: 'connect ENOENT /var/run/docker.sock' },
+          docker: {
+            status: 'unreachable',
+            reason: 'socket_not_found',
+            error: 'connect ENOENT /var/run/docker.sock',
+          },
         },
       });
+    });
+
+    it('should report an unknown reason for an unclassified failure', async () => {
+      (docker.ping as jest.Mock).mockRejectedValue(new Error('boom'));
+
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(503);
+      expect(res.body.checks.docker.reason).toBe('unknown');
     });
   });
 });

--- a/backend/src/modules/health/controllers/healthController.ts
+++ b/backend/src/modules/health/controllers/healthController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import docker from '../../../infrastructure/docker/DockerClient';
+import { classifyDaemonFailure } from '../../../infrastructure/docker/dockerErrors';
 
 export class HealthController {
   static async check(_req: Request, res: Response): Promise<void> {
@@ -13,7 +14,9 @@ export class HealthController {
       const error = err instanceof Error ? err.message : String(err);
       res.status(503).json({
         status: 'degraded',
-        checks: { docker: { status: 'unreachable', error } },
+        // `reason` is the stable, non-identifying code clients may report;
+        // `error` is the raw message for a human reading the response.
+        checks: { docker: { status: 'unreachable', reason: classifyDaemonFailure(err), error } },
       });
     }
   }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 import CanvasPage from '../pages/CanvasPage/CanvasPage';
 import TerminalModal from '../features/terminal/components/TerminalModal';
 import ProjectsPage from '../pages/ProjectsPage/ProjectsPage';
+import { useBootTelemetry } from '../features/telemetry/useBootTelemetry';
 import type { LearningIntent, ProjectInfo, TerminalInfo } from '../shared/types';
 
 function App() {
+  useBootTelemetry();
   const [activeProject, setActiveProject] = useState<ProjectInfo | null>(() => {
     const saved = localStorage.getItem('akal-active-project');
     try {

--- a/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLearningPlayer } from './useLearningPlayer';
+import { trackEvent } from '../../telemetry/telemetry';
 import type {
   Roadmap,
   RoadmapProgressResponse,
   StepValidationResponse,
 } from '../../../shared/types/roadmap';
+
+vi.mock('../../telemetry/telemetry', () => ({ trackEvent: vi.fn() }));
+const trackEventMock = vi.mocked(trackEvent);
 
 function jsonResponse(ok: boolean, body: unknown): Response {
   return { ok, json: () => Promise.resolve(body) } as Response;
@@ -72,6 +76,7 @@ describe('useLearningPlayer', () => {
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    trackEventMock.mockClear();
   });
 
   afterEach(() => {
@@ -454,6 +459,138 @@ describe('useLearningPlayer', () => {
       expect(result.current.completedStepIds).toEqual({});
       expect(result.current.progressNotice).toBe(false);
       expect(result.current.currentStepIndex).toBe(0);
+    });
+  });
+
+  describe('telemetry events', () => {
+    const doneStep = { passed: true, attempts: 1, revealedHints: 0 };
+    const halfDoneProgress: RoadmapProgressResponse = {
+      projectId: 'p1',
+      roadmapId: roadmap.id,
+      steps: { 'create-web-server': doneStep },
+    };
+    const allDoneProgress: RoadmapProgressResponse = {
+      projectId: 'p1',
+      roadmapId: roadmap.id,
+      steps: { 'create-web-server': doneStep, 'add-database': doneStep },
+    };
+    const failResponse: StepValidationResponse = {
+      roadmapId: roadmap.id,
+      stepId: 'create-web-server',
+      stepPassed: false,
+      results: [{ index: 0, type: 'container_running', status: 'fail', message: 'Not running.' }],
+      checkedAt: '2026-07-15T10:00:00.000Z',
+    };
+    const errorResponse: StepValidationResponse = {
+      roadmapId: roadmap.id,
+      stepId: 'create-web-server',
+      stepPassed: false,
+      results: [{ index: 0, type: 'container_running', status: 'error', message: 'Docker down.' }],
+      checkedAt: '2026-07-15T10:00:00.000Z',
+    };
+
+    it('fires roadmap_started when the persisted progress is empty', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+      expect(trackEventMock).toHaveBeenCalledWith('roadmap_started', { roadmap: roadmap.id });
+    });
+
+    it('does not fire roadmap_started on a resumed run or an unreachable progress store', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock, halfDoneProgress);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, roadmap));
+      fetchMock.mockRejectedValueOnce(new Error('network down'));
+      await act(async () => {
+        await result.current.openRoadmap({ id: roadmap.id, language: 'en' });
+      });
+
+      expect(trackEventMock).not.toHaveBeenCalledWith('roadmap_started', expect.anything());
+    });
+
+    it('fires step_validated on a pass and step_failed on a fail, never on an engine error', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, failResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(trackEventMock).toHaveBeenCalledWith('step_failed', {
+        roadmap: roadmap.id,
+        step: 'create-web-server',
+      });
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, errorResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(trackEventMock).not.toHaveBeenCalledWith('step_validated', expect.anything());
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, passResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(trackEventMock).toHaveBeenCalledWith('step_validated', {
+        roadmap: roadmap.id,
+        step: 'create-web-server',
+      });
+    });
+
+    it('fires roadmap_completed once, on the validation that completes the roadmap', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock, halfDoneProgress);
+      expect(result.current.currentStep?.id).toBe('add-database');
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, { ...passResponse, stepId: 'add-database' }));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(trackEventMock).toHaveBeenCalledWith('roadmap_completed', { roadmap: roadmap.id });
+
+      // Re-validating a step of the already complete roadmap must not recount.
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, { ...passResponse, stepId: 'add-database' }));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      const completions = trackEventMock.mock.calls.filter(([name]) => name === 'roadmap_completed');
+      expect(completions).toHaveLength(1);
+    });
+
+    it('fires roadmap_abandoned with keepalive when an unfinished roadmap is closed', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      act(() => result.current.closeRoadmap());
+
+      expect(trackEventMock).toHaveBeenCalledWith(
+        'roadmap_abandoned',
+        { roadmap: roadmap.id, step: 'create-web-server' },
+        { keepalive: true }
+      );
+    });
+
+    it('does not fire roadmap_abandoned when the roadmap is complete', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock, allDoneProgress);
+
+      act(() => result.current.closeRoadmap());
+
+      expect(trackEventMock).not.toHaveBeenCalledWith(
+        'roadmap_abandoned',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('fires roadmap_abandoned exactly once on unmount with the player open', async () => {
+      const { result, unmount } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      unmount();
+
+      const abandons = trackEventMock.mock.calls.filter(([name]) => name === 'roadmap_abandoned');
+      expect(abandons).toHaveLength(1);
     });
   });
 });

--- a/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.test.ts
@@ -73,6 +73,7 @@ describe('useLearningPlayer', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    localStorage.clear();
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -488,6 +489,38 @@ describe('useLearningPlayer', () => {
       results: [{ index: 0, type: 'container_running', status: 'error', message: 'Docker down.' }],
       checkedAt: '2026-07-15T10:00:00.000Z',
     };
+
+    it('fires first_validator_run once per install, whatever the verdict', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, errorResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(trackEventMock).toHaveBeenCalledWith('first_validator_run', {
+        roadmap: roadmap.id,
+        step: 'create-web-server',
+      });
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(true, passResponse));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      const firsts = trackEventMock.mock.calls.filter(([name]) => name === 'first_validator_run');
+      expect(firsts).toHaveLength(1);
+    });
+
+    it('does not fire first_validator_run when the validation request itself fails', async () => {
+      const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));
+      await openExampleRoadmap(result, fetchMock);
+
+      fetchMock.mockResolvedValueOnce(jsonResponse(false, { error: 'Docker down' }));
+      await act(async () => {
+        await result.current.validateCurrentStep();
+      });
+      expect(trackEventMock).not.toHaveBeenCalledWith('first_validator_run', expect.anything());
+    });
 
     it('fires roadmap_started when the persisted progress is empty', async () => {
       const { result } = renderHook(() => useLearningPlayer({ projectId: 'p1' }));

--- a/frontend/src/features/learning/hooks/useLearningPlayer.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { API_BASE } from '../../../shared/types';
 import { readErrorMessage } from '../../../shared/utils/readErrorMessage';
 import { trackEvent } from '../../telemetry/telemetry';
+import { claimMilestone } from '../../telemetry/milestones';
 import { stepOutcome } from '../validationStatus';
 import type {
   Roadmap,
@@ -249,6 +250,12 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
       }
       const response: StepValidationResponse = await res.json();
       setResultsByStepId(prev => ({ ...prev, [currentStep.id]: response }));
+
+      // The install's first-ever validation, whatever its verdict: the moment
+      // the learner has crossed setup and is actually using the engine.
+      if (claimMilestone('first_validator_run')) {
+        trackEvent('first_validator_run', { roadmap: roadmap.id, step: currentStep.id });
+      }
 
       // An engine error is not a pedagogical failure — it is not counted.
       const outcome = stepOutcome(response);

--- a/frontend/src/features/learning/hooks/useLearningPlayer.ts
+++ b/frontend/src/features/learning/hooks/useLearningPlayer.ts
@@ -1,6 +1,8 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { API_BASE } from '../../../shared/types';
 import { readErrorMessage } from '../../../shared/utils/readErrorMessage';
+import { trackEvent } from '../../telemetry/telemetry';
+import { stepOutcome } from '../validationStatus';
 import type {
   Roadmap,
   RoadmapProgressResponse,
@@ -57,8 +59,50 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
   // Two quick openRoadmap clicks race on fetch resolution order; only the
   // latest request is allowed to commit its result.
   const openSeqRef = useRef(0);
+  // Telemetry: the open play-through, read by the abandon paths (close,
+  // unmount, pagehide) — a ref so those handlers see the latest state.
+  const telemetrySessionRef = useRef<{ roadmapId: string; stepId: string; complete: boolean } | null>(
+    null
+  );
 
   const currentStep: RoadmapStep | null = roadmap?.steps[currentStepIndex] ?? null;
+
+  useEffect(() => {
+    if (!roadmap || !currentStep) {
+      telemetrySessionRef.current = null;
+      return;
+    }
+    telemetrySessionRef.current = {
+      roadmapId: roadmap.id,
+      stepId: currentStep.id,
+      complete: roadmap.steps.every(
+        step => completedStepIds[step.id] || resultsByStepId[step.id]?.stepPassed
+      ),
+    };
+  }, [roadmap, currentStep, completedStepIds, resultsByStepId]);
+
+  // Leaving an unfinished roadmap is the abandon event, whatever the exit:
+  // closing the player, unmounting it, or closing/refreshing the whole tab.
+  // Nulling the ref makes the event once-per-play-through — close followed by
+  // unmount must not double-count.
+  const fireAbandon = useCallback(() => {
+    const session = telemetrySessionRef.current;
+    if (!session || session.complete) return;
+    telemetrySessionRef.current = null;
+    trackEvent(
+      'roadmap_abandoned',
+      { roadmap: session.roadmapId, step: session.stepId },
+      { keepalive: true }
+    );
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('pagehide', fireAbandon);
+    return () => {
+      window.removeEventListener('pagehide', fireAbandon);
+      fireAbandon();
+    };
+  }, [fireAbandon]);
 
   const progressUrl = useCallback(
     (roadmapId: string) =>
@@ -92,12 +136,14 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
         // Progress is a convenience: if it can't be read, open fresh anyway.
         let progressSteps: Record<string, StepProgress> = {};
         let recovered = false;
+        let progressLoaded = false;
         try {
           const progressRes = await fetch(progressUrl(data.id));
           if (progressRes.ok) {
             const progress: RoadmapProgressResponse = await progressRes.json();
             progressSteps = progress.steps ?? {};
             recovered = progress.storeRecovered === true;
+            progressLoaded = true;
           } else {
             console.error('Failed to load roadmap progress: HTTP', progressRes.status);
           }
@@ -129,6 +175,12 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
         setProgressNotice(recovered);
         setValidationError(null);
         setResetError(null);
+
+        // A confirmed-empty progress store is what "started" means; a failed
+        // progress fetch could be a resumed run, so it never counts as one.
+        if (progressLoaded && Object.keys(progressSteps).length === 0) {
+          trackEvent('roadmap_started', { roadmap: data.id });
+        }
       } catch (err) {
         console.error('Failed to load roadmap:', err);
         if (seq === openSeqRef.current) setRoadmapError('');
@@ -140,6 +192,7 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
   );
 
   const closeRoadmap = useCallback(() => {
+    fireAbandon();
     setRoadmap(null);
     setRoadmapError(null);
     setCurrentStepIndex(0);
@@ -149,7 +202,7 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
     setProgressNotice(false);
     setValidationError(null);
     setResetError(null);
-  }, []);
+  }, [fireAbandon]);
 
   const goToStep = useCallback(
     (index: number) => {
@@ -196,6 +249,28 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
       }
       const response: StepValidationResponse = await res.json();
       setResultsByStepId(prev => ({ ...prev, [currentStep.id]: response }));
+
+      // An engine error is not a pedagogical failure — it is not counted.
+      const outcome = stepOutcome(response);
+      if (outcome !== 'error') {
+        trackEvent(outcome === 'passed' ? 'step_validated' : 'step_failed', {
+          roadmap: roadmap.id,
+          step: currentStep.id,
+        });
+      }
+
+      // Fresh completion only — this verdict turned the last missing step
+      // green. Re-validating a step of an already complete roadmap must not
+      // count the roadmap as completed again.
+      const stepDone = (step: RoadmapStep) =>
+        completedStepIds[step.id] || resultsByStepId[step.id]?.stepPassed;
+      const wasComplete = roadmap.steps.every(stepDone);
+      const nowComplete =
+        response.stepPassed &&
+        roadmap.steps.every(step => step.id === currentStep.id || stepDone(step));
+      if (nowComplete && !wasComplete) {
+        trackEvent('roadmap_completed', { roadmap: roadmap.id });
+      }
     } catch (err) {
       console.error('Failed to validate step:', err);
       setValidationError('');
@@ -203,7 +278,7 @@ export function useLearningPlayer({ projectId }: UseLearningPlayerOptions) {
       validatingRef.current = false;
       setValidating(false);
     }
-  }, [projectId, roadmap, currentStep]);
+  }, [projectId, roadmap, currentStep, completedStepIds, resultsByStepId]);
 
   /** Forgets this roadmap's persisted progress and restarts it from step 1. */
   const resetProgress = useCallback(async () => {

--- a/frontend/src/features/telemetry/consent.test.ts
+++ b/frontend/src/features/telemetry/consent.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getInstallId,
+  getTelemetryConsent,
+  setTelemetryConsent,
+  subscribeTelemetryConsent,
+} from './consent';
+
+describe('telemetry consent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to unset when nothing is stored', () => {
+    expect(getTelemetryConsent()).toBe('unset');
+  });
+
+  it('round-trips accepted and declined', () => {
+    setTelemetryConsent('accepted');
+    expect(getTelemetryConsent()).toBe('accepted');
+    setTelemetryConsent('declined');
+    expect(getTelemetryConsent()).toBe('declined');
+  });
+
+  it('treats an unknown stored value as unset', () => {
+    localStorage.setItem('torollo_telemetry_consent', 'yes-please');
+    expect(getTelemetryConsent()).toBe('unset');
+  });
+
+  it('falls back to unset when storage throws', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    expect(getTelemetryConsent()).toBe('unset');
+    spy.mockRestore();
+  });
+
+  it('notifies subscribers on change and stops after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeTelemetryConsent(listener);
+    setTelemetryConsent('accepted');
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    setTelemetryConsent('declined');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the install id stable across calls', () => {
+    const first = getInstallId();
+    expect(first).toBeTruthy();
+    expect(getInstallId()).toBe(first);
+  });
+
+  it('forgets the install id when consent is revoked', () => {
+    setTelemetryConsent('accepted');
+    const first = getInstallId();
+    setTelemetryConsent('declined');
+    expect(localStorage.getItem('torollo_telemetry_install_id')).toBeNull();
+    setTelemetryConsent('accepted');
+    expect(getInstallId()).not.toBe(first);
+  });
+});

--- a/frontend/src/features/telemetry/consent.test.ts
+++ b/frontend/src/features/telemetry/consent.test.ts
@@ -51,6 +51,13 @@ describe('telemetry consent', () => {
     expect(getInstallId()).toBe(first);
   });
 
+  it('forgets the claimed milestones when consent is revoked', () => {
+    setTelemetryConsent('accepted');
+    localStorage.setItem('torollo_telemetry_milestones', '["first_validator_run"]');
+    setTelemetryConsent('declined');
+    expect(localStorage.getItem('torollo_telemetry_milestones')).toBeNull();
+  });
+
   it('forgets the install id when consent is revoked', () => {
     setTelemetryConsent('accepted');
     const first = getInstallId();

--- a/frontend/src/features/telemetry/consent.ts
+++ b/frontend/src/features/telemetry/consent.ts
@@ -1,0 +1,65 @@
+const CONSENT_KEY = 'torollo_telemetry_consent';
+const INSTALL_ID_KEY = 'torollo_telemetry_install_id';
+
+/**
+ * Tri-state on purpose: `unset` (never asked or storage unavailable) must
+ * behave exactly like `declined` — zero network — while still telling the UI
+ * that the consent prompt has not been answered yet.
+ */
+export type TelemetryConsent = 'accepted' | 'declined' | 'unset';
+
+const listeners = new Set<() => void>();
+
+export function getTelemetryConsent(): TelemetryConsent {
+  try {
+    const stored = localStorage.getItem(CONSENT_KEY);
+    return stored === 'accepted' || stored === 'declined' ? stored : 'unset';
+  } catch {
+    // Storage disabled (private mode, hardened profile): treat as never
+    // asked, which the sender treats as declined.
+    return 'unset';
+  }
+}
+
+export function setTelemetryConsent(value: 'accepted' | 'declined'): void {
+  try {
+    localStorage.setItem(CONSENT_KEY, value);
+    // Revoking consent also forgets the install id: re-enabling later starts
+    // a fresh anonymous identity instead of relinking to the old one.
+    if (value === 'declined') localStorage.removeItem(INSTALL_ID_KEY);
+  } catch {
+    // Nothing to persist to — the runtime default (unset → no events) holds.
+  }
+  listeners.forEach(listener => listener());
+}
+
+/** Subscription for useSyncExternalStore, so every consent UI stays in sync. */
+export function subscribeTelemetryConsent(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Random, locally-generated install id. Created lazily on first use — which
+ * only ever happens after consent — so a declined install carries no id at
+ * all. Never derived from anything about the machine or the user.
+ */
+export function getInstallId(): string {
+  try {
+    const existing = localStorage.getItem(INSTALL_ID_KEY);
+    if (existing) return existing;
+    const id = generateId();
+    localStorage.setItem(INSTALL_ID_KEY, id);
+    return id;
+  } catch {
+    // No storage means a new id per event; anonymity is preserved either way.
+    return generateId();
+  }
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
+}

--- a/frontend/src/features/telemetry/consent.ts
+++ b/frontend/src/features/telemetry/consent.ts
@@ -1,5 +1,4 @@
-const CONSENT_KEY = 'torollo_telemetry_consent';
-const INSTALL_ID_KEY = 'torollo_telemetry_install_id';
+import { CONSENT_KEY, INSTALL_ID_KEY, MILESTONES_KEY } from './storageKeys';
 
 /**
  * Tri-state on purpose: `unset` (never asked or storage unavailable) must
@@ -24,9 +23,13 @@ export function getTelemetryConsent(): TelemetryConsent {
 export function setTelemetryConsent(value: 'accepted' | 'declined'): void {
   try {
     localStorage.setItem(CONSENT_KEY, value);
-    // Revoking consent also forgets the install id: re-enabling later starts
-    // a fresh anonymous identity instead of relinking to the old one.
-    if (value === 'declined') localStorage.removeItem(INSTALL_ID_KEY);
+    // Revoking consent also forgets the install id and its claimed
+    // milestones: re-enabling later starts a fresh anonymous identity
+    // instead of relinking to the old one.
+    if (value === 'declined') {
+      localStorage.removeItem(INSTALL_ID_KEY);
+      localStorage.removeItem(MILESTONES_KEY);
+    }
   } catch {
     // Nothing to persist to — the runtime default (unset → no events) holds.
   }

--- a/frontend/src/features/telemetry/milestones.test.ts
+++ b/frontend/src/features/telemetry/milestones.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { claimMilestone } from './milestones';
+import { setTelemetryConsent } from './consent';
+
+describe('claimMilestone', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('is true the first time and false afterwards', () => {
+    expect(claimMilestone('first_validator_run')).toBe(true);
+    expect(claimMilestone('first_validator_run')).toBe(false);
+    expect(claimMilestone('first_validator_run')).toBe(false);
+  });
+
+  it('survives a corrupted store by starting over', () => {
+    localStorage.setItem('torollo_telemetry_milestones', '{not json');
+    expect(() => claimMilestone('first_validator_run')).not.toThrow();
+    expect(claimMilestone('first_validator_run')).toBe(false);
+  });
+
+  it('claims again after consent is revoked, like a fresh install', () => {
+    setTelemetryConsent('accepted');
+    expect(claimMilestone('first_validator_run')).toBe(true);
+    setTelemetryConsent('declined');
+    setTelemetryConsent('accepted');
+    expect(claimMilestone('first_validator_run')).toBe(true);
+  });
+
+  it('treats every call as a first when storage throws', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    expect(claimMilestone('first_validator_run')).toBe(true);
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/features/telemetry/milestones.ts
+++ b/frontend/src/features/telemetry/milestones.ts
@@ -1,0 +1,34 @@
+import { MILESTONES_KEY } from './storageKeys';
+
+/** Once-per-install events. Extend the union when a new "first" is tracked. */
+export type TelemetryMilestone = 'first_validator_run';
+
+/**
+ * Claims a milestone: true the first time it is called for this install,
+ * false on every later call. Claims live next to the install id and are
+ * wiped with it on revocation, so a fresh identity gets its "firsts" again.
+ *
+ * Without storage every call is a first — a duplicate event beats a lost one.
+ */
+export function claimMilestone(name: TelemetryMilestone): boolean {
+  try {
+    const claimed = readClaimed();
+    if (claimed.includes(name)) return false;
+    localStorage.setItem(MILESTONES_KEY, JSON.stringify([...claimed, name]));
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+/** A corrupted store reads as empty and is overwritten by the next claim. */
+function readClaimed(): string[] {
+  const raw = localStorage.getItem(MILESTONES_KEY);
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/frontend/src/features/telemetry/storageKeys.ts
+++ b/frontend/src/features/telemetry/storageKeys.ts
@@ -1,0 +1,7 @@
+/**
+ * Every localStorage key telemetry owns, in one place: revoking consent must
+ * wipe all of them except the consent itself, so the list is the contract.
+ */
+export const CONSENT_KEY = 'torollo_telemetry_consent';
+export const INSTALL_ID_KEY = 'torollo_telemetry_install_id';
+export const MILESTONES_KEY = 'torollo_telemetry_milestones';

--- a/frontend/src/features/telemetry/telemetry.test.ts
+++ b/frontend/src/features/telemetry/telemetry.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { trackEvent } from './telemetry';
+import { setTelemetryConsent } from './consent';
+
+describe('trackEvent', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('performs zero network requests while consent is unset', () => {
+    trackEvent('roadmap_started', { roadmap: 'r1' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('performs zero network requests when consent is declined', () => {
+    setTelemetryConsent('declined');
+    trackEvent('step_validated', { roadmap: 'r1', step: 's1' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends one Plausible-shaped event when consent is accepted', () => {
+    setTelemetryConsent('accepted');
+    trackEvent('step_failed', { roadmap: 'r1', step: 's2' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(init.keepalive).toBe(false);
+    const payload = JSON.parse(init.body);
+    expect(payload.name).toBe('step_failed');
+    expect(payload.domain).toBeTruthy();
+    expect(payload.url).toBe('app://torollo/roadmap/r1');
+    expect(payload.props.roadmap).toBe('r1');
+    expect(payload.props.step).toBe('s2');
+    expect(payload.props.install_id).toBeTruthy();
+    expect(payload.props.app_version).toBeTruthy();
+    // The exhaustive prop list — anything beyond it would be an undocumented
+    // (and potentially identifying) leak.
+    expect(Object.keys(payload.props).sort()).toEqual([
+      'app_version',
+      'install_id',
+      'roadmap',
+      'step',
+    ]);
+  });
+
+  it('reuses the same install id across events', () => {
+    setTelemetryConsent('accepted');
+    trackEvent('roadmap_started', { roadmap: 'r1' });
+    trackEvent('roadmap_completed', { roadmap: 'r1' });
+    const ids = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body).props.install_id);
+    expect(ids[0]).toBe(ids[1]);
+  });
+
+  it('passes keepalive through for exit events', () => {
+    setTelemetryConsent('accepted');
+    trackEvent('roadmap_abandoned', { roadmap: 'r1', step: 's3' }, { keepalive: true });
+    expect(fetchMock.mock.calls[0][1].keepalive).toBe(true);
+  });
+
+  it('never throws when the network call fails', async () => {
+    setTelemetryConsent('accepted');
+    fetchMock.mockRejectedValue(new Error('offline'));
+    expect(() => trackEvent('roadmap_started', { roadmap: 'r1' })).not.toThrow();
+    // Let the rejected promise settle — the .catch inside must absorb it.
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+});

--- a/frontend/src/features/telemetry/telemetry.test.ts
+++ b/frontend/src/features/telemetry/telemetry.test.ts
@@ -52,6 +52,25 @@ describe('trackEvent', () => {
     ]);
   });
 
+  it('files events without a roadmap under the app root', () => {
+    setTelemetryConsent('accepted');
+    trackEvent('app_started', {});
+    trackEvent('runtime_failed', { reason: 'socket_not_found' });
+    trackEvent('image_pull_failed', { node: 'redis' });
+
+    const payloads = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body));
+    expect(payloads.map(p => p.url)).toEqual([
+      'app://torollo/app',
+      'app://torollo/app',
+      'app://torollo/app',
+    ]);
+    expect(Object.keys(payloads[0].props).sort()).toEqual(['app_version', 'install_id']);
+    expect(Object.keys(payloads[1].props).sort()).toEqual(['app_version', 'install_id', 'reason']);
+    expect(payloads[1].props.reason).toBe('socket_not_found');
+    expect(Object.keys(payloads[2].props).sort()).toEqual(['app_version', 'install_id', 'node']);
+    expect(payloads[2].props.node).toBe('redis');
+  });
+
   it('reuses the same install id across events', () => {
     setTelemetryConsent('accepted');
     trackEvent('roadmap_started', { roadmap: 'r1' });

--- a/frontend/src/features/telemetry/telemetry.ts
+++ b/frontend/src/features/telemetry/telemetry.ts
@@ -1,0 +1,62 @@
+import { getInstallId, getTelemetryConsent } from './consent';
+
+/**
+ * The five learning-funnel events — the exhaustive list, mirrored verbatim in
+ * the README's Telemetry section. Adding an event here means updating the
+ * README in the same change.
+ */
+export type TelemetryEventName =
+  | 'roadmap_started'
+  | 'step_validated'
+  | 'step_failed'
+  | 'roadmap_completed'
+  | 'roadmap_abandoned';
+
+export interface TelemetryEventProps {
+  /** Roadmap id from the public catalogue — never a user-chosen name. */
+  roadmap: string;
+  /** Step id within the roadmap file, for the funnel/abandon breakdowns. */
+  step?: string;
+}
+
+// Overridable at build time so self-hosters and forks can point events at
+// their own instance — or build with an empty endpoint to hard-disable.
+const ENDPOINT: string =
+  (import.meta.env.VITE_TELEMETRY_ENDPOINT as string | undefined) ?? 'https://plausible.io/api/event';
+const DOMAIN: string =
+  (import.meta.env.VITE_TELEMETRY_DOMAIN as string | undefined) ?? 'torollo.app';
+
+declare const __APP_VERSION__: string;
+
+/**
+ * Sends one event as a Plausible custom event (Umami and self-hosted
+ * Plausible accept the same shape). Hard rules, enforced by tests:
+ * without an explicit `accepted` consent this performs ZERO network requests,
+ * and the payload never carries PII — only catalogue ids, the app version and
+ * a random local install id.
+ *
+ * Fire-and-forget: telemetry must never throw, block, or surface an error.
+ */
+export function trackEvent(
+  name: TelemetryEventName,
+  props: TelemetryEventProps,
+  options: { keepalive?: boolean } = {}
+): void {
+  if (getTelemetryConsent() !== 'accepted' || !ENDPOINT) return;
+  try {
+    void fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        url: `app://torollo/roadmap/${props.roadmap}`,
+        domain: DOMAIN,
+        props: { ...props, install_id: getInstallId(), app_version: __APP_VERSION__ },
+      }),
+      // keepalive lets the abandon event survive the page being closed.
+      keepalive: options.keepalive === true,
+    }).catch(() => {});
+  } catch {
+    // A broken fetch environment must never take the app down with it.
+  }
+}

--- a/frontend/src/features/telemetry/telemetry.ts
+++ b/frontend/src/features/telemetry/telemetry.ts
@@ -1,23 +1,33 @@
 import { getInstallId, getTelemetryConsent } from './consent';
+import type { DockerHealthReason } from '../../shared/hooks/useDockerHealth';
 
 /**
- * The five learning-funnel events — the exhaustive list, mirrored verbatim in
- * the README's Telemetry section. Adding an event here means updating the
- * README in the same change.
+ * The exhaustive event list with the props each one carries, mirrored
+ * verbatim in the README's Telemetry section. Adding an event or a prop here
+ * means updating the README in the same change.
+ *
+ * Prop values are always catalogue ids or closed enums — never free text,
+ * names, paths or error messages.
  */
-export type TelemetryEventName =
-  | 'roadmap_started'
-  | 'step_validated'
-  | 'step_failed'
-  | 'roadmap_completed'
-  | 'roadmap_abandoned';
-
-export interface TelemetryEventProps {
-  /** Roadmap id from the public catalogue — never a user-chosen name. */
-  roadmap: string;
-  /** Step id within the roadmap file, for the funnel/abandon breakdowns. */
-  step?: string;
+export interface TelemetryEvents {
+  /** Once per page load. */
+  app_started: Record<string, never>;
+  /** The Docker readiness probe that follows app_started. */
+  runtime_check_started: Record<string, never>;
+  runtime_ready: Record<string, never>;
+  runtime_failed: { reason: DockerHealthReason };
+  /** A node could not be created because its image failed to download. */
+  image_pull_failed: { node: string };
+  /** The very first validation this install ever runs. */
+  first_validator_run: { roadmap: string; step: string };
+  roadmap_started: { roadmap: string };
+  step_validated: { roadmap: string; step: string };
+  step_failed: { roadmap: string; step: string };
+  roadmap_completed: { roadmap: string };
+  roadmap_abandoned: { roadmap: string; step: string };
 }
+
+export type TelemetryEventName = keyof TelemetryEvents;
 
 // Overridable at build time so self-hosters and forks can point events at
 // their own instance — or build with an empty endpoint to hard-disable.
@@ -32,14 +42,14 @@ declare const __APP_VERSION__: string;
  * Sends one event as a Plausible custom event (Umami and self-hosted
  * Plausible accept the same shape). Hard rules, enforced by tests:
  * without an explicit `accepted` consent this performs ZERO network requests,
- * and the payload never carries PII — only catalogue ids, the app version and
- * a random local install id.
+ * and the payload never carries PII — only the props declared above, the app
+ * version and a random local install id.
  *
  * Fire-and-forget: telemetry must never throw, block, or surface an error.
  */
-export function trackEvent(
-  name: TelemetryEventName,
-  props: TelemetryEventProps,
+export function trackEvent<Name extends TelemetryEventName>(
+  name: Name,
+  props: TelemetryEvents[Name],
   options: { keepalive?: boolean } = {}
 ): void {
   if (getTelemetryConsent() !== 'accepted' || !ENDPOINT) return;
@@ -49,7 +59,7 @@ export function trackEvent(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         name,
-        url: `app://torollo/roadmap/${props.roadmap}`,
+        url: eventUrl(props),
         domain: DOMAIN,
         props: { ...props, install_id: getInstallId(), app_version: __APP_VERSION__ },
       }),
@@ -59,4 +69,13 @@ export function trackEvent(
   } catch {
     // A broken fetch environment must never take the app down with it.
   }
+}
+
+/**
+ * Plausible requires a page URL per event. Roadmap events are filed under
+ * their roadmap so the Pages report doubles as a per-roadmap breakdown;
+ * everything else lands on the app root.
+ */
+function eventUrl(props: TelemetryEvents[TelemetryEventName]): string {
+  return 'roadmap' in props ? `app://torollo/roadmap/${props.roadmap}` : 'app://torollo/app';
 }

--- a/frontend/src/features/telemetry/useBootTelemetry.test.ts
+++ b/frontend/src/features/telemetry/useBootTelemetry.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBootTelemetry } from './useBootTelemetry';
+import { setTelemetryConsent } from './consent';
+import { trackEvent } from './telemetry';
+import { probeDockerHealth } from '../../shared/hooks/useDockerHealth';
+
+vi.mock('./telemetry', () => ({ trackEvent: vi.fn() }));
+vi.mock('../../shared/hooks/useDockerHealth', () => ({ probeDockerHealth: vi.fn() }));
+const trackEventMock = vi.mocked(trackEvent);
+const probeMock = vi.mocked(probeDockerHealth);
+
+const eventNames = () => trackEventMock.mock.calls.map(([name]) => name);
+
+describe('useBootTelemetry', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    trackEventMock.mockClear();
+    probeMock.mockReset();
+    probeMock.mockResolvedValue({ status: 'ok' });
+  });
+
+  it('does nothing — not even the health probe — without consent', () => {
+    renderHook(() => useBootTelemetry());
+    expect(trackEventMock).not.toHaveBeenCalled();
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  it('reports app_started and a ready runtime when consent was already given', async () => {
+    setTelemetryConsent('accepted');
+    renderHook(() => useBootTelemetry());
+    await act(async () => {});
+
+    expect(eventNames()).toEqual(['app_started', 'runtime_check_started', 'runtime_ready']);
+  });
+
+  it('reports the failure reason when the runtime is down', async () => {
+    setTelemetryConsent('accepted');
+    probeMock.mockResolvedValue({ status: 'down', reason: 'socket_not_found' });
+    renderHook(() => useBootTelemetry());
+    await act(async () => {});
+
+    expect(eventNames()).toEqual(['app_started', 'runtime_check_started', 'runtime_failed']);
+    expect(trackEventMock).toHaveBeenCalledWith('runtime_failed', { reason: 'socket_not_found' });
+  });
+
+  it('fires once consent is accepted mid-session, and only once per page load', async () => {
+    const { rerender } = renderHook(() => useBootTelemetry());
+    expect(trackEventMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      setTelemetryConsent('accepted');
+    });
+    expect(eventNames()).toEqual(['app_started', 'runtime_check_started', 'runtime_ready']);
+
+    await act(async () => {
+      setTelemetryConsent('declined');
+      setTelemetryConsent('accepted');
+    });
+    rerender();
+    expect(trackEventMock).toHaveBeenCalledTimes(3);
+    expect(probeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/telemetry/useBootTelemetry.ts
+++ b/frontend/src/features/telemetry/useBootTelemetry.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+import { probeDockerHealth } from '../../shared/hooks/useDockerHealth';
+import { trackEvent } from './telemetry';
+import { useTelemetryConsent } from './useTelemetryConsent';
+
+/**
+ * The boot funnel: `app_started`, then one Docker readiness probe reported as
+ * `runtime_check_started` → `runtime_ready` | `runtime_failed`. That is where
+ * a first run most often dies (Docker Desktop not started, WSL2, socket
+ * permissions), long before any roadmap is opened.
+ *
+ * Fires at most once per page load, as soon as consent is on — at mount when
+ * it was already given, or the moment the learner accepts the consent card.
+ * Without consent nothing runs, not even the (local) health probe.
+ */
+export function useBootTelemetry(): void {
+  const consent = useTelemetryConsent();
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (consent !== 'accepted' || firedRef.current) return;
+    firedRef.current = true;
+    trackEvent('app_started', {});
+    void reportRuntimeCheck();
+  }, [consent]);
+}
+
+async function reportRuntimeCheck(): Promise<void> {
+  trackEvent('runtime_check_started', {});
+  const probe = await probeDockerHealth();
+  if (probe.status === 'ok') {
+    trackEvent('runtime_ready', {});
+  } else {
+    trackEvent('runtime_failed', { reason: probe.reason });
+  }
+}

--- a/frontend/src/features/telemetry/useTelemetryConsent.ts
+++ b/frontend/src/features/telemetry/useTelemetryConsent.ts
@@ -1,0 +1,8 @@
+import { useSyncExternalStore } from 'react';
+import { getTelemetryConsent, subscribeTelemetryConsent } from './consent';
+import type { TelemetryConsent } from './consent';
+
+/** Reactive view of the consent value — card and toggle stay in sync. */
+export function useTelemetryConsent(): TelemetryConsent {
+  return useSyncExternalStore(subscribeTelemetryConsent, getTelemetryConsent);
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -16,7 +16,7 @@
   },
   "telemetry": {
     "title": "Anonymous usage stats",
-    "body": "Opt in to send five anonymous learning events (roadmap started, step validated, step failed, roadmap completed, roadmap abandoned) so we can see where roadmaps lose people. No personal data, no project names, no code — details in the README. Nothing is sent unless you enable it.",
+    "body": "Opt in to send anonymous usage events — app start, whether Docker was reachable, image downloads that failed, and roadmap progress (started, step validated or failed, completed, abandoned) — so we can see where people get stuck. No personal data, no project names, no code — the full event list is in the README. Nothing is sent unless you enable it.",
     "accept": "Enable",
     "decline": "No thanks",
     "toggleOn": "Anonymous usage stats: on — click to disable",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -14,6 +14,14 @@
     "light": "Light",
     "dark": "Dark"
   },
+  "telemetry": {
+    "title": "Anonymous usage stats",
+    "body": "Opt in to send five anonymous learning events (roadmap started, step validated, step failed, roadmap completed, roadmap abandoned) so we can see where roadmaps lose people. No personal data, no project names, no code — details in the README. Nothing is sent unless you enable it.",
+    "accept": "Enable",
+    "decline": "No thanks",
+    "toggleOn": "Anonymous usage stats: on — click to disable",
+    "toggleOff": "Anonymous usage stats: off — click to enable"
+  },
   "learning": {
     "panelTitle": "Learning",
     "close": "Close panel",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -16,7 +16,7 @@
   },
   "telemetry": {
     "title": "Statistiques d'usage anonymes",
-    "body": "Activez l'envoi de cinq événements d'apprentissage anonymes (roadmap démarrée, étape validée, étape échouée, roadmap complétée, roadmap abandonnée) pour nous aider à voir où les roadmaps perdent les gens. Aucune donnée personnelle, aucun nom de projet, aucun code — détails dans le README. Rien n'est envoyé sans votre accord.",
+    "body": "Activez l'envoi d'événements d'usage anonymes — démarrage de l'app, Docker joignable ou non, téléchargements d'image en échec, et progression dans les roadmaps (démarrée, étape validée ou échouée, complétée, abandonnée) — pour nous aider à voir où les gens bloquent. Aucune donnée personnelle, aucun nom de projet, aucun code — la liste complète est dans le README. Rien n'est envoyé sans votre accord.",
     "accept": "Activer",
     "decline": "Non merci",
     "toggleOn": "Statistiques d'usage anonymes : activées — cliquer pour désactiver",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -14,6 +14,14 @@
     "light": "Clair",
     "dark": "Sombre"
   },
+  "telemetry": {
+    "title": "Statistiques d'usage anonymes",
+    "body": "Activez l'envoi de cinq événements d'apprentissage anonymes (roadmap démarrée, étape validée, étape échouée, roadmap complétée, roadmap abandonnée) pour nous aider à voir où les roadmaps perdent les gens. Aucune donnée personnelle, aucun nom de projet, aucun code — détails dans le README. Rien n'est envoyé sans votre accord.",
+    "accept": "Activer",
+    "decline": "Non merci",
+    "toggleOn": "Statistiques d'usage anonymes : activées — cliquer pour désactiver",
+    "toggleOff": "Statistiques d'usage anonymes : désactivées — cliquer pour activer"
+  },
   "learning": {
     "panelTitle": "Apprentissage",
     "close": "Fermer le panneau",

--- a/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -9,6 +9,7 @@ import ProjectsSection from './components/ProjectsSection';
 import type { HomeView } from './components/SideRail';
 import ProjectPickerModal from './components/ProjectPickerModal';
 import LearningSection from './components/learning/LearningSection';
+import TelemetryConsentCard from './components/TelemetryConsentCard';
 import RoadmapDetailPage from './components/learning/detail/RoadmapDetailPage';
 import { filterByUiLanguage } from '../../features/learning/roadmapLanguage';
 import { markLearningPitchSeen } from '../../features/learning/onboarding';
@@ -215,6 +216,8 @@ export default function ProjectsPage({ onSelectProject }: ProjectsPageProps) {
 
           {route.kind === 'projects' ? (
             <>
+              <TelemetryConsentCard />
+
               {storeRecovered && (
                 <div style={styles.noticeBox}>
                   <AlertTriangle

--- a/frontend/src/pages/ProjectsPage/components/PageHeader.tsx
+++ b/frontend/src/pages/ProjectsPage/components/PageHeader.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { BookOpen, ChevronRight, Plus } from 'lucide-react';
 import Button from '../../../shared/components/Button';
 import ThemeSelector from '../../../shared/components/ThemeSelector';
+import TelemetryToggle from '../../../shared/components/TelemetryToggle';
 import logo from '../../../assets/logo.png';
 
 export interface BreadcrumbItem {
@@ -63,6 +64,7 @@ export default function PageHeader({ onNewProject, breadcrumb }: PageHeaderProps
         </div>
       )}
       <div style={styles.actions}>
+        <TelemetryToggle />
         <ThemeSelector />
         <Button onClick={toggleLanguage} size="lg" title={t('topbar.toggleLanguage')}>
           {i18n.language.toUpperCase()}

--- a/frontend/src/pages/ProjectsPage/components/TelemetryConsentCard.tsx
+++ b/frontend/src/pages/ProjectsPage/components/TelemetryConsentCard.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next';
+import Button from '../../../shared/components/Button';
+import { setTelemetryConsent } from '../../../features/telemetry/consent';
+import { useTelemetryConsent } from '../../../features/telemetry/useTelemetryConsent';
+
+/**
+ * The opt-in prompt, asked once on the home shell (the first-run surface)
+ * instead of a blocking modal. It only exists while the choice is unanswered;
+ * either answer is reversible later through the header toggle.
+ */
+export default function TelemetryConsentCard() {
+  const { t } = useTranslation();
+  const consent = useTelemetryConsent();
+  if (consent !== 'unset') return null;
+
+  return (
+    <div style={styles.card} role="region" aria-label={t('telemetry.title')}>
+      <div style={styles.copy}>
+        <div style={styles.title}>{t('telemetry.title')}</div>
+        <p style={styles.body}>{t('telemetry.body')}</p>
+      </div>
+      <div style={styles.actions}>
+        <Button onClick={() => setTelemetryConsent('accepted')}>{t('telemetry.accept')}</Button>
+        <Button onClick={() => setTelemetryConsent('declined')}>{t('telemetry.decline')}</Button>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  card: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--space-6)',
+    flexWrap: 'wrap',
+    padding: 'var(--space-4) var(--space-5)',
+    background: 'var(--bg-surface-solid)',
+    border: '1px solid var(--border-color)',
+    borderRadius: 'var(--radius-lg)',
+  },
+  copy: {
+    flex: '1 1 380px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-1)',
+  },
+  title: {
+    fontSize: 'var(--text-md)',
+    fontWeight: 600,
+    color: 'var(--color-text-primary)',
+  },
+  body: {
+    fontSize: 'var(--text-sm)',
+    color: 'var(--color-text-secondary)',
+    lineHeight: 1.5,
+    margin: 0,
+  },
+  actions: {
+    display: 'flex',
+    gap: 'var(--space-2)',
+    flexWrap: 'wrap',
+  },
+};

--- a/frontend/src/shared/components/TelemetryToggle.tsx
+++ b/frontend/src/shared/components/TelemetryToggle.tsx
@@ -1,0 +1,29 @@
+import { Activity } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import Button from './Button';
+import { setTelemetryConsent } from '../../features/telemetry/consent';
+import { useTelemetryConsent } from '../../features/telemetry/useTelemetryConsent';
+
+/**
+ * The revocation path the README points at: telemetry stays reversible after
+ * the one-time consent card is gone. `unset` toggles to accepted — it already
+ * behaves as declined on the wire.
+ */
+export default function TelemetryToggle() {
+  const { t } = useTranslation();
+  const consent = useTelemetryConsent();
+  const enabled = consent === 'accepted';
+  const label = enabled ? t('telemetry.toggleOn') : t('telemetry.toggleOff');
+
+  return (
+    <Button
+      size="lg"
+      onClick={() => setTelemetryConsent(enabled ? 'declined' : 'accepted')}
+      title={label}
+      aria-label={label}
+      aria-pressed={enabled}
+    >
+      <Activity size={15} style={enabled ? undefined : { opacity: 0.45 }} />
+    </Button>
+  );
+}

--- a/frontend/src/shared/hooks/useContainers.test.ts
+++ b/frontend/src/shared/hooks/useContainers.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useContainers } from './useContainers';
+import { trackEvent } from '../../features/telemetry/telemetry';
 import type { ContainerData } from '../types';
+
+vi.mock('../../features/telemetry/telemetry', () => ({ trackEvent: vi.fn() }));
+const trackEventMock = vi.mocked(trackEvent);
 
 function jsonResponse(ok: boolean, body: unknown): Response {
   return { ok, json: () => Promise.resolve(body) } as Response;
@@ -13,6 +17,7 @@ describe('useContainers', () => {
   beforeEach(() => {
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
+    trackEventMock.mockClear();
   });
 
   afterEach(() => {
@@ -262,5 +267,38 @@ describe('useContainers', () => {
     });
 
     expect(result.current.dockerUnavailable).toBe(true);
+  });
+
+  describe('image pull telemetry', () => {
+    it('reports image_pull_failed with the node type when create fails on IMAGE_NOT_FOUND', async () => {
+      const onNotify = vi.fn();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(false, { error: 'The Docker image could not be downloaded.', code: 'IMAGE_NOT_FOUND' })
+      );
+
+      const { result } = renderHook(() => useContainers({ projectId: 'p1', onNotify }));
+      await act(async () => {
+        await result.current.createContainer('cache', 'redis');
+      });
+
+      expect(trackEventMock).toHaveBeenCalledWith('image_pull_failed', { node: 'redis' });
+      expect(onNotify).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'The Docker image could not be downloaded.',
+      });
+    });
+
+    it('does not report other create failures as pull failures', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(false, { error: 'A port is already taken.', code: 'PORT_IN_USE' })
+      );
+
+      const { result } = renderHook(() => useContainers({ projectId: 'p1' }));
+      await act(async () => {
+        await result.current.createContainer('web', 'nginx');
+      });
+
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/shared/hooks/useContainers.ts
+++ b/frontend/src/shared/hooks/useContainers.ts
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { API_BASE } from '../types';
 import type { ContainerData } from '../types';
 import type { NotificationData } from './useToast';
-import { readErrorMessage } from '../utils/readErrorMessage';
+import { readApiError, readErrorMessage } from '../utils/readErrorMessage';
+import { trackEvent } from '../../features/telemetry/telemetry';
 
 interface UseContainersOptions {
   projectId: string;
@@ -82,8 +83,11 @@ export function useContainers({ projectId, onNotify }: UseContainersOptions) {
         onNotify?.({ type: 'success', message: t('toasts.nodeCreated', { name }) });
         fetchContainers();
       } else {
-        const message = await readErrorMessage(res, t('toasts.nodeCreateFailed', { name }));
+        const { message, code } = await readApiError(res, t('toasts.nodeCreateFailed', { name }));
         onNotify?.({ type: 'error', message });
+        // The image is pulled on first use, so this is the "first boot"
+        // failure mode after the daemon itself: worth counting, per node type.
+        if (code === 'IMAGE_NOT_FOUND') trackEvent('image_pull_failed', { node: type });
       }
     } catch (err) {
       console.error(err);

--- a/frontend/src/shared/hooks/useDockerHealth.test.ts
+++ b/frontend/src/shared/hooks/useDockerHealth.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { probeDockerHealth } from './useDockerHealth';
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as Response;
+}
+
+describe('probeDockerHealth', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('is ok when the backend reports Docker as ok', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(true, { checks: { docker: { status: 'ok' } } }));
+    await expect(probeDockerHealth()).resolves.toEqual({ status: 'ok' });
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/health'), expect.anything());
+  });
+
+  it('passes the backend reason through', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(false, { checks: { docker: { status: 'unreachable', reason: 'permission_denied' } } })
+    );
+    await expect(probeDockerHealth()).resolves.toEqual({ status: 'down', reason: 'permission_denied' });
+  });
+
+  it('normalizes a reason it does not know to unknown', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(false, { checks: { docker: { status: 'unreachable', reason: 'brand_new_code' } } })
+    );
+    await expect(probeDockerHealth()).resolves.toEqual({ status: 'down', reason: 'unknown' });
+  });
+
+  it('is down with backend_unreachable when the request fails', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    await expect(probeDockerHealth()).resolves.toEqual({ status: 'down', reason: 'backend_unreachable' });
+  });
+
+  it('is down with timeout when the backend never answers', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementationOnce(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        })
+    );
+    const probe = probeDockerHealth();
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(probe).resolves.toEqual({ status: 'down', reason: 'timeout' });
+  });
+});

--- a/frontend/src/shared/hooks/useDockerHealth.ts
+++ b/frontend/src/shared/hooks/useDockerHealth.ts
@@ -5,7 +5,55 @@ import { API_BASE } from '../types';
 export type DockerHealth = 'unknown' | 'ok' | 'down';
 
 /**
- * Probes the backend's Docker readiness (GET /health, which pings the daemon).
+ * Why the runtime is not ready. The backend codes come from its `/health`
+ * response (`checks.docker.reason`); the first two are decided here, when
+ * the backend itself cannot be reached or does not answer in time.
+ */
+export type DockerHealthReason =
+  | 'backend_unreachable'
+  | 'timeout'
+  | 'socket_not_found'
+  | 'permission_denied'
+  | 'connection_refused'
+  | 'unknown';
+
+const BACKEND_REASONS: readonly DockerHealthReason[] = [
+  'timeout',
+  'socket_not_found',
+  'permission_denied',
+  'connection_refused',
+  'unknown',
+];
+
+export type DockerHealthProbe = { status: 'ok' } | { status: 'down'; reason: DockerHealthReason };
+
+// A daemon that is starting (Docker Desktop, WSL2 boot) can leave the ping
+// hanging; cap it so the caller gets a verdict either way.
+const PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Probes the backend's Docker readiness (GET /health, which pings the daemon)
+ * and reduces the answer to ready / not ready plus a coarse reason.
+ * Never throws: an unreachable backend is a `down` verdict, not an error.
+ */
+export async function probeDockerHealth(): Promise<DockerHealthProbe> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${API_BASE}/health`, { signal: controller.signal });
+    const data = await res.json();
+    if (data?.checks?.docker?.status === 'ok') return { status: 'ok' };
+    const reason = data?.checks?.docker?.reason;
+    return { status: 'down', reason: BACKEND_REASONS.includes(reason) ? reason : 'unknown' };
+  } catch {
+    // Backend unreachable: no Docker either, as far as the user is concerned.
+    return { status: 'down', reason: controller.signal.aborted ? 'timeout' : 'backend_unreachable' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Used before actions that spin up containers, so the learner hears about a
  * stopped daemon before the first failure rather than after it.
  *
@@ -17,17 +65,10 @@ export function useDockerHealth() {
   const [checking, setChecking] = useState(false);
 
   const check = useCallback(async () => {
-    try {
-      setChecking(true);
-      const res = await fetch(`${API_BASE}/health`);
-      const data = await res.json();
-      setStatus(data?.checks?.docker?.status === 'ok' ? 'ok' : 'down');
-    } catch {
-      // Backend unreachable: no Docker either, as far as the user is concerned.
-      setStatus('down');
-    } finally {
-      setChecking(false);
-    }
+    setChecking(true);
+    const probe = await probeDockerHealth();
+    setStatus(probe.status);
+    setChecking(false);
   }, []);
 
   return { status, checking, check };

--- a/frontend/src/shared/utils/readErrorMessage.ts
+++ b/frontend/src/shared/utils/readErrorMessage.ts
@@ -1,9 +1,23 @@
-/** Extracts the backend's `{ error }` message from a failed response, or the fallback. */
-export async function readErrorMessage(res: Response, fallback: string): Promise<string> {
+export interface ApiError {
+  message: string;
+  /** The backend's stable error code (e.g. a `DockerErrorCode`), when it sent one. */
+  code?: string;
+}
+
+/** Extracts the backend's `{ error, code }` from a failed response, or the fallback message. */
+export async function readApiError(res: Response, fallback: string): Promise<ApiError> {
   try {
     const body = await res.json();
-    return body?.error || fallback;
+    return {
+      message: body?.error || fallback,
+      code: typeof body?.code === 'string' ? body.code : undefined,
+    };
   } catch {
-    return fallback;
+    return { message: fallback };
   }
+}
+
+/** Extracts the backend's `{ error }` message from a failed response, or the fallback. */
+export async function readErrorMessage(res: Response, fallback: string): Promise<string> {
+  return (await readApiError(res, fallback)).message;
 }


### PR DESCRIPTION
## Summary of Changes

Adds strictly opt-in, anonymous product telemetry, sent as Plausible-format custom events to a build-time-configurable endpoint (`VITE_TELEMETRY_ENDPOINT` / `VITE_TELEMETRY_DOMAIN`; an empty endpoint hard-disables telemetry entirely). Eleven events, mirrored verbatim in the README's Telemetry table:

- **Boot funnel — where a first run most often dies (Docker Desktop not started, WSL2, socket permissions, image downloads):** `app_started` (once per page load), then one Docker readiness probe reported as `runtime_check_started` → `runtime_ready` | `runtime_failed { reason }`. `GET /health` now returns a stable, non-identifying `checks.docker.reason` (`socket_not_found`, `permission_denied`, `connection_refused`, `timeout`, `unknown`); the client adds `backend_unreachable` and `timeout` (10 s cap on the probe). `image_pull_failed { node }` fires when a node can't be created because its image failed to download (backend `IMAGE_NOT_FOUND`). `first_validator_run { roadmap, step }` fires once per install, on the first validation ever run.
- **Learning funnel:** `roadmap_started`, `step_validated`, `step_failed`, `roadmap_completed`, `roadmap_abandoned`.
- **Consent is tri-state** (`unset` / `accepted` / `declined`, localStorage key `torollo_telemetry_consent`): anything other than an explicit accept means **zero network requests** — not even the boot health probe. A one-time, non-blocking consent card on the home screen asks the question; a header toggle makes the choice reversible at any time. Accepting mid-session fires the boot funnel right away.
- **Anonymous by construction**: every event is a typed entry of `TelemetryEvents` — props are catalogue ids or closed enums only, plus the app version and a random locally-generated install id. No socket paths, no error messages, no project names. Revoking consent deletes the install id and the "first time" markers tied to it, so re-enabling starts a fresh identity.
- **Honest counting**: `step_failed` only counts pedagogical failures (engine `error` results are not counted); `roadmap_started` only fires when the backend progress store is confirmed empty; `roadmap_completed` fires once, on the validation that completes the roadmap; `roadmap_abandoned` fires once per play-through on close/unmount/pagehide (with `keepalive`).
- Small shared refactors: `probeDockerHealth()` extracted from `useDockerHealth` (with the timeout, so the briefing page's Docker check can no longer hang), `readApiError()` next to `readErrorMessage()` to surface the backend's error code.
- New README **Telemetry** section documents the exact event list, per-event props, payload contents, and how to decline/revoke.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass)

Backend 456 tests (new: `classifyDaemonFailure` matrix, `/health` reason contract). Frontend 340 tests, new suites: consent store (tri-state, install-id + milestone lifecycle, storage-disabled fallback), `trackEvent` (zero fetch when declined/unset, exact prop allowlist per event, URL routing, keepalive passthrough, never throws), `claimMilestone`, `probeDockerHealth` (ok / reason passthrough / unknown reason / backend unreachable / timeout), `useBootTelemetry` (nothing without consent — not even the probe; fires once per page load; fires on mid-session accept), `useContainers` (`IMAGE_NOT_FOUND` → `image_pull_failed`, other codes don't), and the player hook wiring (`first_validator_run` once per install, not on a failed request, plus the five roadmap events with their negatives).

### Manual Verification

E2E against the real backend + real Docker, with a local Plausible-shaped capture server and Playwright driving the UI, across three backend states (23/23 checks):

- **Docker running:** consent unset → zero requests on the wire and no `/health` probe; accepting on the card → `app_started` + `runtime_check_started` + `runtime_ready`; consent already accepted → the same three on load, `app_started` exactly once (StrictMode); opening a roadmap and validating for real → `first_validator_run` (roadmap + step ids only) before the verdict event, a second Validate doesn't repeat it, the milestone is persisted, a reload replays the boot funnel but not the milestone.
- **Dead Docker socket** (`DOCKER_HOST` pointing at a missing socket): `/health` answers 503 with `reason: socket_not_found`; the app reports `runtime_failed { reason: 'socket_not_found' }`.
- **No backend at all:** `runtime_failed { reason: 'backend_unreachable' }`.
- Payload audit over every captured event: names and prop sets match the README table exactly, URLs are the app root or a roadmap path, configured domain honoured, no PII / paths / raw error strings anywhere.
- Learning-funnel events re-verified in the same runs (started, step failed, abandoned with the right step) on top of the earlier 20/20 run (real pass, completion, no-restart-on-resume, no-abandon-after-completion).
- `image_pull_failed` is covered by tests on both sides of the contract (backend 502 `IMAGE_NOT_FOUND` on a failed pull; client code → event); a live repro would require removing a host image, so it was not run against real Docker.
- Consent card and toggle verified visually in light and dark themes.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
