### PR TITLE
feat(learning): show the solution as the step's debrief once its checks pass

### DIFF
--- a/docs/roadmap-format.md
+++ b/docs/roadmap-format.md
@@ -77,7 +77,7 @@ A *slug* is lowercase letters/digits separated by single hyphens: `^[a-z0-9]+(-[
 | `title` | non-empty string | **yes** | Short step name shown in the step list. |
 | `instruction` | non-empty string | **yes** | What the learner must do. **Markdown allowed.** |
 | `hints` | array of non-empty strings | no | Progressive hints, revealed one at a time in array order (hint 1 first). Order them from a gentle nudge to nearly-the-answer. |
-| `solution` | non-empty string | no | The full solution, revealed only after all hints. Always use this field — never encode the solution as the last hint. |
+| `solution` | non-empty string | no | The full solution. While the step is open it is revealed only after all hints; once the step's checks pass the player shows it on its own as the step's **debrief**. Write it explanation-first (the why, the trade-offs, the interview version), recipe last. Always use this field — never encode the solution as the last hint. |
 | `validators` | array of Validator, ≥ 1 | **yes** | Every step must be auto-checkable: a step is complete when **all** its validators pass. |
 
 ### Validator

--- a/frontend/src/features/learning/components/RoadmapPlayer.tsx
+++ b/frontend/src/features/learning/components/RoadmapPlayer.tsx
@@ -230,6 +230,7 @@ export default function RoadmapPlayer({
               step={currentStep}
               revealedCount={revealedHintsByStepId[currentStep.id] ?? 0}
               onReveal={revealNextHint}
+              passed={Boolean(completedStepIds[currentStep.id] || resultsByStepId[currentStep.id]?.stepPassed)}
             />
           </div>
         );

--- a/frontend/src/features/learning/components/StepHints.test.tsx
+++ b/frontend/src/features/learning/components/StepHints.test.tsx
@@ -86,6 +86,64 @@ describe('StepHints', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('shows the solution on its own as the debrief once the step has passed', () => {
+    render(
+      <StepHints
+        step={buildStep({ hints: ['First nudge.', 'Second nudge.'], solution: 'The full answer.' })}
+        revealedCount={0}
+        onReveal={() => {}}
+        passed
+      />
+    );
+
+    expect(screen.getByText('The full answer.')).toBeInTheDocument();
+    expect(screen.getByText('debrief')).toBeInTheDocument();
+    expect(screen.queryByText('solution')).not.toBeInTheDocument();
+    // The ladder is over: no hint is revealed, no control is offered.
+    expect(screen.queryByText('First nudge.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('keeps already-revealed hints readable under the debrief', () => {
+    render(
+      <StepHints
+        step={buildStep({ hints: ['First nudge.', 'Second nudge.'], solution: 'The full answer.' })}
+        revealedCount={1}
+        onReveal={() => {}}
+        passed
+      />
+    );
+
+    expect(screen.getByText('First nudge.')).toBeInTheDocument();
+    expect(screen.queryByText('Second nudge.')).not.toBeInTheDocument();
+    expect(screen.getByText('The full answer.')).toBeInTheDocument();
+    expect(screen.getByText('debrief')).toBeInTheDocument();
+  });
+
+  it('marks a solution the learner had already revealed as the solution, not the debrief, after the pass', () => {
+    render(
+      <StepHints
+        step={buildStep({ hints: ['Only hint.'], solution: 'The full answer.' })}
+        revealedCount={2}
+        onReveal={() => {}}
+        passed
+      />
+    );
+
+    expect(screen.getByText('The full answer.')).toBeInTheDocument();
+    expect(screen.getByText('solution')).toBeInTheDocument();
+    expect(screen.queryByText('debrief')).not.toBeInTheDocument();
+  });
+
+  it('offers nothing more on a passed step without a solution', () => {
+    const { container } = render(
+      <StepHints step={buildStep({ hints: ['First nudge.'] })} revealedCount={0} onReveal={() => {}} passed />
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(container.textContent).toBe('');
+  });
+
   it('shows already-revealed hints on arrival when the step is revisited', () => {
     // Coming back to a step: the player hook hands back the persisted count.
     render(

--- a/frontend/src/features/learning/components/StepHints.tsx
+++ b/frontend/src/features/learning/components/StepHints.tsx
@@ -18,20 +18,28 @@ import type { RoadmapStep } from '../../../shared/types/roadmap';
  *   The armed state is local and resets on step change (`key={step.id}` at
  *   the call site) — no modal.
  * - A step with neither hints nor solution renders nothing.
+ * - Once the step has passed (`passed`), the ladder is over: the solution
+ *   is shown on its own, marked as the step's debrief, with no reveal
+ *   control. Roadmap authors write solutions explanation-first for this
+ *   reason. Hints already revealed stay readable; unrevealed ones stay
+ *   hidden (they are troubleshooting notes for a step that is done).
  *
  * Visually the ladder is marginalia, not a stack of alert cards: one hairline
  * rule bounds the whole column, each rung carries a lowercase mono marker
- * (`hint 1/3`, `solution`), and the reveal control is the last line of the
- * same column. No icons, no fills — only the solution marker takes color.
+ * (`hint 1/3`, `solution`, `debrief`), and the reveal control is the last
+ * line of the same column. No icons, no fills — only the solution marker
+ * takes color.
  */
 
 interface StepHintsProps {
   step: RoadmapStep;
   revealedCount: number;
   onReveal: () => void;
+  /** The step's checks have passed: show the solution as the debrief. */
+  passed?: boolean;
 }
 
-export default function StepHints({ step, revealedCount, onReveal }: StepHintsProps) {
+export default function StepHints({ step, revealedCount, onReveal, passed = false }: StepHintsProps) {
   const { t } = useTranslation();
   const [solutionArmed, setSolutionArmed] = useState(false);
 
@@ -42,7 +50,9 @@ export default function StepHints({ step, revealedCount, onReveal }: StepHintsPr
 
   const revealed = Math.min(revealedCount, totalRungs);
   const solutionRevealed = hasSolution && revealed === totalRungs;
+  const debrief = passed && hasSolution && !solutionRevealed;
   const nextIsSolution = !solutionRevealed && revealed === hints.length;
+  const ladderOpen = !passed && revealed < totalRungs;
 
   const handleReveal = () => {
     if (nextIsSolution && !solutionArmed) {
@@ -56,8 +66,8 @@ export default function StepHints({ step, revealedCount, onReveal }: StepHintsPr
   return (
     // The rule marks revealed marginalia; before the first reveal the lone
     // button stands unruled.
-    <div style={{ ...styles.container, ...(revealed > 0 ? styles.containerRuled : {}) }}>
-      {hints.slice(0, revealed).map((hint, index) => (
+    <div style={{ ...styles.container, ...(revealed > 0 || debrief ? styles.containerRuled : {}) }}>
+      {hints.slice(0, Math.min(revealed, hints.length)).map((hint, index) => (
         <div key={index} style={styles.rung}>
           <span style={styles.marker}>
             {t('learning.player.hintLabel', { n: index + 1, total: hints.length })}
@@ -66,16 +76,16 @@ export default function StepHints({ step, revealedCount, onReveal }: StepHintsPr
         </div>
       ))}
 
-      {solutionRevealed && (
+      {(solutionRevealed || debrief) && (
         <div style={styles.rung}>
           <span style={{ ...styles.marker, ...styles.solutionMarker }}>
-            {t('learning.player.solutionLabel')}
+            {t(debrief ? 'learning.player.debriefLabel' : 'learning.player.solutionLabel')}
           </span>
           {renderInstruction(step.solution!)}
         </div>
       )}
 
-      {revealed < totalRungs && (
+      {ladderOpen && (
         <button
           onClick={handleReveal}
           style={{ ...styles.revealBtn, ...(nextIsSolution ? styles.revealSolutionBtn : {}) }}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -74,6 +74,7 @@
       "hintLabel": "hint {{n}}/{{total}}",
       "showHint": "Show hint ({{n}}/{{total}})",
       "solutionLabel": "solution",
+      "debriefLabel": "debrief",
       "showSolution": "Reveal the solution",
       "confirmSolution": "Sure? Click again to reveal",
       "resetProgress": "Restart roadmap",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -74,6 +74,7 @@
       "hintLabel": "indice {{n}}/{{total}}",
       "showHint": "Voir un indice ({{n}}/{{total}})",
       "solutionLabel": "solution",
+      "debriefLabel": "débrief",
       "showSolution": "Révéler la solution",
       "confirmSolution": "Sûr ? Cliquez à nouveau pour révéler",
       "resetProgress": "Recommencer la roadmap",


### PR DESCRIPTION
## Summary of Changes

A step's `solution` was reachable only through the hint ladder's two-click reveal, so a learner who passes a step never sees the explanation written for it. Once a step's checks pass, the player now shows the solution on its own, marked **debrief**, with no reveal control.

- `StepHints` gets a `passed` prop. When set and the step has a solution, the solution renders as the debrief; hints already revealed stay readable, unrevealed ones stay hidden, and the reveal button disappears. A solution the learner had already revealed keeps its `solution` marker. Before the pass nothing changes.
- `RoadmapPlayer` passes it from the persisted completion state or the latest validation result, so revisiting a completed step shows its debrief too.
- New i18n key `learning.player.debriefLabel` (en/fr).
- `docs/roadmap-format.md`: the `solution` field is now documented as the step's debrief after a pass, to be written explanation-first, recipe last.

## Types of Changes

- [x] New feature / node type addition
- [ ] Bug fix (non-breaking change resolving an issue)
- [ ] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors (0 errors; the 5 warnings pre-date this change)
- [x] Run `npm run build` successfully with no compilation errors
- [x] Run `npm test` successfully (all tests pass) — 371 frontend tests, including 4 new `StepHints` cases: debrief shown with no control after a pass, revealed hints kept under it, an already-revealed solution keeps the `solution` marker, a passed step without a solution renders nothing

### Manual Verification

Not exercised in the browser for this PR; the behaviour is covered by the component tests above. To check by hand: play any catalogue roadmap step to green, the debrief appears under the instruction with no hint button; use Previous to return to it, it is still there; on a step that has not passed, the hint ladder and the two-click solution reveal behave as before.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
