### PR TITLE
feat(cli): honest first run — wait for the backend, diagnose Docker failures, show image progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,26 @@ jobs:
     - name: Run Tests
       run: npm test
 
+  cli-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Run CLI Tests
+      run: npm test
+
   compose-build:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ npx torollo start
 
 Open the app, create a project, and hit **Learning** in the topbar — the best first contact with Torollo is a guided roadmap, not an empty canvas. Start with **Deploy a resilient three-tier app**: it walks you from a single web server to a load-balanced, firewalled, database-backed architecture in ten validated steps.
 
+The first run downloads the node images (a few minutes, once); `torollo start` shows which image it is on and opens the browser only when the backend answers. Pass `--no-open` to skip opening the browser.
+
+### If `torollo start` stops with an error
+
+The CLI probes Docker through the same socket the backend uses and names the problem it found, with the fix for your OS:
+
+| Message | Meaning | Fix |
+|---|---|---|
+| Docker's socket was not found | No daemon socket where Torollo looked | Start Docker (Desktop, or `sudo systemctl start docker`). On macOS, enable *Allow the default Docker socket to be used* in Docker Desktop's Advanced settings, or set `DOCKER_HOST` to your provider's socket. |
+| Your user is not allowed to open Docker's socket | Socket exists, permission denied | `sudo usermod -aG docker $USER`, then log out and back in. |
+| Docker is not running | Socket exists, no daemon answering | Start the daemon, then run `torollo start` again. |
+| Docker is not answering | The daemon hung for more than 10 s | Wait for it to finish starting, then retry. |
+| Rootless Docker detected | Containers work, but subnets, NAT and cross-subnet security groups need host iptables rules a rootless daemon cannot apply | Use a rootful daemon for the full network engine. |
+
+`torollo start` honours `DOCKER_HOST` and, when it is unset, the active `docker context` — so the backend always targets the daemon your `docker` CLI talks to. The backend log lives in `~/.torollo/logs/backend.log`; attach it when you [open an issue](https://github.com/Derssa/Torollo/issues).
+
 ### Run with Docker Compose
 
 The Compose setup builds the frontend and backend, serves them through one local URL, mounts the host Docker socket so Torollo can create lab resources, and persists projects and learning progress in a named volume.

--- a/backend/src/infrastructure/docker/DockerInitializer.test.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.test.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import { DockerInitializer } from './DockerInitializer';
 import docker from './DockerClient';
+import { NODE_TYPES } from './nodeTypes';
+import { getStartupState, resetStartupState } from './startupState';
 
 jest.mock('fs');
 jest.mock('./DockerClient', () => ({
@@ -8,7 +10,14 @@ jest.mock('./DockerClient', () => ({
   default: {
     listNetworks: jest.fn(),
     getNetwork: jest.fn(),
-    createNetwork: jest.fn()
+    createNetwork: jest.fn(),
+    info: jest.fn(),
+    listImages: jest.fn(),
+    createContainer: jest.fn(),
+    getContainer: jest.fn(),
+    getImage: jest.fn(),
+    pull: jest.fn(),
+    modem: { followProgress: jest.fn() }
   }
 }));
 
@@ -16,6 +25,38 @@ const mockedFs = fs as jest.Mocked<typeof fs>;
 const mockedDocker = docker as jest.Mocked<typeof docker>;
 
 const ensureSharedNetwork = () => (DockerInitializer as any).ensureSharedNetwork();
+const ensureHostForwarding = (rootless: boolean) => (DockerInitializer as any).ensureHostForwarding(rootless);
+const detectRootless = () => (DockerInitializer as any).detectRootless();
+const checkAndPullImages = () => (DockerInitializer as any).checkAndPullImages();
+
+const ALL_NODE_TAGS = [
+  NODE_TYPES.ubuntu.image,
+  NODE_TYPES.postgres.image,
+  NODE_TYPES.mongo.image,
+  NODE_TYPES.redis.image,
+  NODE_TYPES.rabbitmq.image
+];
+
+function mockImages(tags: string[]) {
+  (mockedDocker.listImages as jest.Mock).mockResolvedValue(tags.map(tag => ({ RepoTags: [tag] })));
+}
+
+/** docker.pull(tag, opts, cb) followed by modem.followProgress(stream, onFinished). */
+function mockPull(outcome: (tag: string) => Error | null) {
+  (mockedDocker.pull as jest.Mock).mockImplementation((tag: string, _opts: unknown, cb: (err: Error | null, stream?: unknown) => void) => {
+    cb(null, { tag });
+  });
+  (mockedDocker.modem.followProgress as jest.Mock).mockImplementation((stream: { tag: string }, onFinished: (err: Error | null) => void) => {
+    onFinished(outcome(stream.tag));
+  });
+}
+
+beforeEach(() => {
+  resetStartupState();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
 
 describe('DockerInitializer.ensureSharedNetwork', () => {
   const networkHandle = {
@@ -107,5 +148,217 @@ describe('DockerInitializer.ensureSharedNetwork', () => {
     await ensureSharedNetwork();
 
     expect(networkHandle.remove).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('DockerInitializer.detectRootless', () => {
+  it('reads the rootless security option from docker info', async () => {
+    (mockedDocker.info as jest.Mock).mockResolvedValue({ SecurityOptions: ['name=seccomp,profile=builtin', 'name=rootless'] });
+
+    await expect(detectRootless()).resolves.toBe(true);
+    expect(getStartupState().rootless).toBe(true);
+  });
+
+  it('is false on a regular daemon or when the field is missing', async () => {
+    (mockedDocker.info as jest.Mock).mockResolvedValue({ SecurityOptions: ['name=seccomp,profile=builtin'] });
+    await expect(detectRootless()).resolves.toBe(false);
+
+    (mockedDocker.info as jest.Mock).mockResolvedValue({});
+    await expect(detectRootless()).resolves.toBe(false);
+    expect(getStartupState().rootless).toBe(false);
+  });
+});
+
+describe('DockerInitializer.ensureHostForwarding', () => {
+  const temp = { start: jest.fn(), wait: jest.fn(), remove: jest.fn() };
+  const stale = { remove: jest.fn() };
+
+  beforeEach(() => {
+    temp.start.mockResolvedValue(undefined);
+    temp.remove.mockResolvedValue(undefined);
+    stale.remove.mockRejectedValue(new Error('no such container'));
+    (mockedDocker.createContainer as jest.Mock).mockResolvedValue(temp);
+    (mockedDocker.getContainer as jest.Mock).mockReturnValue(stale);
+  });
+
+  it('does not even try on rootless Docker and reports the engine as unsupported', async () => {
+    await ensureHostForwarding(true);
+
+    expect(mockedDocker.createContainer).not.toHaveBeenCalled();
+    expect(getStartupState().hostForwarding).toEqual({ status: 'unsupported', reason: 'rootless' });
+  });
+
+  it('waits for the privileged container to exit cleanly, then removes it', async () => {
+    temp.wait.mockResolvedValue({ StatusCode: 0 });
+
+    await ensureHostForwarding(false);
+
+    expect(mockedDocker.createContainer).toHaveBeenCalledWith(expect.objectContaining({
+      Image: 'alpine',
+      name: 'akal-lab-host-forwarding',
+      HostConfig: { Privileged: true, NetworkMode: 'host' }
+    }));
+    expect(temp.wait).toHaveBeenCalled();
+    expect(temp.remove).toHaveBeenCalledWith({ force: true });
+    expect(getStartupState().hostForwarding).toEqual({ status: 'applied' });
+  });
+
+  it('reports a failure when the rules could not be applied, instead of claiming success', async () => {
+    temp.wait.mockResolvedValue({ StatusCode: 2 });
+
+    await ensureHostForwarding(false);
+
+    expect(temp.remove).toHaveBeenCalledWith({ force: true });
+    expect(getStartupState().hostForwarding).toEqual({ status: 'failed', reason: 'error' });
+  });
+
+  it('reports a failure when the container cannot be created at all', async () => {
+    (mockedDocker.createContainer as jest.Mock).mockRejectedValue(new Error('no such image: alpine'));
+
+    await ensureHostForwarding(false);
+
+    expect(getStartupState().hostForwarding).toEqual({ status: 'failed', reason: 'error' });
+  });
+});
+
+describe('DockerInitializer image preloading', () => {
+  beforeEach(() => {
+    mockedFs.existsSync.mockReturnValue(false);
+    (mockedDocker.listNetworks as jest.Mock).mockResolvedValue([{ Id: 'n3', Name: 'akal-lab-network' }]);
+    (mockedDocker.info as jest.Mock).mockResolvedValue({ SecurityOptions: ['name=rootless'] });
+  });
+
+  it('counts every preloaded image and leaves no current image once done', async () => {
+    mockImages(ALL_NODE_TAGS);
+
+    await checkAndPullImages();
+
+    expect(mockedDocker.pull).not.toHaveBeenCalled();
+    expect(getStartupState().images).toEqual({ total: 5, ready: 5, current: null });
+  });
+
+  it('pulls the missing images and reports which one is in flight', async () => {
+    mockImages(ALL_NODE_TAGS.filter(tag => tag !== NODE_TYPES.ubuntu.image));
+    const seen: Array<{ label: string; action: string } | null> = [];
+    mockPull(() => {
+      seen.push(getStartupState().images.current);
+      return null;
+    });
+
+    await checkAndPullImages();
+
+    expect(mockedDocker.pull).toHaveBeenCalledTimes(1);
+    expect(mockedDocker.pull.mock.calls[0][0]).toBe(NODE_TYPES.ubuntu.image);
+    expect(seen).toEqual([{ label: 'Ubuntu', action: 'pulling' }]);
+    expect(getStartupState().images).toEqual({ total: 5, ready: 5, current: null });
+  });
+
+  it('marks the routine ready through initialize()', async () => {
+    mockImages(ALL_NODE_TAGS);
+
+    DockerInitializer.initialize();
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(getStartupState()).toMatchObject({ status: 'ready', rootless: true, hostForwarding: { status: 'unsupported' } });
+  });
+
+  it('marks the routine failed with the message when Docker cannot list images', async () => {
+    (mockedDocker.listImages as jest.Mock).mockRejectedValue(Object.assign(new Error('connect ENOENT /var/run/docker.sock'), { code: 'ENOENT' }));
+
+    await expect(checkAndPullImages()).rejects.toThrow('connect ENOENT');
+  });
+});
+
+describe('DockerInitializer local image build', () => {
+  const buildContainer = { start: jest.fn(), exec: jest.fn(), commit: jest.fn(), remove: jest.fn() };
+  const exec = { start: jest.fn(), inspect: jest.fn() };
+  const stale = { remove: jest.fn() };
+
+  beforeEach(() => {
+    buildContainer.start.mockResolvedValue(undefined);
+    buildContainer.commit.mockResolvedValue(undefined);
+    buildContainer.remove.mockResolvedValue(undefined);
+    buildContainer.exec.mockResolvedValue(exec);
+    exec.start.mockImplementation(async () => {
+      const handlers: Record<string, () => void> = {};
+      const stream = { on: (event: string, handler: () => void) => { handlers[event] = handler; return stream; } };
+      setImmediate(() => handlers.end?.());
+      return stream;
+    });
+    stale.remove.mockRejectedValue(new Error('no such container'));
+    (mockedDocker.getContainer as jest.Mock).mockReturnValue(stale);
+    (mockedDocker.createContainer as jest.Mock).mockResolvedValue(buildContainer);
+  });
+
+  it('rebuilds a custom image from its public base when the pull fails', async () => {
+    mockImages(['redis:7-alpine']);
+    mockPull(tag => (tag === NODE_TYPES.redis.image ? new Error('pull access denied') : null));
+    exec.inspect.mockResolvedValue({ ExitCode: 0 });
+    const actions: string[] = [];
+    buildContainer.commit.mockImplementation(async () => {
+      actions.push(getStartupState().images.current?.action ?? 'none');
+    });
+
+    await DockerInitializer.ensureImageAvailable(NODE_TYPES.redis.image);
+
+    // The base is already local, so only the custom tag was attempted.
+    expect(mockedDocker.pull).toHaveBeenCalledTimes(1);
+    expect(mockedDocker.createContainer).toHaveBeenCalledWith(expect.objectContaining({
+      Image: 'redis:7-alpine',
+      name: 'akal-lab-temp-redis-build'
+    }));
+    expect(buildContainer.exec).toHaveBeenCalledWith(expect.objectContaining({
+      Cmd: ['sh', '-c', 'apk update && apk add --no-cache iptables iproute2']
+    }));
+    expect(buildContainer.commit).toHaveBeenCalledWith({
+      repo: 'derssa/backend-lab-redis',
+      tag: 'v1',
+      changes: ['ENTRYPOINT ["docker-entrypoint.sh"]', 'CMD ["redis-server"]']
+    });
+    expect(actions).toEqual(['building']);
+    expect(buildContainer.remove).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('pulls the public base first when it is not local either', async () => {
+    mockImages([]);
+    mockPull(tag => (tag === NODE_TYPES.rabbitmq.image ? new Error('pull access denied') : null));
+    exec.inspect.mockResolvedValue({ ExitCode: 0 });
+
+    await DockerInitializer.ensureImageAvailable(NODE_TYPES.rabbitmq.image);
+
+    expect(mockedDocker.pull.mock.calls.map(call => call[0])).toEqual([NODE_TYPES.rabbitmq.image, 'rabbitmq:3-management-alpine']);
+    expect(buildContainer.commit).toHaveBeenCalledWith(expect.objectContaining({ repo: 'derssa/backend-lab-rabbitmq' }));
+  });
+
+  it('fails loudly when iptables could not be installed, and still cleans up', async () => {
+    mockImages(['mongo:latest']);
+    mockPull(() => new Error('pull access denied'));
+    exec.inspect.mockResolvedValue({ ExitCode: 100 });
+
+    await expect(DockerInitializer.ensureImageAvailable(NODE_TYPES.mongo.image)).rejects.toThrow('exited with status 100');
+
+    expect(buildContainer.commit).not.toHaveBeenCalled();
+    expect(buildContainer.remove).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('retags a local postgres base instead of building', async () => {
+    mockImages(['postgres:15-alpine']);
+    mockPull(() => new Error('pull access denied'));
+    const image = { tag: jest.fn().mockResolvedValue(undefined) };
+    (mockedDocker.getImage as jest.Mock).mockReturnValue(image);
+
+    await DockerInitializer.ensureImageAvailable(NODE_TYPES.postgres.image);
+
+    expect(mockedDocker.getImage).toHaveBeenCalledWith('postgres:15-alpine');
+    expect(image.tag).toHaveBeenCalledWith({ repo: 'derssa/backend-lab-postgres', tag: 'v1' });
+    expect(mockedDocker.createContainer).not.toHaveBeenCalled();
+  });
+
+  it('gives up on an image that has neither a fallback nor a local build recipe', async () => {
+    mockImages([]);
+    mockPull(() => new Error('pull access denied'));
+
+    await expect(DockerInitializer.ensureImageAvailable(NODE_TYPES.ubuntu.image)).rejects.toThrow('pull access denied');
   });
 });

--- a/backend/src/infrastructure/docker/DockerInitializer.ts
+++ b/backend/src/infrastructure/docker/DockerInitializer.ts
@@ -2,22 +2,89 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import docker from './DockerClient';
-import { NODE_TYPES } from './nodeTypes';
+import { NODE_TYPES, NodeTypeDescriptor } from './nodeTypes';
 import { parseProjectsRaw } from '../../modules/projects/services/projectStore';
+import {
+  hostForwardingResolved,
+  imagesPlanned,
+  imageReady,
+  imageStarted,
+  rootlessDetected,
+  startupBegan,
+  startupFailed,
+  startupFinished
+} from './startupState';
+
+/**
+ * How to rebuild a custom `derssa/*` image locally when it cannot be pulled:
+ * its public base plus iptables, committed under the expected tag. The base
+ * image's entrypoint is restored explicitly because the build container runs
+ * with a `tail -f` entrypoint.
+ */
+interface LocalBuildSpec {
+  baseTag: string;
+  buildContainerName: string;
+  installCommand: string;
+  repo: string;
+  tag: string;
+  cmd: string;
+}
+
+const LOCAL_BUILDS: Record<string, LocalBuildSpec> = {
+  [NODE_TYPES.mongo.image]: {
+    baseTag: 'mongo:latest',
+    buildContainerName: 'akal-lab-temp-mongo-build',
+    installCommand: 'apt-get update && apt-get install -y iptables iproute2 && apt-get clean && rm -rf /var/lib/apt/lists/*',
+    repo: 'derssa/backend-lab-mongo',
+    tag: 'v1',
+    cmd: 'mongod'
+  },
+  [NODE_TYPES.redis.image]: {
+    baseTag: 'redis:7-alpine',
+    buildContainerName: 'akal-lab-temp-redis-build',
+    installCommand: 'apk update && apk add --no-cache iptables iproute2',
+    repo: 'derssa/backend-lab-redis',
+    tag: 'v1',
+    cmd: 'redis-server'
+  },
+  [NODE_TYPES.rabbitmq.image]: {
+    baseTag: 'rabbitmq:3-management-alpine',
+    buildContainerName: 'akal-lab-temp-rabbitmq-build',
+    installCommand: 'apk update && apk add --no-cache iptables iproute2',
+    repo: 'derssa/backend-lab-rabbitmq',
+    tag: 'v1',
+    cmd: 'rabbitmq-server'
+  }
+};
+
+/** Images downloaded at startup so the first node does not wait for a pull. */
+const PRELOADED_NODE_TYPES: NodeTypeDescriptor[] = [
+  NODE_TYPES.ubuntu,
+  NODE_TYPES.postgres,
+  NODE_TYPES.mongo,
+  NODE_TYPES.redis,
+  NODE_TYPES.rabbitmq
+];
+
+const HOST_FORWARDING_CONTAINER = 'akal-lab-host-forwarding';
 
 export class DockerInitializer {
   private static isInitializing = false;
 
   /**
-   * Initializes Docker dependencies asynchronously in the background.
+   * Initializes Docker dependencies asynchronously in the background. Progress
+   * is published through startupState (see GET /health).
    */
   public static initialize(): void {
     if (this.isInitializing) return;
     this.isInitializing = true;
+    startupBegan();
 
     this.checkAndPullImages()
+      .then(() => startupFinished())
       .catch(err => {
         console.error('[DockerInitializer] Error during initialization:', err);
+        startupFailed(err);
       })
       .finally(() => {
         this.isInitializing = false;
@@ -107,15 +174,44 @@ export class DockerInitializer {
     }
   }
 
-  private static async ensureHostForwarding(): Promise<void> {
+  /**
+   * Rootless Docker runs the daemon in a user namespace: a privileged
+   * host-network container lands in that namespace, not on the host, and
+   * cannot edit its netfilter tables. Detected once so the host forwarding
+   * step can say "unsupported" instead of failing for no visible reason.
+   */
+  private static async detectRootless(): Promise<boolean> {
+    const info = await docker.info();
+    const securityOptions: unknown = info?.SecurityOptions;
+    const rootless = Array.isArray(securityOptions) && securityOptions.includes('name=rootless');
+    rootlessDetected(rootless);
+    return rootless;
+  }
+
+  /**
+   * Applies the host-level rules cross-subnet traffic depends on: an ACCEPT
+   * on FORWARD, and a NAT bypass between private ranges so containers see
+   * each other's real source IPs. Runs a throwaway privileged container in
+   * the host network namespace and reports its exit code — a failure here
+   * silently breaks subnets, NAT and security groups, so it must be visible.
+   */
+  private static async ensureHostForwarding(rootless: boolean): Promise<void> {
+    if (rootless) {
+      console.warn('[DockerInitializer] Rootless Docker detected: host forwarding rules cannot be applied. Containers work; subnets, NAT and cross-subnet security groups will not.');
+      hostForwardingResolved('unsupported');
+      return;
+    }
+
+    console.log('[DockerInitializer] Configuring Docker host to allow forwarding and preserve source IPs...');
+    let temp: Awaited<ReturnType<typeof docker.createContainer>> | null = null;
     try {
-      console.log('[DockerInitializer] Configuring Docker host to allow forwarding and preserve source IPs...');
-      const temp = await docker.createContainer({
+      await this.removeContainerIfExists(HOST_FORWARDING_CONTAINER);
+      temp = await docker.createContainer({
         Image: 'alpine',
+        name: HOST_FORWARDING_CONTAINER,
         HostConfig: {
           Privileged: true,
-          NetworkMode: 'host',
-          AutoRemove: true
+          NetworkMode: 'host'
         },
         Cmd: [
           'sh',
@@ -128,24 +224,35 @@ export class DockerInitializer {
         ]
       });
       await temp.start();
+      const { StatusCode } = await temp.wait();
+      if (StatusCode !== 0) {
+        throw new Error(`host forwarding container exited with status ${StatusCode}`);
+      }
       console.log('[DockerInitializer] Host forwarding and NAT bypass rules applied successfully.');
+      hostForwardingResolved('applied');
     } catch (err) {
       console.error('[DockerInitializer] Failed to configure host forwarding/NAT bypass:', err);
+      hostForwardingResolved('failed');
+    } finally {
+      if (temp) {
+        await temp.remove({ force: true }).catch(() => undefined);
+      }
     }
   }
 
   private static async checkAndPullImages(): Promise<void> {
     try {
       await this.ensureSharedNetwork();
-      await this.ensureHostForwarding();
+      const rootless = await this.detectRootless();
+      await this.ensureHostForwarding(rootless);
       const images = await docker.listImages();
       const tags = images.flatMap(img => img.RepoTags || []);
 
-      await this.ensureImage(tags, NODE_TYPES.ubuntu.image, 'Ubuntu');
-      await this.ensureImage(tags, NODE_TYPES.postgres.image, 'PostgreSQL');
-      await this.ensureImage(tags, NODE_TYPES.mongo.image, 'MongoDB');
-      await this.ensureImage(tags, NODE_TYPES.redis.image, 'Redis');
-      await this.ensureImage(tags, NODE_TYPES.rabbitmq.image, 'RabbitMQ');
+      imagesPlanned(PRELOADED_NODE_TYPES.length);
+      for (const nodeType of PRELOADED_NODE_TYPES) {
+        await this.ensureImage(tags, nodeType.image, nodeType.label);
+        imageReady();
+      }
     } catch (err) {
       console.error('[DockerInitializer] Docker check failed. Is Docker running?');
       throw err;
@@ -154,228 +261,116 @@ export class DockerInitializer {
 
   private static async ensureImage(existingTags: string[], tag: string, label: string): Promise<void> {
     console.log(`Checking ${label} image...`);
-    const hasImage = existingTags.includes(tag);
-
-    if (hasImage) {
+    imageStarted(label, 'checking');
+    if (existingTags.includes(tag)) {
       console.log(`${label} image ready`);
       return;
     }
 
     console.log(`Pulling ${label} image (first run only)...`);
+    imageStarted(label, 'pulling');
     try {
-      await new Promise<void>((resolve, reject) => {
-        docker.pull(tag, {}, (err, stream) => {
-          if (err) return reject(err);
-          if (!stream) return reject(new Error('Pull stream is undefined'));
-
-          docker.modem.followProgress(
-            stream,
-            (errFinished) => {
-              if (errFinished) return reject(errFinished);
-              console.log(`${label} image ready`);
-              resolve();
-            },
-            (event) => {
-              if (event.status) {
-                const progress = event.progress ? ` ${event.progress}` : '';
-                console.log(`[Docker Hub Pull - ${label}] ${event.status}${progress}`);
-              }
-            }
-          );
-        });
-      });
+      await this.pullImage(tag);
+      console.log(`${label} image ready`);
+      return;
     } catch (pullErr) {
       console.warn(`[DockerInitializer] Failed to pull ${tag} (${pullErr}). Trying fallback...`);
-      if (tag === NODE_TYPES.postgres.image) {
-        const fallbackTag = 'postgres:15-alpine';
-        if (existingTags.includes(fallbackTag)) {
-          console.log(`[DockerInitializer] Tagging local ${fallbackTag} as ${tag}...`);
-          const img = docker.getImage(fallbackTag);
-          await img.tag({ repo: 'derssa/backend-lab-postgres', tag: 'v1' });
-          console.log(`[DockerInitializer] Tagged ${fallbackTag} as ${tag} successfully.`);
-        } else {
-          throw pullErr;
-        }
-      } else if (tag === NODE_TYPES.mongo.image) {
-        const fallbackTag = 'mongo:latest';
-        console.log(`[DockerInitializer] Tag ${tag} not found. Building custom MongoDB image locally...`);
-        
-        // Ensure base mongo:latest is pulled
-        const imagesList = await docker.listImages();
-        const localTags = imagesList.flatMap(img => img.RepoTags || []);
-        if (!localTags.includes(fallbackTag)) {
-          console.log(`[DockerInitializer] Pulling base mongo:latest image...`);
-          await new Promise<void>((resolve, reject) => {
-            docker.pull(fallbackTag, {}, (err, stream) => {
-              if (err) return reject(err);
-              if (!stream) return reject(new Error('Pull stream is undefined'));
-              docker.modem.followProgress(stream, (finishedErr) => finishedErr ? reject(finishedErr) : resolve());
-            });
-          });
-        }
-        
-        // Clean up any stale temp containers from previous runs
-        try {
-          const oldContainer = docker.getContainer('akal-lab-temp-mongo-build');
-          await oldContainer.remove({ force: true });
-        } catch {
-          // Ignore if old container doesn't exist
-        }
-
-        console.log(`[DockerInitializer] Creating temporary build container for MongoDB...`);
-        const tempContainer = await docker.createContainer({
-          Image: fallbackTag,
-          name: 'akal-lab-temp-mongo-build',
-          Entrypoint: ['tail', '-f', '/dev/null']
-        });
-        await tempContainer.start();
-        
-        console.log(`[DockerInitializer] Installing iptables inside build container...`);
-        const exec = await tempContainer.exec({
-          Cmd: ['sh', '-c', 'apt-get update && apt-get install -y iptables iproute2 && apt-get clean && rm -rf /var/lib/apt/lists/*'],
-          AttachStdout: true,
-          AttachStderr: true
-        });
-        const stream = await exec.start({});
-        await new Promise<void>((resolve) => {
-          stream.on('data', () => {});
-          stream.on('end', () => resolve());
-        });
-
-        console.log(`[DockerInitializer] Committing custom MongoDB image as ${tag}...`);
-        await tempContainer.commit({
-          repo: 'derssa/backend-lab-mongo',
-          tag: 'v1',
-          changes: [
-            'ENTRYPOINT ["docker-entrypoint.sh"]',
-            'CMD ["mongod"]'
-          ]
-        });
-
-        console.log(`[DockerInitializer] Cleaning up temporary build container...`);
-        await tempContainer.remove({ force: true });
-        console.log(`[DockerInitializer] Custom MongoDB image with iptables created successfully.`);
-      } else if (tag === NODE_TYPES.redis.image) {
-        const fallbackTag = 'redis:7-alpine';
-        console.log(`[DockerInitializer] Tag ${tag} not found. Building custom Redis image locally...`);
-        
-        // Ensure base redis:7-alpine is pulled
-        const imagesList = await docker.listImages();
-        const localTags = imagesList.flatMap(img => img.RepoTags || []);
-        if (!localTags.includes(fallbackTag)) {
-          console.log(`[DockerInitializer] Pulling base redis:7-alpine image...`);
-          await new Promise<void>((resolve, reject) => {
-            docker.pull(fallbackTag, {}, (err, stream) => {
-              if (err) return reject(err);
-              if (!stream) return reject(new Error('Pull stream is undefined'));
-              docker.modem.followProgress(stream, (finishedErr) => finishedErr ? reject(finishedErr) : resolve());
-            });
-          });
-        }
-        
-        // Clean up any stale temp containers from previous runs
-        try {
-          const oldContainer = docker.getContainer('akal-lab-temp-redis-build');
-          await oldContainer.remove({ force: true });
-        } catch {
-          // Ignore if old container doesn't exist
-        }
-
-        console.log(`[DockerInitializer] Creating temporary build container for Redis...`);
-        const tempContainer = await docker.createContainer({
-          Image: fallbackTag,
-          name: 'akal-lab-temp-redis-build',
-          Entrypoint: ['tail', '-f', '/dev/null']
-        });
-        await tempContainer.start();
-        
-        console.log(`[DockerInitializer] Installing iptables inside build container...`);
-        const exec = await tempContainer.exec({
-          Cmd: ['sh', '-c', 'apk update && apk add --no-cache iptables iproute2'],
-          AttachStdout: true,
-          AttachStderr: true
-        });
-        const stream = await exec.start({});
-        await new Promise<void>((resolve) => {
-          stream.on('data', () => {});
-          stream.on('end', () => resolve());
-        });
-
-        console.log(`[DockerInitializer] Committing custom Redis image as ${tag}...`);
-        await tempContainer.commit({
-          repo: 'derssa/backend-lab-redis',
-          tag: 'v1',
-          changes: [
-            'ENTRYPOINT ["docker-entrypoint.sh"]',
-            'CMD ["redis-server"]'
-          ]
-        });
-
-        console.log(`[DockerInitializer] Cleaning up temporary build container...`);
-        await tempContainer.remove({ force: true });
-        console.log(`[DockerInitializer] Custom Redis image with iptables created successfully.`);
-      } else if (tag === NODE_TYPES.rabbitmq.image) {
-        const fallbackTag = 'rabbitmq:3-management-alpine';
-        console.log(`[DockerInitializer] Tag ${tag} not found. Building custom RabbitMQ image locally...`);
-
-        // Ensure base rabbitmq:3-management-alpine is pulled
-        const imagesList = await docker.listImages();
-        const localTags = imagesList.flatMap(img => img.RepoTags || []);
-        if (!localTags.includes(fallbackTag)) {
-          console.log(`[DockerInitializer] Pulling base rabbitmq:3-management-alpine image...`);
-          await new Promise<void>((resolve, reject) => {
-            docker.pull(fallbackTag, {}, (err, stream) => {
-              if (err) return reject(err);
-              if (!stream) return reject(new Error('Pull stream is undefined'));
-              docker.modem.followProgress(stream, (finishedErr) => finishedErr ? reject(finishedErr) : resolve());
-            });
-          });
-        }
-
-        // Clean up any stale temp containers from previous runs
-        try {
-          const oldContainer = docker.getContainer('akal-lab-temp-rabbitmq-build');
-          await oldContainer.remove({ force: true });
-        } catch {
-          // Ignore if old container doesn't exist
-        }
-
-        console.log(`[DockerInitializer] Creating temporary build container for RabbitMQ...`);
-        const tempContainer = await docker.createContainer({
-          Image: fallbackTag,
-          name: 'akal-lab-temp-rabbitmq-build',
-          Entrypoint: ['tail', '-f', '/dev/null']
-        });
-        await tempContainer.start();
-
-        console.log(`[DockerInitializer] Installing iptables inside build container...`);
-        const exec = await tempContainer.exec({
-          Cmd: ['sh', '-c', 'apk update && apk add --no-cache iptables iproute2'],
-          AttachStdout: true,
-          AttachStderr: true
-        });
-        const stream = await exec.start({});
-        await new Promise<void>((resolve) => {
-          stream.on('data', () => {});
-          stream.on('end', () => resolve());
-        });
-
-        console.log(`[DockerInitializer] Committing custom RabbitMQ image as ${tag}...`);
-        await tempContainer.commit({
-          repo: 'derssa/backend-lab-rabbitmq',
-          tag: 'v1',
-          changes: [
-            'ENTRYPOINT ["docker-entrypoint.sh"]',
-            'CMD ["rabbitmq-server"]'
-          ]
-        });
-
-        console.log(`[DockerInitializer] Cleaning up temporary build container...`);
-        await tempContainer.remove({ force: true });
-        console.log(`[DockerInitializer] Custom RabbitMQ image with iptables created successfully.`);
-      } else {
-        throw pullErr;
+      const fallback = NODE_TYPES.postgres.fallbackImage;
+      if (tag === NODE_TYPES.postgres.image && fallback) {
+        if (!existingTags.includes(fallback.sourceTag)) throw pullErr;
+        console.log(`[DockerInitializer] Tagging local ${fallback.sourceTag} as ${tag}...`);
+        await docker.getImage(fallback.sourceTag).tag({ repo: fallback.repo, tag: fallback.tag });
+        console.log(`[DockerInitializer] Tagged ${fallback.sourceTag} as ${tag} successfully.`);
+        return;
       }
+      const build = LOCAL_BUILDS[tag];
+      if (!build) throw pullErr;
+      imageStarted(label, 'building');
+      await this.buildImageWithIptables(tag, build);
+    }
+  }
+
+  private static pullImage(tag: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      docker.pull(tag, {}, (err, stream) => {
+        if (err) return reject(err);
+        if (!stream) return reject(new Error('Pull stream is undefined'));
+        docker.modem.followProgress(
+          stream,
+          (errFinished) => (errFinished ? reject(errFinished) : resolve()),
+          (event) => {
+            // Layer-level byte counters would flood the log; keep the milestones.
+            if (event.status && !event.progress) {
+              console.log(`[Docker Hub Pull - ${tag}] ${event.status}`);
+            }
+          }
+        );
+      });
+    });
+  }
+
+  private static async removeContainerIfExists(name: string): Promise<void> {
+    try {
+      await docker.getContainer(name).remove({ force: true });
+    } catch {
+      // Nothing left over from a previous run.
+    }
+  }
+
+  /**
+   * Pulls the public base, installs iptables in a throwaway container and
+   * commits the result as `tag`. Same steps for every custom image.
+   */
+  private static async buildImageWithIptables(tag: string, build: LocalBuildSpec): Promise<void> {
+    console.log(`[DockerInitializer] Tag ${tag} not found. Building it locally from ${build.baseTag}...`);
+
+    const imagesList = await docker.listImages();
+    const localTags = imagesList.flatMap(img => img.RepoTags || []);
+    if (!localTags.includes(build.baseTag)) {
+      console.log(`[DockerInitializer] Pulling base ${build.baseTag} image...`);
+      await this.pullImage(build.baseTag);
+    }
+
+    await this.removeContainerIfExists(build.buildContainerName);
+
+    console.log(`[DockerInitializer] Creating temporary build container ${build.buildContainerName}...`);
+    const tempContainer = await docker.createContainer({
+      Image: build.baseTag,
+      name: build.buildContainerName,
+      Entrypoint: ['tail', '-f', '/dev/null']
+    });
+    try {
+      await tempContainer.start();
+
+      console.log('[DockerInitializer] Installing iptables inside build container...');
+      const exec = await tempContainer.exec({
+        Cmd: ['sh', '-c', build.installCommand],
+        AttachStdout: true,
+        AttachStderr: true
+      });
+      const stream = await exec.start({});
+      await new Promise<void>((resolve) => {
+        stream.on('data', () => {});
+        stream.on('end', () => resolve());
+      });
+      const { ExitCode } = await exec.inspect();
+      if (ExitCode !== 0) {
+        throw new Error(`installing iptables in ${build.baseTag} exited with status ${ExitCode}`);
+      }
+
+      console.log(`[DockerInitializer] Committing custom image as ${tag}...`);
+      await tempContainer.commit({
+        repo: build.repo,
+        tag: build.tag,
+        changes: [
+          'ENTRYPOINT ["docker-entrypoint.sh"]',
+          `CMD ["${build.cmd}"]`
+        ]
+      });
+      console.log(`[DockerInitializer] Custom image ${tag} with iptables created successfully.`);
+    } finally {
+      console.log('[DockerInitializer] Cleaning up temporary build container...');
+      await tempContainer.remove({ force: true }).catch(() => undefined);
     }
   }
 }

--- a/backend/src/infrastructure/docker/startupState.test.ts
+++ b/backend/src/infrastructure/docker/startupState.test.ts
@@ -1,0 +1,88 @@
+import {
+  getStartupState,
+  hostForwardingResolved,
+  imagesPlanned,
+  imageReady,
+  imageStarted,
+  resetStartupState,
+  rootlessDetected,
+  startupBegan,
+  startupFailed,
+  startupFinished,
+} from './startupState';
+
+describe('startupState', () => {
+  beforeEach(() => resetStartupState());
+
+  it('starts pending with nothing known', () => {
+    expect(getStartupState()).toEqual({
+      status: 'pending',
+      rootless: null,
+      hostForwarding: { status: 'pending' },
+      images: { total: 0, ready: 0, current: null },
+      error: null,
+    });
+  });
+
+  it('tracks the image being processed and the count of ready ones', () => {
+    startupBegan();
+    imagesPlanned(3);
+    imageStarted('Ubuntu', 'checking');
+    expect(getStartupState().images).toEqual({ total: 3, ready: 0, current: { label: 'Ubuntu', action: 'checking' } });
+
+    imageReady();
+    imageStarted('Redis', 'pulling');
+    expect(getStartupState().images).toEqual({ total: 3, ready: 1, current: { label: 'Redis', action: 'pulling' } });
+
+    imageStarted('Redis', 'building');
+    expect(getStartupState().images.current).toEqual({ label: 'Redis', action: 'building' });
+  });
+
+  it('clears the current image once the routine finishes', () => {
+    startupBegan();
+    imagesPlanned(1);
+    imageStarted('Ubuntu', 'pulling');
+    startupFinished();
+    expect(getStartupState()).toMatchObject({ status: 'ready', images: { current: null } });
+  });
+
+  it('records rootless and the host forwarding outcome with its reason', () => {
+    rootlessDetected(true);
+    hostForwardingResolved('unsupported');
+    expect(getStartupState()).toMatchObject({ rootless: true, hostForwarding: { status: 'unsupported', reason: 'rootless' } });
+
+    hostForwardingResolved('failed');
+    expect(getStartupState().hostForwarding).toEqual({ status: 'failed', reason: 'error' });
+
+    hostForwardingResolved('applied');
+    expect(getStartupState().hostForwarding).toEqual({ status: 'applied' });
+  });
+
+  it('keeps the failure message, whether an Error or not', () => {
+    startupBegan();
+    startupFailed(new Error('pull access denied'));
+    expect(getStartupState()).toMatchObject({ status: 'failed', error: 'pull access denied' });
+
+    startupFailed('plain string');
+    expect(getStartupState().error).toBe('plain string');
+  });
+
+  it('starts a fresh state on every begin', () => {
+    startupBegan();
+    imagesPlanned(2);
+    imageReady();
+    startupFailed(new Error('boom'));
+
+    startupBegan();
+    expect(getStartupState()).toMatchObject({ status: 'running', images: { total: 0, ready: 0 }, error: null });
+  });
+
+  it('hands out snapshots, not the live object', () => {
+    startupBegan();
+    imagesPlanned(1);
+    imageStarted('Ubuntu', 'pulling');
+    const snapshot = getStartupState();
+    imageReady();
+    expect(snapshot.images).toEqual({ total: 1, ready: 0, current: { label: 'Ubuntu', action: 'pulling' } });
+  });
+});

--- a/backend/src/infrastructure/docker/startupState.ts
+++ b/backend/src/infrastructure/docker/startupState.ts
@@ -1,0 +1,98 @@
+/**
+ * Progress of the startup routine (shared network, host forwarding rules,
+ * image pulls) that DockerInitializer runs in the background once the HTTP
+ * server listens. GET /health exposes it, so the CLI can show a first run
+ * (several minutes of image downloads) instead of announcing "ready" blindly.
+ *
+ * Plain data, no Docker types: the same shape is read by the CLI and the
+ * frontend, neither of which knows about dockerode.
+ */
+
+export type StartupStatus = 'pending' | 'running' | 'ready' | 'failed';
+
+export type ImageAction = 'checking' | 'pulling' | 'building';
+
+/**
+ * Whether the host-level iptables rules the subnet/NAT engine relies on could
+ * be applied. `unsupported` is rootless Docker: containers work, but a
+ * privileged host-network container cannot touch the host's netfilter.
+ */
+export type HostForwardingStatus = 'pending' | 'applied' | 'unsupported' | 'failed';
+
+export interface ImageProgress {
+  total: number;
+  ready: number;
+  current: { label: string; action: ImageAction } | null;
+}
+
+export interface StartupState {
+  status: StartupStatus;
+  /** null until `docker info` answered. */
+  rootless: boolean | null;
+  hostForwarding: { status: HostForwardingStatus; reason?: 'rootless' | 'error' };
+  images: ImageProgress;
+  /** Human-readable message of the failure that stopped the routine. */
+  error: string | null;
+}
+
+function initialState(): StartupState {
+  return {
+    status: 'pending',
+    rootless: null,
+    hostForwarding: { status: 'pending' },
+    images: { total: 0, ready: 0, current: null },
+    error: null,
+  };
+}
+
+let state: StartupState = initialState();
+
+export function getStartupState(): StartupState {
+  // Callers get a snapshot so a JSON response cannot observe a half-updated state.
+  return {
+    ...state,
+    hostForwarding: { ...state.hostForwarding },
+    images: { ...state.images, current: state.images.current ? { ...state.images.current } : null },
+  };
+}
+
+export function startupBegan(): void {
+  state = { ...initialState(), status: 'running' };
+}
+
+export function rootlessDetected(rootless: boolean): void {
+  state.rootless = rootless;
+}
+
+export function hostForwardingResolved(status: Exclude<HostForwardingStatus, 'pending'>): void {
+  const reason = status === 'unsupported' ? 'rootless' : status === 'failed' ? 'error' : undefined;
+  state.hostForwarding = reason ? { status, reason } : { status };
+}
+
+export function imagesPlanned(total: number): void {
+  state.images = { total, ready: 0, current: null };
+}
+
+export function imageStarted(label: string, action: ImageAction): void {
+  state.images.current = { label, action };
+}
+
+export function imageReady(): void {
+  state.images.ready += 1;
+  state.images.current = null;
+}
+
+export function startupFinished(): void {
+  state.status = 'ready';
+  state.images.current = null;
+}
+
+export function startupFailed(err: unknown): void {
+  state.status = 'failed';
+  state.error = err instanceof Error ? err.message : String(err);
+}
+
+/** Test hook. */
+export function resetStartupState(): void {
+  state = initialState();
+}

--- a/backend/src/modules/health/controllers/healthController.test.ts
+++ b/backend/src/modules/health/controllers/healthController.test.ts
@@ -1,7 +1,17 @@
 import request from 'supertest';
 import express from 'express';
-import { HealthController } from './healthController';
+import { HealthController, pingWithTimeout } from './healthController';
 import docker from '../../../infrastructure/docker/DockerClient';
+import {
+  hostForwardingResolved,
+  imagesPlanned,
+  imageStarted,
+  resetStartupState,
+  rootlessDetected,
+  startupBegan,
+  startupFailed,
+  startupFinished,
+} from '../../../infrastructure/docker/startupState';
 
 jest.mock('../../../infrastructure/docker/DockerClient', () => ({
   ping: jest.fn(),
@@ -10,9 +20,24 @@ jest.mock('../../../infrastructure/docker/DockerClient', () => ({
 const app = express();
 app.get('/health', HealthController.check);
 
+describe('pingWithTimeout', () => {
+  it('rejects with ETIMEDOUT when the daemon never answers', async () => {
+    (docker.ping as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    await expect(pingWithTimeout(20)).rejects.toMatchObject({ code: 'ETIMEDOUT' });
+  });
+
+  it('resolves when the daemon answers in time', async () => {
+    (docker.ping as jest.Mock).mockResolvedValue('OK');
+
+    await expect(pingWithTimeout(1_000)).resolves.toBe('OK');
+  });
+});
+
 describe('HealthController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetStartupState();
   });
 
   describe('GET /health', () => {
@@ -24,7 +49,8 @@ describe('HealthController', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
         status: 'ok',
-        checks: { docker: { status: 'ok' } },
+        checks: { docker: { status: 'ok' }, network: { status: 'pending' } },
+        startup: { status: 'pending', images: { total: 0, ready: 0, current: null }, error: null },
       });
     });
 
@@ -35,15 +61,11 @@ describe('HealthController', () => {
       const res = await request(app).get('/health');
 
       expect(res.status).toBe(503);
-      expect(res.body).toEqual({
-        status: 'degraded',
-        checks: {
-          docker: {
-            status: 'unreachable',
-            reason: 'socket_not_found',
-            error: 'connect ENOENT /var/run/docker.sock',
-          },
-        },
+      expect(res.body.status).toBe('degraded');
+      expect(res.body.checks.docker).toEqual({
+        status: 'unreachable',
+        reason: 'socket_not_found',
+        error: 'connect ENOENT /var/run/docker.sock',
       });
     });
 
@@ -54,6 +76,63 @@ describe('HealthController', () => {
 
       expect(res.status).toBe(503);
       expect(res.body.checks.docker.reason).toBe('unknown');
+    });
+
+    it('should answer timeout when the daemon ping hangs', async () => {
+      (docker.ping as jest.Mock).mockRejectedValue(Object.assign(new Error('Docker did not answer within 10s'), { code: 'ETIMEDOUT' }));
+
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(503);
+      expect(res.body.checks.docker.reason).toBe('timeout');
+    });
+
+    it('should expose the image being pulled while startup runs', async () => {
+      (docker.ping as jest.Mock).mockResolvedValue('OK');
+      startupBegan();
+      rootlessDetected(false);
+      hostForwardingResolved('applied');
+      imagesPlanned(5);
+      imageStarted('Redis', 'pulling');
+
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(200);
+      expect(res.body.checks.docker).toEqual({ status: 'ok', rootless: false });
+      expect(res.body.checks.network).toEqual({ status: 'ok' });
+      expect(res.body.startup).toEqual({
+        status: 'running',
+        images: { total: 5, ready: 0, current: { label: 'Redis', action: 'pulling' } },
+        error: null,
+      });
+    });
+
+    it('should flag the network engine as unsupported on rootless Docker', async () => {
+      (docker.ping as jest.Mock).mockResolvedValue('OK');
+      startupBegan();
+      rootlessDetected(true);
+      hostForwardingResolved('unsupported');
+      startupFinished();
+
+      const res = await request(app).get('/health');
+
+      expect(res.body.checks.docker).toEqual({ status: 'ok', rootless: true });
+      expect(res.body.checks.network).toEqual({ status: 'unsupported', reason: 'rootless' });
+      expect(res.body.startup.status).toBe('ready');
+    });
+
+    it('should carry the startup error message when the routine failed', async () => {
+      (docker.ping as jest.Mock).mockResolvedValue('OK');
+      startupBegan();
+      hostForwardingResolved('failed');
+      startupFailed(new Error('pull access denied for derssa/backend-lab-redis'));
+
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(200);
+      expect(res.body.checks.network).toEqual({ status: 'failed' });
+      expect(res.body.startup.status).toBe('failed');
+      expect(res.body.startup.error).toBe('pull access denied for derssa/backend-lab-redis');
     });
   });
 });

--- a/backend/src/modules/health/controllers/healthController.ts
+++ b/backend/src/modules/health/controllers/healthController.ts
@@ -1,14 +1,53 @@
 import { Request, Response } from 'express';
 import docker from '../../../infrastructure/docker/DockerClient';
 import { classifyDaemonFailure } from '../../../infrastructure/docker/dockerErrors';
+import { getStartupState, StartupState } from '../../../infrastructure/docker/startupState';
+
+// A daemon that is still booting (Docker Desktop, WSL2) can leave the ping
+// hanging for minutes; a bounded wait turns that into a `timeout` reason.
+const PING_TIMEOUT_MS = 10_000;
+
+export function pingWithTimeout(timeoutMs = PING_TIMEOUT_MS): Promise<unknown> {
+  let timer: NodeJS.Timeout;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(Object.assign(new Error(`Docker did not answer within ${timeoutMs / 1000}s`), { code: 'ETIMEDOUT' }));
+    }, timeoutMs);
+  });
+  return Promise.race([docker.ping(), timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * The startup routine as a client sees it: whether it is still running, which
+ * image it is on, and whether the host networking rules the subnet engine
+ * needs could be applied. Never carries socket paths or raw Docker payloads.
+ */
+function describeStartup(state: StartupState) {
+  const network =
+    state.hostForwarding.status === 'unsupported'
+      ? { status: 'unsupported' as const, reason: state.hostForwarding.reason }
+      : state.hostForwarding.status === 'applied'
+        ? { status: 'ok' as const }
+        : { status: state.hostForwarding.status };
+  return {
+    rootless: state.rootless,
+    network,
+    startup: { status: state.status, images: state.images, error: state.error },
+  };
+}
 
 export class HealthController {
   static async check(_req: Request, res: Response): Promise<void> {
+    const { rootless, network, startup } = describeStartup(getStartupState());
     try {
-      await docker.ping();
+      await pingWithTimeout();
       res.status(200).json({
         status: 'ok',
-        checks: { docker: { status: 'ok' } },
+        checks: {
+          docker: rootless === null ? { status: 'ok' } : { status: 'ok', rootless },
+          network,
+        },
+        startup,
       });
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
@@ -16,7 +55,11 @@ export class HealthController {
         status: 'degraded',
         // `reason` is the stable, non-identifying code clients may report;
         // `error` is the raw message for a human reading the response.
-        checks: { docker: { status: 'unreachable', reason: classifyDaemonFailure(err), error } },
+        checks: {
+          docker: { status: 'unreachable', reason: classifyDaemonFailure(err), error },
+          network,
+        },
+        startup,
       });
     }
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,157 +1,178 @@
 #!/usr/bin/env node
+'use strict';
 
-const { execSync, exec } = require('child_process');
+const { spawn, exec } = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const net = require('net');
-// concurrently removed
+const os = require('os');
+const { log, paint } = require('./lib/output');
+const { findAvailablePort, waitForPort } = require('./lib/ports');
+const { resolveDockerHost, describeDockerHost } = require('./lib/dockerHost');
+const { waitForBackend, waitForDocker, waitForStartup, dockerStatus } = require('./lib/backendHealth');
+const { explainDaemonFailure, explainNetworkSupport } = require('./lib/diagnostics');
+const { ProgressPrinter } = require('./lib/progress');
+
+const USAGE = 'Usage: torollo start [--no-open]';
 
 const args = process.argv.slice(2);
 const command = args[0];
 
-// Helper to open a URL natively on the default browser
-function openUrl(url) {
-  const start = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start ""' : 'xdg-open';
-  exec(`${start} ${url}`);
-}
-
-// Helper to check if a port is free on both IPv4 and IPv6 loopbacks
-function checkPort(port) {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once('error', () => {
-      resolve(false);
-    });
-    server.once('listening', () => {
-      server.close(() => {
-        // Double check on IPv6 localhost to ensure Vite can bind to it
-        const v6Server = net.createServer();
-        v6Server.once('error', () => resolve(false));
-        v6Server.once('listening', () => {
-          v6Server.close(() => resolve(true));
-        });
-        v6Server.listen(port, '::1');
-      });
-    });
-    server.listen(port, '127.0.0.1');
-  });
-}
-
-// Helper to find the next available TCP port
-async function findAvailablePort(startPort) {
-  let port = startPort;
-  while (!(await checkPort(port))) {
-    port++;
-  }
-  return port;
-}
-
-// Helper to check if Docker is installed and running
-function checkDocker() {
-  try {
-    execSync('docker info', { stdio: 'ignore' });
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
-// ANSI Colors
-const colors = {
-  reset: "\x1b[0m",
-  cyan: "\x1b[36m",
-  green: "\x1b[32m",
-  yellow: "\x1b[33m",
-  red: "\x1b[31m",
-  magenta: "\x1b[35m",
-  bold: "\x1b[1m"
-};
-
 if (command === 'start') {
-  console.log(`${colors.cyan}[i] Checking system requirements...${colors.reset}`);
-
-  if (!checkDocker()) {
-    console.error(`\n${colors.red}${colors.bold}[x] Error: Docker is not installed or not running on your machine.${colors.reset}`);
-    
-    if (process.platform === 'win32') {
-      console.log(`\n${colors.yellow}[!] WINDOWS DETECTED:${colors.reset}`);
-      console.log('Please download and install Docker Desktop:');
-      console.log(`${colors.cyan}[>] https://www.docker.com/products/docker-desktop/\n${colors.reset}`);
-    } else if (process.platform === 'darwin') {
-      console.log(`\n${colors.yellow}[!] MACOS DETECTED:${colors.reset}`);
-      console.log('Please download and install Docker Desktop:');
-      console.log(`${colors.cyan}[>] https://www.docker.com/products/docker-desktop/\n${colors.reset}`);
-    } else {
-      console.log(`\n${colors.yellow}[!] LINUX DETECTED:${colors.reset}`);
-      console.log('Please install Docker using your package manager:');
-      console.log(`${colors.cyan}[>] Run: curl -fsSL https://get.docker.com | sh\n${colors.reset}`);
-    }
+  start({ openBrowser: !args.includes('--no-open') }).catch((err) => {
+    log.error(`Failed to start Torollo: ${err.message}`);
     process.exit(1);
-  }
+  });
+} else if (!command || command === '--help' || command === '-h') {
+  console.log(USAGE);
+} else {
+  console.error(USAGE);
+  process.exit(1);
+}
 
-  console.log(`${colors.green}[v] Docker is running.${colors.reset}`);
-  console.log(`${colors.magenta}🚀 Booting Torollo System Lab...${colors.reset}\n`);
+function openUrl(url) {
+  const opener = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start ""' : 'xdg-open';
+  exec(`${opener} ${url}`);
+}
 
+/** Spawns a child with stdout/stderr appended to `logFile`, and tracks whether it is still running. */
+function spawnLogged(cmd, cmdArgs, options, logFile) {
+  const fd = fs.openSync(logFile, 'w');
+  const child = spawn(cmd, cmdArgs, { ...options, stdio: ['ignore', fd, fd] });
+  let exited = false;
+  child.once('exit', () => {
+    exited = true;
+    fs.closeSync(fd);
+  });
+  child.isAlive = () => !exited;
+  return child;
+}
+
+function printExplanation(explanation, level = 'error') {
+  log[level](explanation.title);
+  for (const line of explanation.lines) log.detail(line);
+  for (const cmd of explanation.commands) log.command(cmd);
+}
+
+async function start({ openBrowser }) {
   const backendPath = path.join(__dirname, '../backend');
   const frontendPath = path.join(__dirname, '../frontend');
+  const logDir = path.join(os.homedir(), '.torollo', 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  const backendLog = path.join(logDir, 'backend.log');
+  const frontendLog = path.join(logDir, 'frontend.log');
 
-  (async () => {
-    try {
-      const frontendPort = await findAvailablePort(23232);
-      const backendPort = await findAvailablePort(frontendPort + 1);
+  // Both the CLI's verdict and the backend's probe must target the same
+  // daemon: hand the docker CLI's active context down as DOCKER_HOST.
+  const dockerHost = resolveDockerHost();
+  const backendEnv = { ...process.env };
+  if (dockerHost.source === 'context') backendEnv.DOCKER_HOST = dockerHost.host;
+  const endpointNote = dockerHost.source === 'default' ? 'default socket' : `from ${dockerHost.source === 'env' ? 'DOCKER_HOST' : 'docker context'}`;
+  log.info(`Docker endpoint: ${describeDockerHost(dockerHost.host, process.platform)} (${endpointNote})`);
 
-      const envContent = `window.TOROLLO_BACKEND_PORT = ${backendPort};`;
+  const frontendPort = await findAvailablePort(23232);
+  const backendPort = await findAvailablePort(frontendPort + 1);
+  writeFrontendEnv(frontendPath, backendPort);
 
-      // Ensure directory structures exist before writing env.js
-      const publicPath = path.join(frontendPath, 'public');
-      if (fs.existsSync(publicPath)) {
-        fs.writeFileSync(path.join(publicPath, 'env.js'), envContent);
-      }
+  const backend = spawnLogged('node', [path.join(backendPath, 'dist/server.js')], {
+    env: { ...backendEnv, PORT: String(backendPort) }
+  }, backendLog);
+  const servePath = require.resolve('serve/build/main.js');
+  const frontend = spawnLogged('node', [servePath, '-s', 'dist', '-l', String(frontendPort)], {
+    cwd: frontendPath
+  }, frontendLog);
 
-      const distPath = path.join(frontendPath, 'dist');
-      if (fs.existsSync(distPath)) {
-        fs.writeFileSync(path.join(distPath, 'env.js'), envContent);
-      }
-
-      const { spawn } = require('child_process');
-
-      const backendProcess = spawn('node', [path.join(backendPath, 'dist/server.js')], {
-        env: { ...process.env, PORT: backendPort },
-        stdio: 'ignore'
-      });
-
-      const servePath = require.resolve('serve/build/main.js');
-      const frontendProcess = spawn('node', [servePath, '-s', 'dist', '-l', frontendPort], {
-        cwd: frontendPath,
-        stdio: 'ignore'
-      });
-
-      console.log(`${colors.cyan}================================================${colors.reset}`);
-      console.log(`${colors.green}${colors.bold}[*] Torollo System Lab is ready!${colors.reset}`);
-      console.log(`${colors.cyan}[>] Access it here: ${colors.reset}${colors.bold}http://localhost:${frontendPort}${colors.reset}`);
-      console.log(`${colors.cyan}================================================${colors.reset}\n`);
-
-      // Automatically open browser tab
-      setTimeout(() => {
-        openUrl(`http://localhost:${frontendPort}`);
-      }, 1200);
-
-      // Clean shutdown on Ctrl+C (avoids logs printing after Windows batch prompt)
-      process.on('SIGINT', () => {
-        try {
-          backendProcess.kill('SIGKILL');
-          frontendProcess.kill('SIGKILL');
-        } catch (e) {}
-        process.exit(0);
-      });
-
-    } catch (err) {
-      console.error('Failed to start Torollo:', err);
-      process.exit(1);
+  let shuttingDown = false;
+  const shutdown = (exitCode) => {
+    shuttingDown = true;
+    for (const child of [backend, frontend]) {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
     }
-  })();
+    process.exit(exitCode);
+  };
+  process.on('SIGINT', () => shutdown(0));
+  process.on('SIGTERM', () => shutdown(0));
 
-} else {
-  console.log('Usage: torollo start');
-  process.exit(0);
+  const fail = (explanation) => {
+    printExplanation(explanation);
+    log.detail(`Backend log: ${backendLog}`);
+    shutdown(1);
+  };
+
+  log.info('Starting the Torollo backend...');
+  let body;
+  try {
+    body = await waitForBackend(backendPort, { isAlive: backend.isAlive });
+  } catch (err) {
+    return fail({ title: 'The Torollo backend did not start.', lines: [err.message], commands: [] });
+  }
+
+  body = await waitForDocker(backendPort, body, {
+    isAlive: backend.isAlive,
+    onWaiting: (reason) => log.info(`Docker is not reachable yet (${reason}). Waiting a few seconds in case it is still starting...`)
+  });
+  const docker = dockerStatus(body);
+  if (docker.status !== 'ok') {
+    return fail(explainDaemonFailure({
+      reason: docker.reason,
+      platform: process.platform,
+      dockerHost: dockerHost.host,
+      error: docker.error
+    }));
+  }
+  log.ok(`Docker is running${docker.rootless ? ' (rootless)' : ''}.`);
+
+  const progress = new ProgressPrinter({ log });
+  try {
+    body = await waitForStartup(backendPort, {
+      isAlive: backend.isAlive,
+      onProgress: (startup) => progress.update(startup)
+    });
+  } catch (err) {
+    return fail({ title: 'The Torollo backend stopped during startup.', lines: [err.message], commands: [] });
+  }
+
+  if (body.startup.status === 'failed') {
+    log.warn(`The node images could not all be prepared: ${body.startup.error}`);
+    log.detail('Torollo will try again when you create a node that needs a missing image. Check your internet connection if downloads keep failing.');
+    log.detail(`Backend log: ${backendLog}`);
+  } else if (progress.sawWork) {
+    log.ok('Node images are ready.');
+  }
+
+  const networkNote = explainNetworkSupport(body.checks.network);
+  if (networkNote) printExplanation(networkNote, 'warn');
+
+  try {
+    await waitForPort(frontendPort);
+  } catch (err) {
+    return fail({ title: 'The Torollo frontend did not start.', lines: [err.message, `Frontend log: ${frontendLog}`], commands: [] });
+  }
+
+  const url = `http://localhost:${frontendPort}`;
+  log.blank();
+  console.log(paint('cyan', '================================================'));
+  console.log(`${paint('green', paint('bold', '[*] Torollo is ready:'))} ${paint('bold', url)}`);
+  console.log(paint('cyan', '================================================'));
+  log.detail('Press Ctrl+C to stop.');
+  log.blank();
+
+  if (openBrowser) openUrl(url);
+
+  for (const [name, child] of [['backend', backend], ['frontend', frontend]]) {
+    child.once('exit', () => {
+      if (shuttingDown) return;
+      log.error(`The Torollo ${name} stopped unexpectedly (${child.signalCode || `exit code ${child.exitCode}`}).`);
+      log.detail(`Log: ${name === 'backend' ? backendLog : frontendLog}`);
+      shutdown(1);
+    });
+  }
+}
+
+/** Tells the built frontend which port the backend listens on. */
+function writeFrontendEnv(frontendPath, backendPort) {
+  const envContent = `window.TOROLLO_BACKEND_PORT = ${backendPort};`;
+  for (const dir of ['public', 'dist']) {
+    const target = path.join(frontendPath, dir);
+    if (fs.existsSync(target)) fs.writeFileSync(path.join(target, 'env.js'), envContent);
+  }
 }

--- a/bin/lib/backendHealth.js
+++ b/bin/lib/backendHealth.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Polling helpers around the backend's GET /health, which answers 200 when
+ * Docker pings and 503 (with `checks.docker.reason`) when it does not, and
+ * always carries `startup` — the image preloading progress.
+ *
+ * Every function takes `isAlive`: a check that the backend process is still
+ * running, so a crashed backend is reported at once instead of after the
+ * timeout.
+ */
+
+const REQUEST_TIMEOUT_MS = 15000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function backendUnreachable(message) {
+  return Object.assign(new Error(message), { code: 'backend_unreachable' });
+}
+
+/** One GET /health, resolved with the parsed body whatever the status code. */
+async function fetchHealth(port, { fetchImpl = globalThis.fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}) {
+  const res = await fetchImpl(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(timeoutMs) });
+  return res.json();
+}
+
+/** Resolves with the first /health body once the backend listens. */
+async function waitForBackend(port, { timeoutMs = 30000, intervalMs = 500, fetchImpl, isAlive = () => true } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (!isAlive()) throw backendUnreachable('The backend process exited before it started listening.');
+    try {
+      return await fetchHealth(port, { fetchImpl });
+    } catch {
+      if (Date.now() >= deadline) {
+        throw backendUnreachable(`The backend did not answer on port ${port} within ${timeoutMs / 1000}s.`);
+      }
+      await sleep(intervalMs);
+    }
+  }
+}
+
+function dockerStatus(body) {
+  return body && body.checks && body.checks.docker ? body.checks.docker : { status: 'unreachable', reason: 'unknown' };
+}
+
+/**
+ * Gives a daemon that is still booting a chance: keeps probing for
+ * `graceMs` while Docker is unreachable, unless the reason is one waiting
+ * cannot fix. Resolves with the last body either way; the caller decides.
+ */
+async function waitForDocker(port, body, { graceMs = 20000, intervalMs = 1000, fetchImpl, isAlive = () => true, onWaiting } = {}) {
+  let docker = dockerStatus(body);
+  if (docker.status === 'ok' || docker.reason === 'permission_denied') return body;
+  if (onWaiting) onWaiting(docker.reason);
+  const deadline = Date.now() + graceMs;
+  let last = body;
+  while (Date.now() < deadline) {
+    await sleep(intervalMs);
+    if (!isAlive()) throw backendUnreachable('The backend process exited while waiting for Docker.');
+    try {
+      last = await fetchHealth(port, { fetchImpl });
+    } catch {
+      continue;
+    }
+    docker = dockerStatus(last);
+    if (docker.status === 'ok') return last;
+  }
+  return last;
+}
+
+/**
+ * Follows the startup routine until it is `ready` or `failed`, calling
+ * `onProgress(startup, body)` on every poll so the caller can print what
+ * changed. Resolves with the final body.
+ */
+async function waitForStartup(port, { intervalMs = 1000, fetchImpl, isAlive = () => true, onProgress } = {}) {
+  for (;;) {
+    if (!isAlive()) throw backendUnreachable('The backend process exited during startup.');
+    let body;
+    try {
+      body = await fetchHealth(port, { fetchImpl });
+    } catch {
+      await sleep(intervalMs);
+      continue;
+    }
+    const startup = body.startup || { status: 'ready' };
+    if (onProgress) onProgress(startup, body);
+    if (startup.status === 'ready' || startup.status === 'failed') return body;
+    await sleep(intervalMs);
+  }
+}
+
+module.exports = { fetchHealth, waitForBackend, waitForDocker, waitForStartup, dockerStatus };

--- a/bin/lib/backendHealth.test.js
+++ b/bin/lib/backendHealth.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { fetchHealth, waitForBackend, waitForDocker, waitForStartup, dockerStatus } = require('./backendHealth');
+
+/** A /health stand-in that answers with the next scripted body on every call. */
+function scriptedHealth(bodies) {
+  let calls = 0;
+  const server = http.createServer((req, res) => {
+    const body = bodies[Math.min(calls, bodies.length - 1)];
+    calls += 1;
+    res.writeHead(body.status === 'degraded' ? 503 : 200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ port: server.address().port, calls: () => calls, close: () => new Promise((done) => server.close(done)) });
+    });
+  });
+}
+
+function unusedPort() {
+  return new Promise((resolve) => {
+    const server = http.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+const OK = { status: 'ok', checks: { docker: { status: 'ok' }, network: { status: 'ok' } }, startup: { status: 'ready', images: { total: 5, ready: 5, current: null }, error: null } };
+const DOWN = (reason) => ({ status: 'degraded', checks: { docker: { status: 'unreachable', reason, error: 'x' } }, startup: { status: 'pending' } });
+
+test('fetchHealth returns the body even on a 503', async () => {
+  const server = await scriptedHealth([DOWN('connection_refused')]);
+  try {
+    const body = await fetchHealth(server.port);
+    assert.equal(body.checks.docker.reason, 'connection_refused');
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForBackend resolves as soon as the backend answers', async () => {
+  const server = await scriptedHealth([OK]);
+  try {
+    const body = await waitForBackend(server.port, { timeoutMs: 2000, intervalMs: 10 });
+    assert.equal(body.status, 'ok');
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForBackend gives up after the timeout when nothing listens', async () => {
+  const port = await unusedPort();
+  await assert.rejects(
+    waitForBackend(port, { timeoutMs: 200, intervalMs: 20 }),
+    (err) => err.code === 'backend_unreachable' && /did not answer/.test(err.message)
+  );
+});
+
+test('waitForBackend stops at once when the backend process is gone', async () => {
+  const port = await unusedPort();
+  const started = Date.now();
+  await assert.rejects(
+    waitForBackend(port, { timeoutMs: 5000, intervalMs: 20, isAlive: () => false }),
+    (err) => err.code === 'backend_unreachable' && /exited/.test(err.message)
+  );
+  assert.ok(Date.now() - started < 1000);
+});
+
+test('waitForDocker returns immediately when Docker is fine', async () => {
+  const server = await scriptedHealth([OK]);
+  try {
+    const body = await waitForDocker(server.port, OK, { graceMs: 1000, intervalMs: 10 });
+    assert.equal(body.checks.docker.status, 'ok');
+    assert.equal(server.calls(), 0);
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForDocker keeps probing during the grace period and picks up a daemon that just started', async () => {
+  const server = await scriptedHealth([DOWN('connection_refused'), DOWN('connection_refused'), OK]);
+  const waitedFor = [];
+  try {
+    const body = await waitForDocker(server.port, DOWN('connection_refused'), {
+      graceMs: 2000,
+      intervalMs: 10,
+      onWaiting: (reason) => waitedFor.push(reason)
+    });
+    assert.equal(body.checks.docker.status, 'ok');
+    assert.deepEqual(waitedFor, ['connection_refused']);
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForDocker hands back the last verdict when the grace period runs out', async () => {
+  const server = await scriptedHealth([DOWN('socket_not_found')]);
+  try {
+    const body = await waitForDocker(server.port, DOWN('socket_not_found'), { graceMs: 100, intervalMs: 10 });
+    assert.equal(body.checks.docker.reason, 'socket_not_found');
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForDocker does not wait on a permission problem', async () => {
+  const server = await scriptedHealth([OK]);
+  try {
+    const body = await waitForDocker(server.port, DOWN('permission_denied'), { graceMs: 5000, intervalMs: 10 });
+    assert.equal(body.checks.docker.reason, 'permission_denied');
+    assert.equal(server.calls(), 0);
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForStartup reports every poll and stops on ready', async () => {
+  const running = (label, ready) => ({
+    ...OK,
+    startup: { status: 'running', images: { total: 5, ready, current: { label, action: 'pulling' } }, error: null }
+  });
+  const server = await scriptedHealth([running('Ubuntu', 0), running('Redis', 1), OK]);
+  const seen = [];
+  try {
+    const body = await waitForStartup(server.port, { intervalMs: 10, onProgress: (startup) => seen.push(startup.status) });
+    assert.deepEqual(seen, ['running', 'running', 'ready']);
+    assert.equal(body.startup.status, 'ready');
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForStartup stops on failed and keeps the error', async () => {
+  const failed = { ...OK, startup: { status: 'failed', images: { total: 5, ready: 2, current: null }, error: 'pull access denied' } };
+  const server = await scriptedHealth([failed]);
+  try {
+    const body = await waitForStartup(server.port, { intervalMs: 10 });
+    assert.equal(body.startup.error, 'pull access denied');
+  } finally {
+    await server.close();
+  }
+});
+
+test('waitForStartup treats a backend without startup info as ready', async () => {
+  const server = await scriptedHealth([{ status: 'ok', checks: { docker: { status: 'ok' } } }]);
+  try {
+    const body = await waitForStartup(server.port, { intervalMs: 10 });
+    assert.equal(body.status, 'ok');
+  } finally {
+    await server.close();
+  }
+});
+
+test('dockerStatus is defensive about malformed bodies', () => {
+  assert.deepEqual(dockerStatus(null), { status: 'unreachable', reason: 'unknown' });
+  assert.deepEqual(dockerStatus({ checks: {} }), { status: 'unreachable', reason: 'unknown' });
+  assert.deepEqual(dockerStatus(OK), { status: 'ok' });
+});

--- a/bin/lib/diagnostics.js
+++ b/bin/lib/diagnostics.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const { describeDockerHost } = require('./dockerHost');
+
+const DESKTOP_URL = 'https://www.docker.com/products/docker-desktop/';
+const ROOTLESS_URL = 'https://docs.docker.com/engine/security/rootless/';
+
+/**
+ * Turns the backend's `checks.docker.reason` into what the user should read:
+ * one sentence on what is wrong, then the command or setting that fixes it
+ * on their OS. Each entry is `{ title, lines, commands }`; `commands` are
+ * rendered on their own line so they can be copied.
+ */
+function explainDaemonFailure({ reason, platform, dockerHost, error }) {
+  const endpoint = describeDockerHost(dockerHost, platform);
+  switch (reason) {
+    case 'socket_not_found':
+      return socketNotFound(platform, endpoint, Boolean(dockerHost));
+    case 'permission_denied':
+      return permissionDenied(platform, endpoint);
+    case 'connection_refused':
+      return connectionRefused(platform, endpoint);
+    case 'timeout':
+      return {
+        title: 'Docker is not answering.',
+        lines: [
+          'A daemon that is still starting can hang for a while. Wait until Docker reports it is running, then run `torollo start` again.',
+          `Endpoint probed: ${endpoint}`
+        ],
+        commands: []
+      };
+    default:
+      return {
+        title: 'Docker could not be reached.',
+        lines: [
+          error ? `Docker answered: ${error}` : 'The daemon returned an unexpected error.',
+          `Endpoint probed: ${endpoint}`,
+          'Check that `docker info` works in this terminal, then run `torollo start` again.'
+        ],
+        commands: []
+      };
+  }
+}
+
+function socketNotFound(platform, endpoint, explicitHost) {
+  if (platform === 'darwin') {
+    return {
+      title: `Docker's socket was not found (${endpoint}).`,
+      lines: [
+        'Start Docker Desktop (or Colima, OrbStack, Rancher Desktop) and wait until it reports it is running.',
+        'If it is already running, Torollo looked in the wrong place. Either enable "Allow the default Docker socket to be used" in Docker Desktop (Settings → Advanced), or point Torollo at your provider\'s socket:'
+      ],
+      commands: ['export DOCKER_HOST=unix://$HOME/.docker/run/docker.sock', `No Docker yet? ${DESKTOP_URL}`]
+    };
+  }
+  if (platform === 'win32') {
+    return {
+      title: `Docker's named pipe was not found (${endpoint}).`,
+      lines: [
+        'Start Docker Desktop and wait until it reports it is running.',
+        'Under WSL2, run `torollo start` from a distribution that has Docker Desktop\'s WSL integration enabled (Settings → Resources → WSL integration).'
+      ],
+      commands: [`No Docker yet? ${DESKTOP_URL}`]
+    };
+  }
+  return {
+    title: `Docker's socket was not found (${endpoint}).`,
+    lines: [
+      explicitHost
+        ? 'DOCKER_HOST points at a socket that does not exist. Fix the path, or unset it to use the default socket.'
+        : 'Is Docker installed and running? Start the daemon with:'
+    ],
+    commands: explicitHost
+      ? []
+      : [
+        'sudo systemctl start docker',
+        'No Docker yet?  curl -fsSL https://get.docker.com | sh',
+        'Rootless Docker?  export DOCKER_HOST=unix:///run/user/$(id -u)/docker.sock'
+      ]
+  };
+}
+
+function permissionDenied(platform, endpoint) {
+  if (platform === 'linux') {
+    return {
+      title: `Your user is not allowed to open Docker's socket (${endpoint}).`,
+      lines: ['Add yourself to the docker group, then log out and back in (or reboot) for it to take effect:'],
+      commands: ['sudo usermod -aG docker $USER', `Prefer not to? Rootless Docker: ${ROOTLESS_URL}`]
+    };
+  }
+  return {
+    title: `Your user is not allowed to open Docker's socket (${endpoint}).`,
+    lines: [
+      'Restart Docker Desktop. On macOS, also check "Allow the default Docker socket to be used" in Settings → Advanced, which re-creates the socket with the right permissions.'
+    ],
+    commands: []
+  };
+}
+
+function connectionRefused(platform, endpoint) {
+  const lines = [`The endpoint exists (${endpoint}) but no daemon is answering on it.`];
+  if (platform === 'linux') {
+    return { title: 'Docker is not running.', lines: [...lines, 'Start the daemon with:'], commands: ['sudo systemctl start docker'] };
+  }
+  return {
+    title: 'Docker is not running.',
+    lines: [...lines, 'Start Docker Desktop and wait until it reports it is running, then run `torollo start` again.'],
+    commands: []
+  };
+}
+
+/**
+ * What to say once Docker works but the startup routine could not apply the
+ * host networking rules subnets/NAT/security groups depend on. Returns null
+ * when there is nothing to warn about.
+ */
+function explainNetworkSupport(network) {
+  if (!network) return null;
+  if (network.status === 'unsupported' && network.reason === 'rootless') {
+    return {
+      title: 'Rootless Docker detected: containers work, but the network engine does not.',
+      lines: [
+        'Subnets, NAT and cross-subnet security groups need iptables rules on the host, which a rootless daemon cannot apply. Single-network projects and roadmaps that do not split subnets are fine.',
+        'For the full network engine, run Torollo against a regular (rootful) Docker daemon.'
+      ],
+      commands: []
+    };
+  }
+  if (network.status === 'failed') {
+    return {
+      title: 'The host networking rules could not be applied.',
+      lines: [
+        'Subnets, NAT and cross-subnet security groups may not work in this session. The backend log has the details.'
+      ],
+      commands: []
+    };
+  }
+  return null;
+}
+
+/** Progress of the image preloading, as one line the CLI prints when it changes. */
+function describeImageProgress(images) {
+  if (!images || !images.current) return null;
+  const { total, ready, current } = images;
+  const step = `${Math.min(ready + 1, total)}/${total}`;
+  switch (current.action) {
+    case 'pulling':
+      return `Downloading the ${current.label} image (${step})...`;
+    case 'building':
+      return `Building the ${current.label} image locally (${step}) — this one takes a few minutes...`;
+    default:
+      return null;
+  }
+}
+
+module.exports = { explainDaemonFailure, explainNetworkSupport, describeImageProgress };

--- a/bin/lib/diagnostics.test.js
+++ b/bin/lib/diagnostics.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { explainDaemonFailure, explainNetworkSupport, describeImageProgress } = require('./diagnostics');
+
+const REASONS = ['socket_not_found', 'permission_denied', 'connection_refused', 'timeout', 'unknown'];
+const PLATFORMS = ['linux', 'darwin', 'win32'];
+
+test('every reason on every platform yields a title and at least one hint', () => {
+  for (const platform of PLATFORMS) {
+    for (const reason of REASONS) {
+      const explanation = explainDaemonFailure({ reason, platform, dockerHost: null });
+      assert.ok(explanation.title.length > 0, `${reason}/${platform} has a title`);
+      assert.ok(explanation.lines.length + explanation.commands.length > 0, `${reason}/${platform} has a hint`);
+    }
+  }
+});
+
+test('the three first-run failures read differently from each other', () => {
+  const titles = ['socket_not_found', 'permission_denied', 'connection_refused']
+    .map((reason) => explainDaemonFailure({ reason, platform: 'linux', dockerHost: null }).title);
+  assert.equal(new Set(titles).size, 3);
+});
+
+test('permission denied on Linux hands out the usermod command', () => {
+  const explanation = explainDaemonFailure({ reason: 'permission_denied', platform: 'linux', dockerHost: null });
+  assert.ok(explanation.commands.some((cmd) => cmd.includes('sudo usermod -aG docker $USER')));
+  assert.match(explanation.lines.join(' '), /log out/);
+});
+
+test('a missing socket on macOS points at the Docker Desktop socket setting', () => {
+  const explanation = explainDaemonFailure({ reason: 'socket_not_found', platform: 'darwin', dockerHost: null });
+  assert.match(explanation.lines.join(' '), /Allow the default Docker socket to be used/);
+  assert.ok(explanation.commands.some((cmd) => cmd.includes('DOCKER_HOST=unix://')));
+});
+
+test('a missing socket on Linux with an explicit DOCKER_HOST blames the path, not the install', () => {
+  const explanation = explainDaemonFailure({ reason: 'socket_not_found', platform: 'linux', dockerHost: 'unix:///tmp/nope.sock' });
+  assert.match(explanation.title, /\/tmp\/nope\.sock/);
+  assert.match(explanation.lines[0], /DOCKER_HOST/);
+  assert.deepEqual(explanation.commands, []);
+});
+
+test('a missing socket on Linux without DOCKER_HOST offers to start or install the daemon', () => {
+  const explanation = explainDaemonFailure({ reason: 'socket_not_found', platform: 'linux', dockerHost: null });
+  assert.ok(explanation.commands.some((cmd) => cmd.includes('systemctl start docker')));
+  assert.ok(explanation.commands.some((cmd) => cmd.includes('get.docker.com')));
+});
+
+test('connection refused on Linux tells how to start the daemon', () => {
+  const explanation = explainDaemonFailure({ reason: 'connection_refused', platform: 'linux', dockerHost: null });
+  assert.match(explanation.title, /not running/);
+  assert.deepEqual(explanation.commands, ['sudo systemctl start docker']);
+});
+
+test('the unknown reason surfaces the raw error for a human', () => {
+  const explanation = explainDaemonFailure({ reason: 'unknown', platform: 'linux', dockerHost: null, error: 'boom' });
+  assert.ok(explanation.lines.some((line) => line.includes('boom')));
+});
+
+test('network support: rootless is a warning with the scope of what breaks', () => {
+  const note = explainNetworkSupport({ status: 'unsupported', reason: 'rootless' });
+  assert.match(note.title, /Rootless Docker/);
+  assert.match(note.lines.join(' '), /Subnets, NAT and cross-subnet security groups/);
+});
+
+test('network support: nothing to say when the rules were applied or not attempted yet', () => {
+  assert.equal(explainNetworkSupport({ status: 'ok' }), null);
+  assert.equal(explainNetworkSupport({ status: 'pending' }), null);
+  assert.equal(explainNetworkSupport(undefined), null);
+});
+
+test('network support: a failed attempt is reported', () => {
+  assert.match(explainNetworkSupport({ status: 'failed' }).title, /could not be applied/);
+});
+
+test('image progress describes pulls and builds with their position', () => {
+  assert.equal(
+    describeImageProgress({ total: 5, ready: 1, current: { label: 'Redis', action: 'pulling' } }),
+    'Downloading the Redis image (2/5)...'
+  );
+  assert.match(
+    describeImageProgress({ total: 5, ready: 4, current: { label: 'RabbitMQ', action: 'building' } }),
+    /^Building the RabbitMQ image locally \(5\/5\)/
+  );
+});
+
+test('image progress stays quiet for cache checks and when idle', () => {
+  assert.equal(describeImageProgress({ total: 5, ready: 0, current: { label: 'Ubuntu', action: 'checking' } }), null);
+  assert.equal(describeImageProgress({ total: 5, ready: 5, current: null }), null);
+  assert.equal(describeImageProgress(undefined), null);
+});

--- a/bin/lib/dockerHost.js
+++ b/bin/lib/dockerHost.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+/**
+ * Which daemon endpoint the backend will use, and where that decision came
+ * from. The backend (dockerode) honours DOCKER_HOST and otherwise opens the
+ * default socket; it knows nothing about `docker context`, which is how
+ * Docker Desktop, Colima, OrbStack and Rancher Desktop point the docker CLI
+ * at a per-user socket. Asking the CLI for its active endpoint and handing
+ * it down as DOCKER_HOST keeps both sides on the same daemon, so a "Docker
+ * is running" verdict here means the backend will reach it too.
+ *
+ * Returns `{ host, source }` where `source` is `env` (DOCKER_HOST was set),
+ * `context` (taken from the docker CLI) or `default` (dockerode's own
+ * fallback; `host` is null).
+ */
+function resolveDockerHost({ env = process.env, readActiveContext = readActiveContextEndpoint } = {}) {
+  if (env.DOCKER_HOST) return { host: env.DOCKER_HOST, source: 'env' };
+  const endpoint = readActiveContext();
+  if (endpoint) return { host: endpoint, source: 'context' };
+  return { host: null, source: 'default' };
+}
+
+function readActiveContextEndpoint() {
+  try {
+    const out = execFileSync('docker', ['context', 'inspect', '--format', '{{.Endpoints.docker.Host}}'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+      encoding: 'utf8'
+    });
+    return out.trim() || null;
+  } catch {
+    // No docker CLI, or a CLI that cannot read its contexts: let dockerode
+    // fall back to the default socket, exactly as the backend would alone.
+    return null;
+  }
+}
+
+/** Human-readable location of the daemon endpoint, for error messages. */
+function describeDockerHost(host, platform) {
+  if (host) return host;
+  if (platform === 'win32') return '//./pipe/docker_engine';
+  if (platform === 'darwin') return '~/.docker/run/docker.sock or /var/run/docker.sock';
+  return '/var/run/docker.sock';
+}
+
+module.exports = { resolveDockerHost, readActiveContextEndpoint, describeDockerHost };

--- a/bin/lib/dockerHost.test.js
+++ b/bin/lib/dockerHost.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveDockerHost, describeDockerHost } = require('./dockerHost');
+
+test('DOCKER_HOST wins over the docker context', () => {
+  const result = resolveDockerHost({
+    env: { DOCKER_HOST: 'unix:///run/user/1000/docker.sock' },
+    readActiveContext: () => 'unix:///Users/me/.docker/run/docker.sock'
+  });
+  assert.deepEqual(result, { host: 'unix:///run/user/1000/docker.sock', source: 'env' });
+});
+
+test('falls back to the active docker context endpoint', () => {
+  const result = resolveDockerHost({
+    env: {},
+    readActiveContext: () => 'unix:///Users/me/.docker/run/docker.sock'
+  });
+  assert.deepEqual(result, { host: 'unix:///Users/me/.docker/run/docker.sock', source: 'context' });
+});
+
+test('leaves the decision to dockerode when no context can be read', () => {
+  const result = resolveDockerHost({ env: {}, readActiveContext: () => null });
+  assert.deepEqual(result, { host: null, source: 'default' });
+});
+
+test('describes the default endpoint per platform', () => {
+  assert.equal(describeDockerHost(null, 'linux'), '/var/run/docker.sock');
+  assert.equal(describeDockerHost(null, 'win32'), '//./pipe/docker_engine');
+  assert.match(describeDockerHost(null, 'darwin'), /\.docker\/run\/docker\.sock/);
+  assert.equal(describeDockerHost('tcp://127.0.0.1:2375', 'linux'), 'tcp://127.0.0.1:2375');
+});

--- a/bin/lib/output.js
+++ b/bin/lib/output.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const colors = {
+  reset: '\x1b[0m',
+  cyan: '\x1b[36m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m'
+};
+
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR;
+
+function paint(color, text) {
+  return useColor ? `${colors[color]}${text}${colors.reset}` : text;
+}
+
+const log = {
+  info: (msg) => console.log(`${paint('cyan', '[i]')} ${msg}`),
+  ok: (msg) => console.log(`${paint('green', '[v]')} ${msg}`),
+  warn: (msg) => console.log(`${paint('yellow', '[!]')} ${msg}`),
+  error: (msg) => console.error(`${paint('red', '[x]')} ${paint('bold', msg)}`),
+  /** Indented continuation line under a previous message. */
+  detail: (msg) => console.log(`    ${msg}`),
+  command: (cmd) => console.log(`      ${paint('bold', cmd)}`),
+  blank: () => console.log('')
+};
+
+module.exports = { colors, paint, log };

--- a/bin/lib/ports.js
+++ b/bin/lib/ports.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const net = require('net');
+
+/** Whether `port` is free on both loopbacks: the frontend server binds to both. */
+function checkPort(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => {
+        const v6Server = net.createServer();
+        v6Server.once('error', () => resolve(false));
+        v6Server.once('listening', () => {
+          v6Server.close(() => resolve(true));
+        });
+        v6Server.listen(port, '::1');
+      });
+    });
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function findAvailablePort(startPort) {
+  let port = startPort;
+  while (!(await checkPort(port))) {
+    port++;
+  }
+  return port;
+}
+
+/** Resolves once something accepts TCP connections on `port`, or rejects after `timeoutMs`. */
+function waitForPort(port, { timeoutMs = 15000, intervalMs = 250 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      const socket = net.connect({ port, host: '127.0.0.1' });
+      socket.once('connect', () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once('error', () => {
+        socket.destroy();
+        if (Date.now() >= deadline) {
+          reject(new Error(`Nothing is listening on port ${port} after ${timeoutMs / 1000}s`));
+        } else {
+          setTimeout(attempt, intervalMs);
+        }
+      });
+    };
+    attempt();
+  });
+}
+
+module.exports = { checkPort, findAvailablePort, waitForPort };

--- a/bin/lib/progress.js
+++ b/bin/lib/progress.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { describeImageProgress } = require('./diagnostics');
+
+/**
+ * Prints image preloading progress: one line per image transition plus a
+ * heartbeat while a long download or build is in flight, so a first run
+ * never looks stuck. `sawWork` tells the caller whether anything had to be
+ * downloaded at all.
+ */
+class ProgressPrinter {
+  constructor({ log, heartbeatMs = 30000, now = Date.now }) {
+    this.log = log;
+    this.heartbeatMs = heartbeatMs;
+    this.now = now;
+    this.lastLine = null;
+    this.lastPrintedAt = 0;
+    this.startedAt = 0;
+    this.sawWork = false;
+  }
+
+  update(startup) {
+    const line = describeImageProgress(startup && startup.images);
+    if (!line) return;
+    if (!this.sawWork) {
+      this.sawWork = true;
+      this.startedAt = this.now();
+      this.log.info('First run: downloading the node images. This happens once and can take a few minutes.');
+    }
+    if (line !== this.lastLine) {
+      this.log.info(line);
+      this.lastLine = line;
+      this.lastPrintedAt = this.now();
+    } else if (this.now() - this.lastPrintedAt >= this.heartbeatMs) {
+      this.log.detail(`still working (${Math.round((this.now() - this.startedAt) / 1000)}s elapsed)...`);
+      this.lastPrintedAt = this.now();
+    }
+  }
+}
+
+module.exports = { ProgressPrinter };

--- a/bin/lib/progress.test.js
+++ b/bin/lib/progress.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { ProgressPrinter } = require('./progress');
+
+function harness({ heartbeatMs = 30000 } = {}) {
+  const lines = [];
+  let clock = 1000;
+  const printer = new ProgressPrinter({
+    log: { info: (msg) => lines.push(`info: ${msg}`), detail: (msg) => lines.push(`detail: ${msg}`) },
+    heartbeatMs,
+    now: () => clock
+  });
+  return { printer, lines, tick: (ms) => { clock += ms; } };
+}
+
+const pulling = (label, ready) => ({ images: { total: 5, ready, current: { label, action: 'pulling' } } });
+const checking = (label, ready) => ({ images: { total: 5, ready, current: { label, action: 'checking' } } });
+const idle = { images: { total: 5, ready: 5, current: null } };
+
+test('stays silent when every image is already local', () => {
+  const { printer, lines } = harness();
+  printer.update(checking('Ubuntu', 0));
+  printer.update(checking('Redis', 3));
+  printer.update(idle);
+  assert.deepEqual(lines, []);
+  assert.equal(printer.sawWork, false);
+});
+
+test('announces the first run once, then one line per image transition', () => {
+  const { printer, lines } = harness();
+  printer.update(pulling('Ubuntu', 0));
+  printer.update(pulling('Ubuntu', 0));
+  printer.update(pulling('Redis', 1));
+  printer.update(idle);
+  assert.deepEqual(lines, [
+    'info: First run: downloading the node images. This happens once and can take a few minutes.',
+    'info: Downloading the Ubuntu image (1/5)...',
+    'info: Downloading the Redis image (2/5)...'
+  ]);
+  assert.equal(printer.sawWork, true);
+});
+
+test('prints a heartbeat with the elapsed time while the same image stays in flight', () => {
+  const { printer, lines, tick } = harness({ heartbeatMs: 30000 });
+  printer.update(pulling('Ubuntu', 0));
+  tick(10000);
+  printer.update(pulling('Ubuntu', 0));
+  tick(25000);
+  printer.update(pulling('Ubuntu', 0));
+  tick(30000);
+  printer.update(pulling('Ubuntu', 0));
+  assert.deepEqual(lines.slice(2), [
+    'detail: still working (35s elapsed)...',
+    'detail: still working (65s elapsed)...'
+  ]);
+});

--- a/package.json
+++ b/package.json
@@ -18,9 +18,13 @@
     "type": "git",
     "url": "https://github.com/Derssa/torollo.git"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "bin": "bin/cli.js",
   "scripts": {
-    "start": "node ./bin/cli.js start"
+    "start": "node ./bin/cli.js start",
+    "test": "node --test bin/lib/dockerHost.test.js bin/lib/diagnostics.test.js bin/lib/backendHealth.test.js bin/lib/progress.test.js"
   },
   "dependencies": {
     "chokidar": "^3.6.0",
@@ -35,6 +39,7 @@
     "README.md",
     "assets/**/*",
     "bin/**/*",
+    "!bin/**/*.test.js",
     "backend/dist/**/*",
     "backend/package.json",
     "backend/projects.json",


### PR DESCRIPTION
## Summary of Changes

`torollo start` used to be blind on a first run: it only checked `docker info`'s exit code, spawned the backend with its output discarded, printed "ready" immediately and opened the browser 1.2 s later — before the backend listened, and while the backend was pulling five images (minutes) with no signal. Three real failures were misreported: Docker Desktop on macOS (the `docker` CLI follows contexts, the backend's dockerode does not, so `docker info` passed while the backend hit `socket_not_found`), a user outside the `docker` group (reduced to "not installed"), and rootless Docker (host forwarding rules failed silently, breaking subnets/NAT/security groups without a word).

This PR makes the first run honest:

- **Backend** — a small `startupState` records what the startup routine is doing (network, host forwarding, image by image with pull/build action). `GET /health` now exposes it as `startup`, plus `checks.docker.rootless` and `checks.network` (`ok` / `unsupported` (rootless) / `failed`). The daemon ping is bounded (10 s → `timeout` reason). `ensureHostForwarding` now waits for the privileged container's exit code instead of logging "applied successfully" unconditionally, and skips it on rootless daemons. The three duplicated local-build blocks (Mongo/Redis/RabbitMQ) collapse into one table-driven helper that also checks the `apk`/`apt` exit code. Existing response fields are unchanged, so the frontend probe and telemetry are untouched.
- **CLI** — `bin/cli.js` is split into small testable modules under `bin/lib/`. `start` now: resolves the Docker endpoint the way the backend will (`DOCKER_HOST`, else the active `docker context`, handed down as `DOCKER_HOST` so both sides target the same daemon); starts the backend with its output in `~/.torollo/logs/backend.log`; waits for `/health` (30 s timeout); gives a starting daemon a 20 s grace; on failure prints one diagnosis per `reason` with the fix command for the OS (`socket_not_found`, `permission_denied`, `connection_refused`, `timeout`, unknown); follows the image preloading with one line per image ("Downloading the Redis image (4/5)...", "Building the RabbitMQ image locally (5/5)...") and a heartbeat every 30 s; warns clearly on rootless Docker; prints "ready" and opens the browser only once both the backend and the frontend answer. A crashed backend after startup is reported with the log path instead of leaving a dead URL. New flag: `--no-open`.
- **Repo** — root `npm test` (Node's built-in test runner, no new dependency) with a `cli-test` CI job; test files excluded from the npm package; `engines.node >= 18`; README gets a short "If `torollo start` stops with an error" table.

Adjacent findings, not addressed here: `derssa/backend-lab-rabbitmq:v1` is not on Docker Hub, so every first run rebuilds it locally (publishing it would shorten the first run); the published `derssa/*` images are amd64-only.

## Types of Changes

- [x] New feature / node type addition
- [x] Bug fix (non-breaking change resolving an issue)
- [x] Refactoring / structural cleanup
- [x] Documentation update

## Verification & Testing
### Automated Checks
- [x] Run `npm run lint` successfully with no errors (backend clean; frontend: 5 pre-existing warnings in untouched files)
- [x] Run `npm run build` successfully with no compilation errors (backend + frontend)
- [x] Run `npm test` successfully (all tests pass) — root 32 (new), backend 509, frontend 367

### Manual Verification

Played `node bin/cli.js start --no-open` against real Docker states on Linux (Fedora, rootless daemon + a root-owned `/var/run/docker.sock` the user cannot open), each with a scratch `HOME`:

| State | What the CLI printed | Exit |
|---|---|---|
| Docker OK (rootless) | `Docker is running (rootless).` → rootless network warning → ready banner in ~2 s | stays up |
| `DOCKER_HOST` unset, active context = `rootless` | endpoint taken `from docker context`, backend reaches the same daemon (before: `docker info` passed, backend got EACCES on `/var/run/docker.sock`) | stays up |
| `DOCKER_HOST=unix:///tmp/nope.sock` | 20 s grace, then `Docker's socket was not found (…)` + "DOCKER_HOST points at a socket that does not exist" | 1 |
| `DOCKER_HOST` unset, no context, `/var/run/docker.sock` root:docker | `Your user is not allowed to open Docker's socket` + `sudo usermod -aG docker $USER` + relogin, no grace wait | 1 |
| unix socket with no listener | `Docker is not running.` + `sudo systemctl start docker` | 1 |
| `DOCKER_HOST=tcp://10.255.255.1:2375` (blackhole) | backend answers `timeout` after 10 s, CLI: `Docker is not answering.` | 1 |
| backend cannot bind (`TOROLLO_HOST` invalid) | `The Torollo backend did not start.` + log path, within 1.5 s | 1 |
| first run: `derssa/backend-lab-redis:v1` and `…-rabbitmq:v1` removed | `First run: downloading…` → `Downloading the Redis image (4/5)...` (Hub) → `Downloading the RabbitMQ image (5/5)...` → `Building the RabbitMQ image locally (5/5)…` (no Hub tag) → `Node images are ready.` → banner; both tags back, no leftover build container | stays up |
| backend killed after ready | `The Torollo backend stopped unexpectedly (SIGKILL).` + log path | 1 |

Also confirmed on this host that the privileged host-forwarding container fails under rootless Docker (`iptables: Permission denied (you must be root)`) — which the old code logged as a success.

## Checklist

- [x] My code follows the repository's code style and lint standards
- [x] I have updated the documentation or instructions if necessary
- [x] All unit and integration tests are passing
